### PR TITLE
[bug][fix] GitHub star count update via internal API

### DIFF
--- a/hooks/useGithubStars.tsx
+++ b/hooks/useGithubStars.tsx
@@ -1,13 +1,16 @@
 import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
 
 export function useGithubStars(initialStars = "10.2K") {
   const [stars, setStars] = useState(initialStars);
+  const { basePath } = useRouter();
 
   useEffect(() => {
-    fetch("https://api.github.com/repos/keploy/keploy")
+    const url = `${basePath}/api/github-stars`;
+    fetch(url)
       .then((response) => response.json())
       .then((data) => {
-        const count = data.stargazers_count;
+        const count = data.stars ?? data.stargazers_count;
         const formattedCount =
           count >= 1000
             ? `${(count / 1000).toFixed(1).replace(".0", "")}K`
@@ -15,7 +18,7 @@ export function useGithubStars(initialStars = "10.2K") {
         setStars(formattedCount);
       })
       .catch(() => {});
-  }, []);
+  }, [basePath]);
 
   return stars;
 }

--- a/pages/api/github-stars.ts
+++ b/pages/api/github-stars.ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+type GithubRepoResponse = {
+  stargazers_count?: number;
+};
+
+type Data = {
+  stars: number;
+  cachedAt: string;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Data | { error: string }>
+) {
+  try {
+    const apiRes = await fetch("https://api.github.com/repos/keploy/keploy", {
+      headers: {
+        "User-Agent": "keploy-blog",
+        Accept: "application/vnd.github+json",
+      },
+      cache: "no-store",
+    });
+
+    if (!apiRes.ok) {
+      return res.status(apiRes.status).json({ error: "Failed to fetch stars" });
+    }
+
+    const data: GithubRepoResponse = await apiRes.json();
+    const stars = typeof data.stargazers_count === "number" ? data.stargazers_count : 0;
+
+    res.setHeader("Cache-Control", "s-maxage=600, stale-while-revalidate");
+    return res.status(200).json({ stars, cachedAt: new Date().toISOString() });
+  } catch (error) {
+    return res.status(500).json({ error: "Unexpected error" });
+  }
+}
+
+


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Suggested PR title format examples:
  feat: Adding a new feature
  fix: For bug fixes that affect the end-user
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  chore: For small tasks
  docs: For documentation
  ui: For UI/design changes or improvements
  perf: For performance improvements
-->
## Related Tickets & Documents
<!-- Please list the issue or open one if it doesnt exist -->
Fixes: #2966 - https://github.com/keploy/keploy/issues/2966

## Description
<!-- Please include a summary of the change along with the relevant motivation and context. -->
- Why the issue occurred: Direct browser requests to GitHub’s API were blocked by Content Security Policy (CSP) and CORS, so the star count did not update in production. While it worked in local development, the production environment enforced stricter security policies, causing the browser to refuse requests to https://api.github.com.
- How it was fixed: Added a server-side API route (/api/github-stars) that fetches the star count and caches it. Updated useGithubStars hook to call this internal API instead of GitHub directly.

While it would have been possible to relax the CSP headers to allow requests to https://api.github.com, we chose an internal API proxy instead because the CSP is enforced at the hosting level and cannot be modified from the code.

### Changes
<!-- Provide a concise bullet-point list of key modifications. -->
- Added pages/api/github-stars.ts for server-side fetching and caching.
- Updated hooks/useGithubStars.tsx to call /api/github-stars

## Type of Change
<!--  Select the most appropriate option(s) -->
- [ ] Chore (maintenance, refactoring, tooling updates)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (change that adds functionality)
- [ ] Breaking Change (may require updates in existing code)
- [ ] UI improvement (visual or design changes)
- [ ] Performance improvement (optimization or efficiency enhancements)
- [ ] Documentation update (changes to README, guides, etc.)
- [ ] CI (updates to continuous integration workflows)
- [ ] Revert (undo a previous commit or merge)

## Testing
<!-- Please describe how these changes were tested, specify any test cases or list any relevant details. -->
- Verified locally that the hook displays the correct formatted star count.
- Confirmed CSP compliance; no browser errors from direct GitHub requests.
- Numbers and API calls were verified locally; final production values will be confirmed after deployment due to CSP and caching behavior


## Demo
<!--
For UI changes, please provide:
1. Video showing before/after
2. Responsiveness across mobile, tablet and desktop screens
For functional changes, include example API requests or screenshots of console output etc.
-->
Hook now displays live GitHub star count via internal API.
- Live Check :
<img width="1920" height="275" alt="Screenshot 2025-09-25 202253" src="https://github.com/user-attachments/assets/f7c285d1-68af-4290-b9f5-e46a2478af2e" />

- Build Check :
<img width="480" height="360" alt="Screenshot 2025-09-25 202639" src="https://github.com/user-attachments/assets/126fc0ef-2ee4-45a6-8546-a433da125d63" />


## Environment and Dependencies 
- **New Dependencies:** <!-- List any new packages or libraries --> None
- **Configuration Changes:** <!-- Describe any changes needed in the environment setup --> None

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added corresponding tests
- [x] I have run the build command to ensure there are no build errors
- [x] My changes have been tested across relevant browsers/devices
- [x] For UI changes, I've included visual evidence of my changes

<!--- Thanks for contributing to our blog website! If the tests fail or you have questions, please leave a comment below and our team will be happy to assist you. --->