### PR TITLE
Fix minor ui break in mobile devices for table

### DIFF
--- a/components/post-body.tsx
+++ b/components/post-body.tsx
@@ -280,7 +280,7 @@ export default function PostBody({
       </div>
       <div className={`w-full p-4 ${isList ? "ml-10" : ""}  md:w-4/5 lg:w-3/5`} id="post-body-check">
         {slug === "how-to-compare-two-json-files" && <JsonDiffViewer />}
-        <div className="prose lg:prose-xl">{renderCodeBlocks()}</div>
+        <div className="prose lg:prose-xl prose lg:prose-xl post-content-wrapper">{renderCodeBlocks()}</div>
         <hr className="border-gray-300 mt-10 mb-20" />
         <div>
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -223,3 +223,22 @@ td{
   border: solid 1px black;
   padding: 5px;
 }
+
+.post-content-wrapper table {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+  display: block;
+  box-sizing: border-box;
+}
+
+@media (max-width: 1024px) {
+  .post-content-wrapper table {
+    width: 100%;
+    max-width: 100%;
+  }
+  .post-content-wrapper th,
+  .post-content-wrapper td {
+    white-space: normal;
+  }
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change along with the relevant motivation and context. -->
This PR fixes a breaking UI in the mobile device. If the table component is too long, then it takes a lot of extra space.


### Changes
<!-- Provide a concise bullet-point list of key modifications. -->
Fixed the CSS for mobile so that the UI doesn't stretch itself, rather it wraps itself and the user can easily scroll through.