### PR TITLE
Fix: use Image tag instead of img tag in open source vector png.

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,6 +10,7 @@ import { HOME_OG_IMAGE_URL } from "../lib/constants";
 import TopBlogs from "../components/topBlogs";
 import Testimonials from "../components/testimonials";
 import Image from "next/image";
+import OpenSourceVectorPng from "../public/images/open-source-vector.png";
 export default function Index({ communityPosts, technologyPosts, preview }) {
   return (
     <Layout
@@ -57,10 +58,10 @@ export default function Index({ communityPosts, technologyPosts, preview }) {
             </div>
           </div>
           <div className="open-source-vector-container bottom-9 mb-12 flex md:justify-start justify-center">
-            <img
-              src="/blog/images/open-source-vector.png"
+            <Image
+              src={OpenSourceVectorPng}
               alt="vector"
-              className=" spin-anim"
+              className="spin-anim"
             />
           </div>
         </div>


### PR DESCRIPTION
This pull request fixes the issue - [Link](https://github.com/keploy/keploy/issues/1763)

The use of `Image` tag will leverage the use of Next.js framework.