### PR TITLE
fix: prevent wp-caption from overflowing on mobile devices

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -109,6 +109,10 @@
   @apply max-w-full;
 }
 
+.wp-caption {
+  @apply max-w-full;
+}
+
 /* Custom CSS */
 
 .baloo-2-600 {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6c573505-93c6-409b-8e5a-17130df9280e)

@nehagup, there's an issue with the `wp-caption` class, causing the max width to exceed on mobile devices.