### PR TITLE
fix: author profiles

### DIFF
--- a/components/AuthorMapping.tsx
+++ b/components/AuthorMapping.tsx
@@ -7,31 +7,31 @@ export default function AuthorMapping({
   AuthorArray,
   itemsPerPage = 8, // You can customize the number of items per page
 }:{
-  AuthorArray: Pick<Post, "author" | "postAuthor">[],
+  AuthorArray: Pick<Post, "author" | "ppmaAuthorName">[],
   itemsPerPage?:number
 }) {
   const [currentPage, setCurrentPage] = useState(1);
 
   const authorData = [];
-  const postAuthorArray = [];
+  const ppmaAuthorNameArray = [];
 
   AuthorArray.forEach((item) => {
-    const postAuthor = formatAuthorName(item.postAuthor);
+    const ppmaAuthorName = formatAuthorName(item.ppmaAuthorName);
     const avatarUrl = item.author.node.avatar.url;
-    const slug = item.postAuthor;
+    const slug = item.ppmaAuthorName;
     const publishingAuthor = item.author.node.name;
-    if (Array.isArray(postAuthor)) {
+    if (Array.isArray(ppmaAuthorName)) {
       return;
     }
 
-    if (!postAuthorArray.includes(postAuthor)) {
-      postAuthorArray.push(postAuthor);
+    if (!ppmaAuthorNameArray.includes(ppmaAuthorName)) {
+      ppmaAuthorNameArray.push(ppmaAuthorName);
     } else {
       return;
     }
     authorData.push({
       publishingAuthor,
-      postAuthor,
+      ppmaAuthorName,
       avatarUrl,
       slug,
     });
@@ -67,10 +67,10 @@ export default function AuthorMapping({
             <div className="p-5 rounded-lg mt-5 mb-5 flex flex-col justify-between  border border-transparent transform transition-colors  hover:border-accent-2 hover:dark:bg-neutral-400/30 hover:scale-105 cursor-pointer">
               <div className="flex items-center mb-3 sm:mb-0">
                 {author.publishingAuthor.split(" ")[0].toLowerCase().trim() ==
-                author.postAuthor.split(" ")[0].toLowerCase().trim() ? (
+                author.ppmaAuthorName.split(" ")[0].toLowerCase().trim() ? (
                   <Image
                     src={author.avatarUrl}
-                    alt={`${author.postAuthor}'s Avatar`}
+                    alt={`${author.ppmaAuthorName}'s Avatar`}
                     className="w-12 h-12 rounded-full mr-3 sm:mr-2 "
                     height={48}
                     width={48}
@@ -78,14 +78,14 @@ export default function AuthorMapping({
                 ) : (
                   <Image
                     src={`/blog/images/author.png`}
-                    alt={`${author.postAuthor}'s Avatar`}
+                    alt={`${author.ppmaAuthorName}'s Avatar`}
                     className="w-12 h-12 rounded-full mr-3 sm:mr-2 "
                     height={48}
                     width={48}
                   />
                 )}
                 <h2 className="bg-gradient-to-r from-orange-200 to-orange-100 bg-[length:100%_20px] bg-no-repeat bg-left-bottom w-max mb-8 text-2xl heading1 md:text-xl font-bold tracking-tighter leading-tight">
-                  {author.postAuthor}
+                  {author.ppmaAuthorName}
                 </h2>
               </div>
             </div>

--- a/components/TagsPostPreview.tsx
+++ b/components/TagsPostPreview.tsx
@@ -17,7 +17,7 @@ export default function TagsPostPreview({
   coverImage: Post["featuredImage"];
   date: Post["date"];
   excerpt: Post["excerpt"];
-  author: Post["postAuthor"];
+  author: Post["ppmaAuthorName"];
   slug: Post["slug"];
   isCommunity: any;
 }) {

--- a/components/TagsStories.tsx
+++ b/components/TagsStories.tsx
@@ -20,7 +20,7 @@ export default function TagsStories({ posts}) {
             title={node.title}
             coverImage={node.featuredImage}
             date={node.date}
-            author={node.postAuthor}
+            author={node.ppmaAuthorName}
             slug={node.slug}
             excerpt={getExcerpt(node.excerpt, 20)}
             isCommunity={node.categories}

--- a/components/avatar.tsx
+++ b/components/avatar.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import { Post } from "../types/post";
-export default function Avatar({ author }: { author: Post["postAuthor"] }) {
+export default function Avatar({ author }: { author: Post["ppmaAuthorName"] }) {
   // const isAuthorHaveFullName = author?.node?.firstName && author?.node?.lastName
   // const name = isAuthorHaveFullName
   //   ? `${author.node.firstName} ${author.node.lastName}`

--- a/components/hero-post.tsx
+++ b/components/hero-post.tsx
@@ -6,7 +6,7 @@ import { Post } from "../types/post";
 
 interface Props extends Pick<Post, "title" | "date" | "excerpt" | "slug"> {
   coverImage: Post["featuredImage"];
-  author: Post["postAuthor"];
+  author: Post["ppmaAuthorName"];
   isCommunity?: boolean;
 }
 

--- a/components/more-stories.tsx
+++ b/components/more-stories.tsx
@@ -55,7 +55,7 @@ export default function MoreStories({
               title={node.title}
               coverImage={node.featuredImage}
               date={node.date}
-              author={node.postAuthor}
+              author={node.ppmaAuthorName}
               slug={node.slug}
               excerpt={getExcerpt(node.excerpt, 20)}
               isCommunity={

--- a/components/post-body.tsx
+++ b/components/post-body.tsx
@@ -19,7 +19,7 @@ export default function PostBody({
   ReviewAuthorDetails,
 }: {
   content: Post["content"];
-  authorName: Post["postAuthor"];
+  authorName: Post["ppmaAuthorName"];
   ReviewAuthorDetails: { edges: { node: { name: string; avatar: { url: string }; description: string } }[] };
 }) {
   const [tocItems, setTocItems] = useState([]);

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -18,7 +18,7 @@ export default function PostPreview({
   coverImage: Post["featuredImage"];
   date: Post["date"];
   excerpt: Post["excerpt"];
-  author: Post["postAuthor"];
+  author: Post["ppmaAuthorName"];
   slug: Post["slug"];
   isCommunity?: boolean;
 }) {

--- a/components/postByAuthorMapping.tsx
+++ b/components/postByAuthorMapping.tsx
@@ -44,7 +44,7 @@ function Node({ node }) {
             height={200}
             width={200}
           />
-          <p className="mb-2 text-gray-400">Author: {node.postAuthor}</p>
+          <p className="mb-2 text-gray-400">Author: {node.ppmaAuthorName}</p>
           <p className="mb-4 text-gray-500">
             Category: {node.categories.edges[0].node.name}
           </p>
@@ -62,7 +62,7 @@ const PostByAuthorMapping = ({
   filteredPosts: { node: Post }[];
   Content: string;
 }) => {
-  const AuthorName = filteredPosts[0].node.postAuthor;
+  const AuthorName = filteredPosts[0].node.ppmaAuthorName;
   return (
     <div className="container mx-auto mt-8">
       <div className="mb-5">

--- a/components/topBlogs.tsx
+++ b/components/topBlogs.tsx
@@ -16,7 +16,7 @@ const TopBlogs = ({ communityPosts, technologyPosts }) => {
             title={node.title}
             coverImage={node.featuredImage}
             date={node.date}
-            author={node.postAuthor}
+            author={node.ppmaAuthorName}
             slug={node.slug}
             excerpt={getExcerpt(node.excerpt, 20)}
             isCommunity={false}
@@ -43,7 +43,7 @@ const TopBlogs = ({ communityPosts, technologyPosts }) => {
             title={node.title}
             coverImage={node.featuredImage}
             date={node.date}
-            author={node.postAuthor}
+            author={node.ppmaAuthorName}
             slug={node.slug}
             excerpt={getExcerpt(node.excerpt, 20)}
             isCommunity={true}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -103,7 +103,7 @@ export async function getAllPostsFromTags(tagName: String, preview) {
                 name
               }
             }
-            postAuthor
+            ppmaAuthorName
             categories {
               edges {
                 node {
@@ -196,7 +196,7 @@ export async function getAllPostsForHome(preview) {
                   name
                 }
               }
-              postAuthor
+              ppmaAuthorName
               categories {
                 edges {
                   node {
@@ -291,7 +291,7 @@ export async function getAllPostsForTechnology(preview) {
                 }
               }
             }
-            postAuthor
+            ppmaAuthorName
             categories {
               edges {
                 node {
@@ -320,7 +320,7 @@ export async function getAllAuthors() {
       posts(first:1000){
         edges{
           node{
-            postAuthor
+            ppmaAuthorName
             author {
               node {
                 name
@@ -348,7 +348,7 @@ export async function getPostsByAuthor() {
           node {
             postId
             title
-            postAuthor
+            ppmaAuthorName
             slug
             featuredImage {
               node {
@@ -397,7 +397,7 @@ export async function getMoreStoriesForSlugs() {
                 }
               }
             }
-            postAuthor
+            ppmaAuthorName
             categories {
               edges {
                 node {
@@ -430,7 +430,7 @@ export async function getMoreStoriesForSlugs() {
                 }
               }
             }
-            postAuthor
+            ppmaAuthorName
             categories {
               edges {
                 node {
@@ -493,7 +493,7 @@ export async function getPostAndMorePosts(slug, preview, previewData) {
       excerpt
       slug
       date
-      postAuthor
+      ppmaAuthorName
       featuredImage {
         node {
           sourceUrl
@@ -538,7 +538,7 @@ export async function getPostAndMorePosts(slug, preview, previewData) {
                   ...AuthorFields
                 }
               }
-              postAuthor
+              ppmaAuthorName
             }
           }
         }

--- a/pages/authors/[slug].tsx
+++ b/pages/authors/[slug].tsx
@@ -19,7 +19,7 @@ export default function AuthorPage({ preview, filteredPosts ,content }) {
     );
   }
 
-  const authorName  =  filteredPosts[0]?.node?.postAuthor;
+  const authorName  =  filteredPosts[0]?.node?.ppmaAuthorName;
 
   return (
     <div className="bg-accent-1">
@@ -45,7 +45,7 @@ export const getStaticPaths: GetStaticPaths = async ({}) => {
   const AllAuthors = await getAllAuthors();
   return {
     paths:
-      AllAuthors.edges.map(({ node }) => `/authors/${node.postAuthor}`) ||
+      AllAuthors.edges.map(({ node }) => `/authors/${node.ppmaAuthorName}`) ||
       [],
     fallback: true,
   };
@@ -58,7 +58,7 @@ export const getStaticProps: GetStaticProps = async ({
   const { slug } = params;
   const postsByAuthor = await getPostsByAuthor();
   const filteredPosts = postsByAuthor.edges.filter(
-    (item) => item.node.postAuthor === slug
+    (item) => item.node.ppmaAuthorName === slug
   );
   const postId = (filteredPosts[0].node.postId);
   const content = await getContent(postId);

--- a/pages/authors/index.tsx
+++ b/pages/authors/index.tsx
@@ -13,7 +13,7 @@ export default function Authors({
 }: {
   AllAuthors: {
     edges: {
-      node: { author: Post["author"]; postAuthor: Post["postAuthor"] };
+      node: { author: Post["author"]; ppmaAuthorName: Post["ppmaAuthorName"] };
     }[];
   };
   preview;

--- a/pages/community/[slug].tsx
+++ b/pages/community/[slug].tsx
@@ -35,7 +35,7 @@ const postBody = ({ content, post }) => {
   // Replace the URL in the content with the desired one using the regular expression
   const replacedContent = content.replace(
     urlPattern,
-    `/blog/authors/${post.postAuthor}/`
+    `/blog/authors/${post.ppmaAuthorName}/`
   );
 
   return replacedContent;
@@ -54,7 +54,7 @@ export default function Post({ post, posts, reviewAuthorDetails, preview }) {
 
   useEffect(() => {
     if (reviewAuthorDetails && reviewAuthorDetails?.length > 0) {
-      const authorIndex = post.postAuthor === "Neha" ? 1 : 0;
+      const authorIndex = post.ppmaAuthorName === "Neha" ? 1 : 0;
       const authorNode = reviewAuthorDetails[authorIndex]?.edges[0]?.node;
       if (authorNode) {
         setpostBodyReviewerAuthor(authorIndex);
@@ -66,7 +66,7 @@ export default function Post({ post, posts, reviewAuthorDetails, preview }) {
   }, [post, reviewAuthorDetails]);
   const blogwriter = [
     {
-      name: post?.postAuthor || "Author",
+      name: post?.ppmaAuthorName || "Author",
       ImageUrl: avatarImgSrc || "/blog/images/author.png",
       description: blogWriterDescription || "An author for keploy's blog.",
     },
@@ -155,7 +155,7 @@ export default function Post({ post, posts, reviewAuthorDetails, preview }) {
                 title={post?.title || "Loading..."}
                 coverImage={post?.featuredImage}
                 date={post?.date || ""}
-                author={post?.postAuthor || ""}
+                author={post?.ppmaAuthorName || ""}
                 categories={post?.categories || []}
                 BlogWriter={blogwriter}
                 BlogReviewer={blogreviewer}
@@ -172,7 +172,7 @@ export default function Post({ post, posts, reviewAuthorDetails, preview }) {
             content={
               post?.content && postBody({ content: post?.content, post })
             }
-            authorName={post?.postAuthor || ""}
+            authorName={post?.ppmaAuthorName || ""}
             ReviewAuthorDetails={
               reviewAuthorDetails &&
               reviewAuthorDetails?.length > 0 &&

--- a/pages/community/index.tsx
+++ b/pages/community/index.tsx
@@ -37,7 +37,7 @@ export default function Community({ allPosts: { edges }, preview }) {
             title={heroPost.title}
             coverImage={heroPost.featuredImage}
             date={heroPost.date}
-            author={heroPost.postAuthor}
+            author={heroPost.ppmaAuthorName}
             slug={heroPost.slug}
             excerpt={excerpt}
             isCommunity={true}

--- a/pages/technology/[slug].tsx
+++ b/pages/technology/[slug].tsx
@@ -34,7 +34,7 @@ const postBody = ({ content, post }) => {
   // Replace the URL in the content with the desired one using the regular expression
   const replacedContent = content.replace(
     urlPattern,
-    `/blog/authors/${post?.postAuthor || "Unknown Author"}/`
+    `/blog/authors/${post?.ppmaAuthorName || "Unknown Author"}/`
   );
 
   return replacedContent;
@@ -52,7 +52,7 @@ export default function Post({ post, posts, reviewAuthorDetails, preview }) {
   const [postBodyReviewerAuthor, setpostBodyReviewerAuthor] = useState(0);
   useEffect(() => {
     if (reviewAuthorDetails && reviewAuthorDetails?.length > 0) {
-      const authorIndex = post.postAuthor === "Neha" ? 1 : 0;
+      const authorIndex = post.ppmaAuthorName === "Neha" ? 1 : 0;
       const authorNode = reviewAuthorDetails[authorIndex]?.edges[0]?.node;
       if (authorNode) {
         setpostBodyReviewerAuthor(authorIndex);
@@ -65,7 +65,7 @@ export default function Post({ post, posts, reviewAuthorDetails, preview }) {
 
   const blogwriter = [
     {
-      name: post?.postAuthor || "Author",
+      name: post?.ppmaAuthorName || "Author",
       ImageUrl: avatarImgSrc || "/blog/images/author.png",
       description: blogWriterDescription || "An author for keploy's blog.",
     },
@@ -153,7 +153,7 @@ export default function Post({ post, posts, reviewAuthorDetails, preview }) {
                 title={post?.title || "Loading..."}
                 coverImage={post?.featuredImage}
                 date={post?.date || ""}
-                author={post?.postAuthor || ""}
+                author={post?.ppmaAuthorName || ""}
                 categories={post?.categories || []}
                 BlogWriter={blogwriter}
                 BlogReviewer={blogreviewer}
@@ -170,7 +170,7 @@ export default function Post({ post, posts, reviewAuthorDetails, preview }) {
             content={
               post?.content && postBody({ content: post?.content, post })
             }
-            authorName={post?.postAuthor || ""}
+            authorName={post?.ppmaAuthorName || ""}
             ReviewAuthorDetails={
               reviewAuthorDetails &&
               reviewAuthorDetails?.length > 0 &&

--- a/pages/technology/index.tsx
+++ b/pages/technology/index.tsx
@@ -31,7 +31,7 @@ export default function Index({ allPosts: { edges }, preview }) {
             title={heroPost.title}
             coverImage={heroPost.featuredImage}
             date={heroPost.date}
-            author={heroPost.postAuthor}
+            author={heroPost.ppmaAuthorName}
             slug={heroPost.slug}
             excerpt={excerpt}
             isCommunity={false}

--- a/types/post.ts
+++ b/types/post.ts
@@ -14,7 +14,7 @@ export interface Post {
   author: {
     node: Author;
   };
-  postAuthor: string;
+  ppmaAuthorName: string;
   categories: {
     edges: {
       node: {


### PR DESCRIPTION
tested locally with `npm run build`

<img width="1183" alt="image" src="https://github.com/user-attachments/assets/a45f38c6-0232-490e-901f-99a93e162367">

In this PR, we have update `postAuthor` query back to `ppmaAuthorName` and disabled yoast plugin. Since PublishPressAuthors and Yoast are in compatible. We explore Mologui Plugin with PostAuthor, it worked best, but at many places certain values were hardcoded, leading to breaking changes in author data.