### PR TITLE
Add: Tab added to show language type for code blocks, prettify code blocks

### DIFF
--- a/components/post-body.tsx
+++ b/components/post-body.tsx
@@ -98,7 +98,7 @@ export default function PostBody({ content, authorName }) {
               ? codeMatch[0].split("language-")[1].split('"')[0]
               : "bash"; // Extract language if available, otherwise default to 'bash'
           return (
-            <div key={index} className="relative mb-4">
+            <div key={index} className="relative mb-4 mx-auto">
               <pre
                 dangerouslySetInnerHTML={{ __html: part }}
                 className={`language-${language}`}
@@ -113,6 +113,13 @@ export default function PostBody({ content, authorName }) {
                 ) : (
                   <IoCopyOutline />
                 )}
+              </button>
+              <button
+                disabled
+                className="absolute top-1 left-1 text-orange-400 border-2 border-gray-400 border-b-0 rounded  rounded-b-none px-2 flex flex-col gap-y-1 capitalize"
+              >
+                {language}
+                <span className="h-[1px] w-full border rounded-full border-gray-400"></span>
               </button>
             </div>
           );


### PR DESCRIPTION
This pull request fixes the [issue](https://github.com/keploy/keploy/issues/1685)

Tab as a button is added to show the type of language used in the code block.