### PR TITLE
feat: Add social sharing options to blog posts

### DIFF
--- a/components/floating-social-share.tsx
+++ b/components/floating-social-share.tsx
@@ -1,0 +1,84 @@
+import React, { useState, useEffect } from "react";
+import Link from "next/link";
+import { FaTwitter, FaLinkedin, FaLink } from "react-icons/fa";
+import { useRouter } from "next/router";
+
+interface FloatingSocialShareProps {
+  postUrl: string;
+  postTitle: string;
+}
+
+const FloatingSocialShare: React.FC<FloatingSocialShareProps> = ({ postUrl, postTitle }) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const router = useRouter();
+
+  const currentURL = encodeURIComponent(postUrl);
+  const twitterShareUrl = `https://twitter.com/share?url=${currentURL}&text=${encodeURIComponent(postTitle)}`;
+  const linkedinShareUrl = `https://www.linkedin.com/shareArticle?url=${currentURL}&title=${encodeURIComponent(postTitle)}`;
+
+  const copyToClipboard = async () => {
+    try {
+      await navigator.clipboard.writeText(postUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy!", err);
+    }
+  };
+
+  useEffect(() => {
+    const handleScroll = () => {
+      // Show when scrolled past header (around 300px)
+      const scrollY = window.scrollY;
+      setIsVisible(scrollY > 300);
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  if (!isVisible) return null;
+
+  return (
+    <div className="fixed right-6 top-1/2 -translate-y-1/2 z-50 hidden lg:flex flex-col gap-3">
+      <div className="bg-white/90 backdrop-blur-sm rounded-full p-3 shadow-lg border border-gray-200/50">
+        <p className="text-xs text-gray-600 mb-2 text-center font-medium">Share</p>
+        <div className="flex flex-col gap-3">
+          <Link
+            href={twitterShareUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-gray-700 hover:text-blue-500 transition-colors duration-200 p-2 rounded-full hover:bg-blue-50"
+            aria-label="Share on Twitter"
+          >
+            <FaTwitter className="w-5 h-5" />
+          </Link>
+          <Link
+            href={linkedinShareUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-gray-700 hover:text-blue-600 transition-colors duration-200 p-2 rounded-full hover:bg-blue-50"
+            aria-label="Share on LinkedIn"
+          >
+            <FaLinkedin className="w-5 h-5" />
+          </Link>
+          <button
+            onClick={copyToClipboard}
+            className="text-gray-700 hover:text-orange-500 transition-colors duration-200 p-2 rounded-full hover:bg-orange-50 focus:outline-none"
+            aria-label="Copy link to clipboard"
+          >
+            <FaLink className="w-5 h-5" />
+          </button>
+        </div>
+        {copied && (
+          <div className="absolute -left-20 top-1/2 -translate-y-1/2 bg-orange-500 text-white text-xs px-2 py-1 rounded whitespace-nowrap">
+            Copied!
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default FloatingSocialShare;

--- a/components/inline-social-share.tsx
+++ b/components/inline-social-share.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from "react";
+import Link from "next/link";
+import { FaTwitter, FaLinkedin, FaLink } from "react-icons/fa";
+
+interface InlineSocialShareProps {
+  postUrl: string;
+  postTitle: string;
+}
+
+const InlineSocialShare: React.FC<InlineSocialShareProps> = ({ postUrl, postTitle }) => {
+  const [copied, setCopied] = useState(false);
+
+  const currentURL = encodeURIComponent(postUrl);
+  const twitterShareUrl = `https://twitter.com/share?url=${currentURL}&text=${encodeURIComponent(postTitle)}`;
+  const linkedinShareUrl = `https://www.linkedin.com/shareArticle?url=${currentURL}&title=${encodeURIComponent(postTitle)}`;
+
+  const copyToClipboard = async () => {
+    try {
+      await navigator.clipboard.writeText(postUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy!", err);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-4 mt-6 mb-6 lg:hidden">
+      <span className="text-sm text-gray-600 font-medium">Share:</span>
+      <div className="flex gap-3">
+        <Link
+          href={twitterShareUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-gray-700 hover:text-blue-500 transition-colors duration-200 p-2 rounded-full hover:bg-blue-50"
+          aria-label="Share on Twitter"
+        >
+          <FaTwitter className="w-5 h-5" />
+        </Link>
+        <Link
+          href={linkedinShareUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-gray-700 hover:text-blue-600 transition-colors duration-200 p-2 rounded-full hover:bg-blue-50"
+          aria-label="Share on LinkedIn"
+        >
+          <FaLinkedin className="w-5 h-5" />
+        </Link>
+        <button
+          onClick={copyToClipboard}
+          className="text-gray-700 hover:text-orange-500 transition-colors duration-200 p-2 rounded-full hover:bg-orange-50 focus:outline-none relative"
+          aria-label="Copy link to clipboard"
+        >
+          <FaLink className="w-5 h-5" />
+          {copied && (
+            <div className="absolute -top-8 left-1/2 -translate-x-1/2 bg-orange-500 text-white text-xs px-2 py-1 rounded whitespace-nowrap">
+              Copied!
+            </div>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default InlineSocialShare;

--- a/package-lock.json
+++ b/package-lock.json
@@ -270,7 +270,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.34.1.tgz",
       "integrity": "sha512-t1zK/l9UiRqwUNPm+pdIT0qzJlzuVckbTEMVNFhfWkGiBQClstzg+78vedCvLSX0xJEZ6lwZbPpnljL7L6iwMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.4.0",
         "style-mod": "^4.1.0",
@@ -1454,7 +1453,6 @@
       "version": "18.2.36",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.36.tgz",
       "integrity": "sha512-o9XFsHYLLZ4+sb9CWUYwHqFVoG61SesydF353vFMMsQziiyRu8np4n2OYMUSDZ8XuImxDr9c5tR7gidlH29Vnw==",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -1465,7 +1463,6 @@
       "version": "18.2.14",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.14.tgz",
       "integrity": "sha512-V835xgdSVmyQmI1KLV2BEIUgqEuinxp9O4G6g3FqO/SqLac049E53aysv0oEFD2kHfejeKU+ZqL2bcFWj9gLAQ==",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -1524,7 +1521,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -1796,7 +1792,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2185,7 +2180,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001541",
         "electron-to-chromium": "^1.4.535",
@@ -2780,7 +2774,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
       "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2933,7 +2926,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
       "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.7",
         "array.prototype.findlastindex": "^1.2.3",
@@ -4918,7 +4910,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -5098,7 +5089,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5110,7 +5100,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -5808,7 +5797,6 @@
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.5.tgz",
       "integrity": "sha512-5SEZU4J7pxZgSkv7FP1zY8i2TIAOooNZ1e/OGtxIEv6GltpoiXUqWvLy89+a10qYTB1N5Ifkuw9lqQkN9sscvA==",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -6053,7 +6041,6 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/pages/community/[slug].tsx
+++ b/pages/community/[slug].tsx
@@ -34,6 +34,14 @@ const PostBody = dynamic(() => import("../../components/post-body"), {
   ssr: false,
 });
 
+const FloatingSocialShare = dynamic(() => import("../../components/floating-social-share"), {
+  ssr: false,
+});
+
+const InlineSocialShare = dynamic(() => import("../../components/inline-social-share"), {
+  ssr: false,
+});
+
 const postBody = ({ content, post }) => {
   const urlPattern = /https:\/\/keploy\.io\/wp\/author\/[^\/]+\//g;
 
@@ -200,6 +208,7 @@ export default function Post({ post, posts, reviewAuthorDetails, preview }) {
                 BlogReviewer={blogreviewer}
                 TimeToRead={time}
               />
+              <InlineSocialShare postUrl={postUrl} postTitle={post?.title || ""} />
             </article>
           </>
         )}
@@ -221,6 +230,10 @@ export default function Post({ post, posts, reviewAuthorDetails, preview }) {
           />
         </div>
       </ContainerSlug>
+      <FloatingSocialShare
+        postUrl={postUrl}
+        postTitle={post?.title || ""}
+      />
       <Container>
         <article>
           <footer>

--- a/pages/technology/[slug].tsx
+++ b/pages/technology/[slug].tsx
@@ -27,6 +27,8 @@ import {
   getBreadcrumbListSchema,
   SITE_URL,
 } from "../../lib/structured-data";
+import FloatingSocialShare from "../../components/floating-social-share";
+import InlineSocialShare from "../../components/inline-social-share";
 
 const PostBody = dynamic(() => import("../../components/post-body"), {
   ssr: false,
@@ -190,6 +192,7 @@ export default function Post({ post, posts, reviewAuthorDetails, preview }) {
                 BlogReviewer={blogreviewer}
                 TimeToRead={time}
               />
+              <InlineSocialShare postUrl={postUrl} postTitle={post?.title || ""} />
             </article>
           </>
         )}
@@ -221,6 +224,7 @@ export default function Post({ post, posts, reviewAuthorDetails, preview }) {
           )}
         </article>
       </Container>
+      <FloatingSocialShare postUrl={postUrl} postTitle={post?.title || ""} />
     </Layout>
   );
 }


### PR DESCRIPTION
## Related Tickets & Documents
Fixes: #3579

## Description
Adds simple social sharing options to blog posts so readers can easily share content or copy the post link.

**Proposed options:**
- Twitter / X
- LinkedIn  
- Copy link to clipboard (with visual confirmation)

**Suggested placement:**
- Desktop: floating near the content
- Mobile: inline below the post header

## Changes
- ✅ Created `FloatingSocialShare` component for desktop floating share
- ✅ Created `InlineSocialShare` component for mobile inline share  
- ✅ Integrated components into technology and community post pages
- ✅ Added proper TypeScript types and accessibility features
- ✅ Code passes linting and TypeScript checks

## Type of Change
- [x] New feature (change that adds functionality)

## Testing
- Code passes linting and TypeScript compilation
- Components render correctly on desktop and mobile
- Social media links open in new tabs with proper URLs
- Copy link functionality shows visual confirmation
- Responsive design works across screen sizes

## Demo
Desktop: Floating share panel appears when scrolling past header
Mobile: Inline share buttons below post header