### PR TITLE
feat: add search bar to more stories section on blog reading pages

### DIFF
--- a/components/more-stories.tsx
+++ b/components/more-stories.tsx
@@ -90,12 +90,14 @@ export default function MoreStories({
   // 3. Handle Enter Key (Conditional Logic)
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
-      // ONLY redirect if we are on Community AND NOT already on the search page
-      if (isCommunity && !isSearchPage && searchTerm.trim()) {
+      // ONLY redirect if we are on Community index page (not detail pages with showSearch)
+      // AND NOT already on the search page
+      if (isCommunity && !isSearchPage && !showSearch && searchTerm.trim()) {
         event.preventDefault();
         router.push(`/community/search?q=${encodeURIComponent(searchTerm)}`);
       }
-      // For Technology (!isCommunity), do nothing. The local filter is already active.
+      // For Technology (!isCommunity) or detail pages (showSearch), do nothing. 
+      // The local filter is already active.
     }
   };
 

--- a/components/more-stories.tsx
+++ b/components/more-stories.tsx
@@ -12,6 +12,7 @@ interface MoreStoriesProps {
   isCommunity: boolean;
   isIndex: boolean;
   isSearchPage?: boolean;
+  showSearch?: boolean;
   initialPageInfo?: { hasNextPage: boolean; endCursor: string | null };
   externalSearchTerm?: string;
   onSearchChange?: (term: string) => void;
@@ -22,6 +23,7 @@ export default function MoreStories({
   isCommunity,
   isIndex,
   isSearchPage = false,
+  showSearch = false,
   initialPageInfo,
   externalSearchTerm,
   onSearchChange,
@@ -195,7 +197,7 @@ export default function MoreStories({
         )}
       </h2>
       
-      {(isIndex || isSearchPage) && (
+      {(isIndex || isSearchPage || showSearch) && (
         <div className="flex w-full mb-8">
           <div className="relative w-full">
             <input

--- a/pages/community/[slug].tsx
+++ b/pages/community/[slug].tsx
@@ -228,7 +228,7 @@ export default function Post({ post, posts, reviewAuthorDetails, preview }) {
           </footer>
           <SectionSeparator />
           {morePosts?.length > 0 && (
-            <MoreStories isIndex={false} posts={morePosts} isCommunity={true} />
+            <MoreStories isIndex={false} posts={morePosts} isCommunity={true} showSearch={true} />
           )}
         </article>
       </Container>

--- a/pages/technology/[slug].tsx
+++ b/pages/technology/[slug].tsx
@@ -217,7 +217,7 @@ export default function Post({ post, posts, reviewAuthorDetails, preview }) {
           </footer>
           <SectionSeparator />
           {morePosts?.length > 0 && (
-            <MoreStories isIndex={false} posts={morePosts} isCommunity={false} />
+            <MoreStories isIndex={false} posts={morePosts} isCommunity={false} showSearch={true} />
           )}
         </article>
       </Container>


### PR DESCRIPTION
## Description
Added a search bar to the "More Stories" section at the bottom of blog reading pages, allowing users to search for specific blogs right after reading.

## Changes Made
- Added `showSearch` prop to `MoreStories` component interface
- Updated search bar visibility condition to include `showSearch` prop
- Enabled search on both technology and community blog reading pages
- Search bar appears right after the "More Stories" heading

## Technical Details
- Modified `components/more-stories.tsx` to accept optional `showSearch` prop
- Updated `pages/technology/[slug].tsx` to pass `showSearch={true}`
- Updated `pages/community/[slug].tsx` to pass `showSearch={true}`
- Reused existing search functionality (filtering, URL sync, etc.)

## Testing
- Tested on `/blog/technology/[slug]` pages
- Tested on `/blog/community/[slug]` pages
- Verified search filters the 6 suggested posts correctly
- Confirmed search bar only appears on blog reading pages, not index pages

Fixes keploy/keploy#3436
