### PR TITLE
ci: add lint and typecheck workflow

### DIFF
--- a/.github/workflows/lint-and-typecheck.yml
+++ b/.github/workflows/lint-and-typecheck.yml
@@ -1,0 +1,33 @@
+name: Lint and Typecheck
+
+on:
+  pull_request:
+    branches: ["**"]
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  lint-typecheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Run Typecheck
+        run: npm run typecheck

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "eslint-config-next": "14.1.0",
         "postcss": "8.4.31",
         "tailwindcss": "^3.0.24",
-        "typescript": "^5.9.3"
+        "typescript": "^5.3.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -6050,9 +6050,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,8 +40,7 @@
         "react-dom": "^18.2.0",
         "react-icons": "^5.0.1",
         "tailwind-merge": "^2.6.0",
-        "tailwindcss-animate": "^1.0.7",
-        "typescript": "^4.7.4"
+        "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
         "@types/prismjs": "^1.26.3",
@@ -51,7 +50,8 @@
         "eslint": "8.56.0",
         "eslint-config-next": "14.1.0",
         "postcss": "8.4.31",
-        "tailwindcss": "^3.0.24"
+        "tailwindcss": "^3.0.24",
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -6050,16 +6050,18 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@codemirror/lang-go": "^6.0.1",
@@ -42,8 +43,7 @@
     "react-dom": "^18.2.0",
     "react-icons": "^5.0.1",
     "tailwind-merge": "^2.6.0",
-    "tailwindcss-animate": "^1.0.7",
-    "typescript": "^4.7.4"
+    "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
     "@types/prismjs": "^1.26.3",
@@ -53,6 +53,7 @@
     "eslint": "8.56.0",
     "eslint-config-next": "14.1.0",
     "postcss": "8.4.31",
-    "tailwindcss": "^3.0.24"
+    "tailwindcss": "^3.0.24",
+    "typescript": "^5.9.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "eslint-config-next": "14.1.0",
     "postcss": "8.4.31",
     "tailwindcss": "^3.0.24",
-    "typescript": "^5.9.3"
+    "typescript": "^5.3.3"
   }
 }


### PR DESCRIPTION
## ✅ Summary
This PR adds a GitHub Actions workflow to run **ESLint** and **TypeScript type-checking** on every PR (and pushes to `main`) to catch issues early.

---

## 🔧 Changes Included
- Added `Lint and Typecheck` GitHub Actions workflow
- Added required npm scripts:
  - `npm run lint`
  - `npm run typecheck`
- Ensured TypeScript version compatibility (`typescript@5.3.3`)

---

## ✅ Why this change?
- Prevents broken or failing builds from being merged
- Improves code quality and consistency
- Catches TypeScript errors before deployment

---

## 🧪 Testing Done
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] Workflow runs successfully on PR

---