### PR TITLE
fix: replace twitter icon with X

### DIFF
--- a/components/PostHeaderAuthors.tsx
+++ b/components/PostHeaderAuthors.tsx
@@ -2,7 +2,12 @@ import React, { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { FaLinkedin, FaTwitter, FaLink } from "react-icons/fa";
+import { FaLinkedin, FaLink } from "react-icons/fa";
+
+
+import { FaXTwitter } from "react-icons/fa6";
+
+
 import { sanitizeAuthorSlug } from "../utils/sanitizeAuthorSlug"; 
 
 const PostHeaderAuthors = ({ blogwriter, blogreviewer, timetoRead }) => {
@@ -146,9 +151,9 @@ const PostHeaderAuthors = ({ blogwriter, blogreviewer, timetoRead }) => {
             href={twitterShareUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="twitter-share-button text-xl text-black transition-colors duration-300 hover:text-blue-500"
+            className="twitter-share-button text-xl text-black transition-colors duration-300 hover:text-black"
           >
-            <FaTwitter className="icon" />
+      <FaXTwitter className="icon" />
           </Link>
           <Link
             href={linkedinShareUrl}


### PR DESCRIPTION
Fixes: #3692

### Description

This PR updates the social sharing icon in the post header to reflect the recent Twitter rebrand to X.
The previous bird icon was outdated and did not match the current platform branding.

### Changes

Replaced the old FaTwitter icon with FaXTwitter from react-icons/fa6
Updated the UI to maintain consistency with the latest X branding

### Testing
<img width="1881" height="958" alt="Screenshot 2026-02-02 143618" src="https://github.com/user-attachments/assets/fd35af49-8bcb-4b06-8d9f-b0315f081d98" />

