### PR TITLE
fix(navbar): align scrolled navbar width with content sections

### DIFF
--- a/components/navbar/FloatingNavbar.tsx
+++ b/components/navbar/FloatingNavbar.tsx
@@ -43,7 +43,7 @@ export default function FloatingNavbar({ isBlogReadingPage }: FloatingNavbarProp
     ? "relative top-0 mx-auto z-40"
     : "fixed top-6 left-1/2 -translate-x-1/2 z-40";
   const navWidthClasses = isScrolled
-    ? "w-[82%] md:max-w-5xl"
+    ? "w-[82%] md:max-w-7xl"
     : "w-[96%] md:max-w-6xl";
   const navPaddingClasses = isScrolled
     ? "px-4 py-1.5 md:px-4 md:py-2 lg:px-5 lg:py-2.5"


### PR DESCRIPTION
Fixes keploy/keploy#3429

## Summary
Fixed the navbar alignment issue where the scrolled/shrunk navbar width did not match the content sections on the landing page. The navbar now uses the same max-width as the Container component to ensure visual consistency.

## Changes
- Changed the scrolled navbar max-width from `md:max-w-5xl` (1024px) to `md:max-w-7xl` (1280px) in `components/navbar/FloatingNavbar.tsx`
- This aligns the navbar with the Container component's max-width used by content sections like Technology Blogs and Community Blogs

## Testing
- Verified that the Container component uses `max-w-7xl` for content width
- The change ensures the navbar aligns with content sections when scrolled

## Diff Stats