### PR TITLE
fix: add missing Script import in _document.tsx

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,4 +1,5 @@
 import { Html, Head, Main, NextScript } from 'next/document';
+import Script from 'next/script';
 
 export default function Document() {
   return (


### PR DESCRIPTION
## fix: add missing Script import in `_document.tsx`

**Problem:** Build was failing with `'Script' is not defined` because `next/script` was used in `_document.tsx` without being imported.

**Fix:** Added `import Script from 'next/script'` to resolve the compile error.

**Successful Build:**

<img width="939" height="350" alt="Screenshot 2026-03-31 at 5 56 03 PM" src="https://github.com/user-attachments/assets/d2c7f2bb-b175-4c60-83c3-0169aef6efc3" />

