### PR TITLE
fix: Navbar dropdown not opening on (iPad Mini ,iPad Air,iPad Pro) responsive viewport 

### DIFF
--- a/components/navbar/FloatingNavbarClient.tsx
+++ b/components/navbar/FloatingNavbarClient.tsx
@@ -223,6 +223,14 @@ export default function FloatingNavbarClient({ techLatest = [], communityLatest 
           >
             <Link
               href="/technology"
+              onClick={(e) => {
+  if (window.matchMedia("(hover: none)").matches) {
+    e.preventDefault();
+    setShowCommunityDropdown((v) => !v);
+    setShowTechDropdown(false);
+  }
+}}
+
               onMouseEnter={() => { setHoveredNav('tech'); setLinkHoverTech(true); }}
               onMouseLeave={() => { setLinkHoverTech(false); setHoveredNav(null); }}
               className={`${(showTechDropdown || showCommunityDropdown || resourcesOpen) && !showTechDropdown ? 'text-black/50' : 'text-foreground'} transition-colors text-[15px] font-medium py-2 px-1 inline-flex items-center gap-1.5 align-middle ${linkHoverTech ? 'underline underline-offset-2 decoration-1 decoration-neutral-400' : ''}`}
@@ -293,6 +301,14 @@ export default function FloatingNavbarClient({ techLatest = [], communityLatest 
           >
             <Link
               href="/community"
+              onClick={(e) => {
+  if (window.matchMedia("(hover: none)").matches) {
+    e.preventDefault();
+    setShowCommunityDropdown((v) => !v);
+    setShowTechDropdown(false);
+  }
+}}
+
               onMouseEnter={() => { setHoveredNav('community'); setLinkHoverCommunity(true); }}
               onMouseLeave={() => { setLinkHoverCommunity(false); setHoveredNav(null); }}
               className={`${(showTechDropdown || showCommunityDropdown || resourcesOpen) && !showCommunityDropdown ? 'text-black/50' : 'text-foreground'} transition-colors text-[15px] font-medium py-2 px-1 inline-flex items-center gap-1.5 align-middle ${linkHoverCommunity ? 'underline underline-offset-2 decoration-1 decoration-neutral-400' : ''}`}


### PR DESCRIPTION
## Related Tickets

Fixes: #3755

## Description

This PR fixes dropdown interaction on touch devices (tablet/iPad) where menus relied only on hover and didn’t open properly.
Now the dropdown toggles on click for non-hover devices while keeping desktop behavior unchanged.

### Changes

* Added click toggle for touch devices
* Ensured only one dropdown opens at a time
* Prevented unwanted navigation when toggling

## Type of Change

* [x] Bug fix
* [x] UI improvement

## Testing

* Tested on desktop (hover works)
* Tested on tablet/mobile viewport (click toggle works)
* No build errors

## Demo video


https://github.com/user-attachments/assets/8162c8d5-011d-4141-9266-c67b8dd939b8



## Checklist

* [x] Self reviewed
* [x] Build runs successfully
* [x] Tested on multiple screen sizes
