### PR TITLE
fix: Make table of contents headings clickable and scrollable #3438

### DIFF
--- a/components/TableContents.tsx
+++ b/components/TableContents.tsx
@@ -67,7 +67,7 @@ export default function TOC({ headings, isList, setIsList }) {
   }, [])
 
   const handleItemClick = (id) => {
-    // id is already sanitized from post-body.tsx
+
     const element = document.getElementById(id);
     if (element) {
       const offset = 80; 
@@ -77,7 +77,6 @@ export default function TOC({ headings, isList, setIsList }) {
         behavior: "smooth",
       });
 
-      // Update URL hash with the sanitized ID
       window.history.replaceState(null, null, `#${id}`);
     }
   };
@@ -145,7 +144,7 @@ export default function TOC({ headings, isList, setIsList }) {
                   >
                     <button
                       onClick={() => {
-                        // item.id is already sanitized from post-body.tsx
+                   
                         const el = document.getElementById(item.id);
                         if (el) {
                           const offset = 80;

--- a/components/TableContents.tsx
+++ b/components/TableContents.tsx
@@ -37,7 +37,7 @@ function TOCItem({
     <li className={itemClasses} style={{ marginLeft }}>
       <button
         onClick={() => onClick(id)}
-        className="block w-full py-1 text-sm text-left text-black transition-all duration-150 ease-in-out rounded-md opacity-75 hover:text-orange-500 hover:opacity-100"
+        className="block w-full py-1 text-sm text-left text-black transition-all duration-150 ease-in-out rounded-md opacity-75 hover:text-orange-500 hover:opacity-100 cursor-pointer"
       >
         {title}
       </button>
@@ -67,6 +67,7 @@ export default function TOC({ headings, isList, setIsList }) {
   }, [])
 
   const handleItemClick = (id) => {
+    // id is already sanitized from post-body.tsx
     const element = document.getElementById(id);
     if (element) {
       const offset = 80; 
@@ -76,9 +77,8 @@ export default function TOC({ headings, isList, setIsList }) {
         behavior: "smooth",
       });
 
-      const urlChange = sanitizeStringForURL(element.innerHTML,true)
-
-      window.history.replaceState(null, null, `#${urlChange}`);
+      // Update URL hash with the sanitized ID
+      window.history.replaceState(null, null, `#${id}`);
     }
   };
 
@@ -145,6 +145,7 @@ export default function TOC({ headings, isList, setIsList }) {
                   >
                     <button
                       onClick={() => {
+                        // item.id is already sanitized from post-body.tsx
                         const el = document.getElementById(item.id);
                         if (el) {
                           const offset = 80;
@@ -152,16 +153,15 @@ export default function TOC({ headings, isList, setIsList }) {
                             top: el.offsetTop - offset,
                             behavior: "smooth",
                           });
-                          const sanitizedId = sanitizeStringForURL(item.title, true);
                           window.history.replaceState(
                             null,
                             null,
-                            `#${sanitizedId}`
+                            `#${item.id}`
                           );
                           setIsDropdownOpen(false);
                         }
                       }}
-                      className="w-full text-left"
+                      className="w-full text-left cursor-pointer"
                     >
                       {item.title}
                     </button>

--- a/components/post-body.tsx
+++ b/components/post-body.tsx
@@ -81,8 +81,8 @@ export default function PostBody({
       const headings = Array.from(document.getElementById('post-body-check').querySelectorAll("h1, h2, h3, h4"));
 
       const tocItems = headings.map((heading) => {
-        const id = `${heading.textContent}`;
-        heading.setAttribute("id", sanitizeStringForURL(id, true));
+        const id = sanitizeStringForURL(`${heading.textContent}`, true);
+        heading.setAttribute("id", id);
 
         return {
           id,


### PR DESCRIPTION
## Description
Fixes the table of contents functionality on blog pages. TOC items now properly scroll to their corresponding sections when clicked.

## Changes
- Fixed ID mismatch between TOC items and heading elements
- TOC items now use sanitized IDs that match heading element IDs
- Added cursor-pointer class for better UX
- Updated handleItemClick to use sanitized IDs correctly
- Fixed dropdown click handler to use correct ID format

## Testing
- Tested locally on blog pages
- TOC items now properly scroll to sections when clicked
- URL hash updates correctly
- Works on both desktop and mobile views

## Issue
The table of contents showed pointer cursor on hover but clicking did nothing. This was due to ID mismatch between TOC items (using raw text) and heading elements (using sanitized IDs).