### PR TITLE
feat: design, implement and test the automated qa agent

### DIFF
--- a/.github/workflows/qa-review.yml
+++ b/.github/workflows/qa-review.yml
@@ -1,0 +1,155 @@
+name: QA Review Agent
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+  issue_comment:
+    types: [created]
+
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: "PR number to review"
+        required: true
+      review-mode:
+        description: "full (with second-order analysis) or fast"
+        required: false
+        default: "full"
+
+  # Covers "commit pushed" cases. The job will try to resolve an associated PR and skip if none.
+  push:
+    branches:
+      - "**"
+
+jobs:
+  update-codebase-map:
+    name: Update codebase dependency map
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'push' &&
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') &&
+      github.actor != 'github-actions[bot]'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build codebase map
+        run: python qa-agent/scripts/build_codebase_map.py
+      - name: Commit updated map
+        run: |
+          git config user.name "qa-agent"
+          git config user.email "qa-agent@users.noreply.github.com"
+          git add qa-agent/codebase_map.json
+          git diff --staged --quiet || git commit -m "chore: update qa-agent codebase map"
+          git push
+
+  qa-review:
+    name: QA Review
+    runs-on: ubuntu-latest
+
+    if: |
+      github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.comment.body, '/qa-review')) ||
+      github.event_name == 'push'
+
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r qa-agent/requirements.txt
+
+      - name: Resolve PR number and review mode
+        id: context
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "pr_number=${{ github.event.inputs.pr-number }}" >> $GITHUB_OUTPUT
+            echo "mode=${{ github.event.inputs.review-mode }}" >> $GITHUB_OUTPUT
+            echo "skip=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            echo "pr_number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+            if echo "${{ github.event.comment.body }}" | grep -qiE "^/qa-review\\s+fast|/qa-review\\s+fast$"; then
+              echo "mode=fast" >> $GITHUB_OUTPUT
+            else
+              echo "mode=full" >> $GITHUB_OUTPUT
+            fi
+            echo "skip=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            echo "mode=full" >> $GITHUB_OUTPUT
+            echo "skip=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # push event: attempt to resolve an associated PR for this commit
+          python - <<'PY' >> $GITHUB_OUTPUT
+          import json, os, sys, urllib.request
+          repo = os.environ["GITHUB_REPOSITORY"]
+          sha = os.environ["GITHUB_SHA"]
+          token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+          if not token:
+            print("skip=true")
+            sys.exit(0)
+          url = f"https://api.github.com/repos/{repo}/commits/{sha}/pulls"
+          req = urllib.request.Request(url)
+          req.add_header("Authorization", f"Bearer {token}")
+          req.add_header("Accept", "application/vnd.github+json")
+          # preview header required for commits/{sha}/pulls on some GitHub versions
+          req.add_header("Accept", "application/vnd.github.groot-preview+json")
+          try:
+            with urllib.request.urlopen(req, timeout=20) as resp:
+              data = json.loads(resp.read().decode("utf-8"))
+          except Exception:
+            print("skip=true")
+            sys.exit(0)
+          pr_number = None
+          for pr in data or []:
+            if pr.get("state") == "open":
+              pr_number = pr.get("number")
+              break
+          if not pr_number:
+            print("skip=true")
+            sys.exit(0)
+          print(f"pr_number={pr_number}")
+          print("mode=full")
+          print("skip=false")
+          PY
+
+      - name: Skip (no associated PR)
+        if: steps.context.outputs.skip == 'true'
+        run: echo "No open PR associated with this push; skipping QA review."
+
+      - name: Run QA review agent
+        if: steps.context.outputs.skip != 'true'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.context.outputs.pr_number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          REVIEW_MODE: ${{ steps.context.outputs.mode }}
+        run: python qa-agent/scripts/qa_review.py
+

--- a/qa-agent/QA_GUIDELINES.md
+++ b/qa-agent/QA_GUIDELINES.md
@@ -1,0 +1,444 @@
+# QA Guidelines
+> Generated from codebase analysis on 2026-04-13
+> These rules are derived from actual patterns in this codebase.
+> Update this file when the codebase conventions change — via PR, reviewed by the team.
+
+---
+
+## Section 1 — Architecture rules
+
+### RULE-A-001: Respect the `/blog` basePath everywhere
+**What**: Any hardcoded internal path to site assets or routes must include the `/blog` prefix (because `next.config.js` sets `basePath: '/blog'` and `assetPrefix: '/blog'`).  
+**Why**: Missing the prefix breaks favicons, RSS link, and other assets in production, and can break Playwright tests (which use `BASE_URL=http://localhost:3000/blog`).  
+**How to check**: In diffs, search for new `href="/` or `src="/` in React components and ensure it’s `"/blog/..."`
+**Example of violation**:
+```tsx
+// components/meta.tsx style, but missing basePath:
+<link rel="icon" href="/favicon/favicon.ico" />
+```
+**Example of compliance**:
+```tsx
+// components/meta.tsx
+<link rel="shortcut icon" href="/blog/favicon/favicon.ico" />
+```
+
+### RULE-A-002: Routes live in the Pages Router (`pages/`), not `app/`
+**What**: New routes must be added under `pages/` using the existing patterns (e.g. `pages/technology/index.tsx`, `pages/technology/[slug].tsx`, `pages/api/*.ts`).  
+**Why**: The repo currently uses Next.js Pages Router conventions and Playwright tests navigate to `.../blog/technology`, `.../blog/community`, etc. Introducing App Router patterns without a migration plan can break routing and test assumptions.  
+**How to check**: New route files should be under `pages/` and follow existing naming (`index.tsx`, `[slug].tsx`).  
+**Example of violation**:
+```txt
+app/technology/page.tsx
+```
+**Example of compliance**:
+```txt
+pages/technology/index.tsx
+pages/technology/[slug].tsx
+```
+
+### RULE-A-003: WordPress/WPGraphQL access must go through `lib/api.ts`
+**What**: Fetching posts/tags/authors/content from WordPress should use exported functions in `lib/api.ts` (`getAllPostsForTechnology`, `getPostAndMorePosts`, `getAllTags`, etc.) rather than ad-hoc `fetch()` scattered across pages/components.  
+**Why**: `lib/api.ts` centralizes headers, auth token handling (`WORDPRESS_AUTH_REFRESH_TOKEN`), error handling (throws on GraphQL errors), and response normalization (`normalizePostEdges`) to avoid null runtime crashes in downstream consumers.  
+**How to check**: New diffs should not add direct `fetch(process.env.WORDPRESS_API_URL...)` calls in page components; instead add/extend a function in `lib/api.ts` and reuse it.  
+**Example of violation**:
+```ts
+// pages/technology/index.tsx (hypothetical)
+await fetch(process.env.WORDPRESS_API_URL!, { method: "POST", body: ... })
+```
+**Example of compliance**:
+```ts
+// pages/technology/index.tsx
+const allPosts = await getAllPostsForTechnology(preview);
+```
+
+### RULE-A-004: Heavy UI is dynamically imported with `ssr: false`
+**What**: Large client-only components are imported via `next/dynamic` with `ssr: false` (e.g. `components/post-body.tsx` in `pages/*/[slug].tsx`, `components/PageLoader.tsx` in `pages/_app.tsx`).  
+**Why**: This repo explicitly uses dynamic imports to keep initial JS smaller and to avoid SSR mismatches for DOM-dependent code (TOC building, CodeMirror, portals).  
+**How to check**: If a new component reads `window`, uses CodeMirror, portals, IntersectionObserver, etc., it should follow the dynamic import pattern used for `PostBody`.  
+**Example of violation**:
+```tsx
+import PostBody from "../../components/post-body"; // SSR will execute DOM code
+```
+**Example of compliance**:
+```tsx
+const PostBody = dynamic(() => import("../../components/post-body"), { ssr: false });
+```
+
+### RULE-A-005: SEO structured data comes from `lib/structured-data.ts`
+**What**: JSON-LD schemas must be produced via helpers in `lib/structured-data.ts`, and injected via `Meta`/`_document.tsx` as the codebase currently does.  
+**Why**: `tests/e2e/SeoMeta.spec.ts` asserts meta tags, canonical/og URLs, and presence of schema.org JSON-LD. Duplicate or conflicting JSON-LD can regress SEO tests and search parsing.  
+**How to check**: When adding structured data, prefer `getBreadcrumbListSchema`, `getBlogPostingSchema`, `getWebSiteSchema`; avoid inlining hand-written JSON-LD blocks in pages.  
+**Example of violation**:
+```tsx
+<script type="application/ld+json" dangerouslySetInnerHTML={{__html: '{\"@type\":\"BreadcrumbList\"...}'}} />
+```
+**Example of compliance**:
+```tsx
+structuredData={[getBreadcrumbListSchema([{ name: "Home", url: SITE_URL }])]}
+```
+
+---
+
+## Section 2 — Type safety rules
+
+### RULE-T-001: Shared shapes must be modeled via `types/` interfaces
+**What**: When changing or introducing shared post/author/tag data, update `types/post.ts`, `types/author.ts`, `types/tag.ts` and wire the types through component props.  
+**Why**: Many components type their props off `Post` (e.g. `Layout` and `Meta` use `Post["featuredImage"]["node"]["sourceUrl"]`). Unmodeled shape changes can cause subtle runtime breakage that TypeScript won’t catch (tsconfig `strict: false`).  
+**How to check**: If a PR changes the GraphQL selection set or adds fields used by multiple files, ensure `types/` reflects it and usage sites compile logically.  
+**Example of violation**:
+```ts
+// Adding new field usage without updating Post:
+post.seo.metaDesc
+```
+**Example of compliance**:
+```ts
+// types/post.ts updated + code uses typed access
+export interface Post { seo?: { metaDesc?: string } }
+```
+
+### RULE-T-002: URL fragments and slugs must use the existing sanitizers
+**What**: Any URL slug/anchor derived from arbitrary text must go through existing utilities:
+- `utils/sanitizeStringForUrl.ts` (`sanitizeStringForURL`)
+- `utils/sanitizeAuthorSlug.ts` (`sanitizeAuthorSlug`)
+**Why**: The TOC system depends on stable heading IDs; author pages depend on stable slug normalization. Changing the algorithm or bypassing it can break deep links and internal navigation.  
+**How to check**: If a PR introduces `id={heading.textContent}` or similar, require `sanitizeStringForURL(...)`.  
+**Example of violation**:
+```ts
+heading.setAttribute("id", heading.textContent || "");
+```
+**Example of compliance**:
+```ts
+heading.setAttribute("id", sanitizeStringForURL(heading.textContent || "", true));
+```
+
+---
+
+## Section 3 — Error handling rules
+
+### RULE-E-001: Network/GraphQL failures in `getStaticProps` must degrade gracefully
+**What**: When a page fetches WordPress data at build/ISR time, it must protect against API failures (use `try/catch` and return safe empty props + reasonable `revalidate`).  
+**Why**: This repo already guards critical pages (e.g. `pages/technology/index.tsx` returns `emptyData` on error, `pages/community/[slug].tsx` returns `notFound` on errors). Unhandled fetch errors can fail builds or cause ISR crashes.  
+**How to check**: New `getStaticProps` and `getStaticPaths` code should not allow unhandled exceptions to bubble out.  
+**Example of violation**:
+```ts
+export const getStaticProps = async () => {
+  const allPosts = await getAllPostsForTechnology(false); // no try/catch
+  return { props: { allPosts } };
+};
+```
+**Example of compliance**:
+```ts
+try {
+  const allPosts = await getAllPostsForTechnology(preview);
+  return { props: { allPosts }, revalidate: 10 };
+} catch (error) {
+  return { props: { allPosts: emptyData }, revalidate: 60 };
+}
+```
+
+### RULE-E-002: Public proxy endpoints must keep explicit allowlists
+**What**: If modifying `pages/api/proxy-image.ts`, keep:
+- `https:` only
+- hostname allowlist
+**Why**: This route proxies arbitrary URLs. Relaxing validation can create SSRF/open-proxy risks and cache poisoning.  
+**How to check**: Ensure `ALLOWED_HOSTNAMES` remains restrictive and protocol remains `https:`.  
+**Example of violation**:
+```ts
+// Accept http and any host
+if (!targetUrl.hostname) return;
+```
+**Example of compliance**:
+```ts
+if (targetUrl.protocol !== "https:") return res.status(400).send("Only https protocol is allowed");
+if (!ALLOWED_HOSTNAMES.has(targetUrl.hostname)) return res.status(403).send("Host not allowed");
+```
+
+---
+
+## Section 4 — API and data layer rules
+
+### RULE-D-001: Category slug pages must enforce canonical category routing
+**What**: When rendering `pages/community/[slug].tsx` and `pages/technology/[slug].tsx`, the page must validate the fetched post belongs to the intended category and redirect to the correct category otherwise.  
+**Why**: This repo explicitly prevents duplicate content (same post accessible under both `/community/slug` and `/technology/slug`). Breaking this can harm SEO and can invalidate canonical/og:url assumptions.  
+**How to check**: If editing these slug pages, preserve the “validate category + redirect” logic.  
+**Example of violation**:
+```ts
+// Removing category validation means duplicate URLs can exist.
+return { props: { post: data.post }, revalidate: 60 };
+```
+**Example of compliance**:
+```ts
+const postCategories = data.post?.categories?.edges?.map((e) => e.node.name.toLowerCase()) || [];
+if (!postCategories.includes("technology")) return { redirect: { destination: `/community/${data.post.slug}`, permanent: true } };
+```
+
+### RULE-D-002: Slug redirects use `config/redirect.ts`
+**What**: If adding redirects for stale slugs, add mappings to `config/redirect.ts` and use `getRedirectSlug()` in slug pages (as already done).  
+**Why**: Central mapping avoids scattered redirect logic and keeps redirect behavior consistent across categories and Vercel/Next redirect layers.  
+**How to check**: New redirect mappings should appear in `config/redirect.ts`, not hardcoded inside page files.  
+**Example of violation**:
+```ts
+if (slug === "old-slug") return { redirect: { destination: "/community/new-slug", permanent: true } };
+```
+**Example of compliance**:
+```ts
+const redirectSlug = getRedirectSlug(slug);
+if (redirectSlug) return { redirect: { destination: `/community/${redirectSlug}`, permanent: true } };
+```
+
+---
+
+## Section 5 — Testing rules
+
+This codebase uses Playwright E2E tests (`@playwright/test`) in `tests/`, with a local mock GraphQL server (`tests/mock-server.js`) started via `playwright.config.ts:webServer`.
+
+### RULE-S-001: UI changes must preserve `data-testid` used by tests
+**What**: If a PR changes markup in tested components, it must preserve or update the `data-testid` contract (examples: `data-testid="post-grid"`, `post-card`, `hero-post-title`, `post-content`, `toc-nav`, `scroll-to-top`, `site-footer`).  
+**Why**: This repo’s tests heavily rely on these attributes for stable selectors across responsive breakpoints.  
+**How to check**: Search in `tests/**/*.spec.ts` for any `getByTestId(...)` value touched by the diff.  
+**Example of violation**:
+```tsx
+// Removing this breaks multiple specs:
+<footer data-testid="site-footer">...</footer>
+```
+**Example of compliance**:
+```tsx
+<footer data-testid="site-footer" className="...">...</footer>
+```
+
+### RULE-S-002: Playwright assumes the app runs under `/blog`
+**What**: Do not change Playwright’s base URL semantics without updating tests:
+- `playwright.config.ts` defaults `BASE_URL=http://localhost:3000/blog`
+- `.env.test.example` documents the same
+**Why**: Routes and assets are basePath’d; tests navigate to `/technology`, `/community` relative to `/blog`.  
+**How to check**: If touching `next.config.js` basePath, or `playwright.config.ts`, ensure tests and env examples are updated in the same PR.  
+**Example of violation**:
+```ts
+const BASE_URL = 'http://localhost:3000'; // breaks all test navigations
+```
+**Example of compliance**:
+```ts
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000/blog';
+```
+
+**Minimum test requirements for a PR to pass**:
+- [ ] If SEO/meta behavior changes: update `tests/e2e/SeoMeta.spec.ts`
+- [ ] If navigation/search changes: update `tests/components/Navigation.spec.ts` and/or `tests/responsive/MobileNavigation.spec.ts`
+- [ ] If post rendering/TOC changes: update `tests/components/PostBody.spec.ts` and/or `tests/components/TableContents.spec.ts`
+- [ ] If footer changes: update `tests/components/Footer.spec.ts`
+
+---
+
+## Section 6 — Naming and style rules
+
+### RULE-N-001: Tailwind class merging uses `cn(...)` helper
+**What**: When conditionally composing Tailwind classes, use `cn` from `lib/utils/utils.ts` (clsx + tailwind-merge).  
+**Why**: This repo already has a canonical class merging helper used in `components/header.tsx` and nav components.  
+**How to check**: If a PR adds conditional `className`, prefer `cn(...)` over manual string concatenation when it improves readability.  
+**Example of violation**:
+```tsx
+className={isActive ? "text-orange-500 " + base : base}
+```
+**Example of compliance**:
+```tsx
+className={cn(base, isActive && "text-orange-500")}
+```
+
+---
+
+## Section 7 — Dependency rules
+
+### RULE-P-001: Avoid adding redundant libraries that duplicate existing deps
+**What**: Before adding a dependency, check existing equivalents already used in this repo:
+- Classnames: `clsx` + `tailwind-merge` via `lib/utils/utils.ts:cn`
+- Icons: `lucide-react` and `react-icons` already used
+- E2E tests: `@playwright/test` is the established runner
+**Why**: This repo already has overlapping utilities (`classnames` + `clsx` exist) and a large UI surface; extra deps increase bundle/tooling complexity.  
+**How to check**: If adding deps to `package.json`, the PR description must justify why existing deps are insufficient.  
+**Example of violation**:
+```json
+{ "dependencies": { "another-classnames-lib": "^1.0.0" } }
+```
+**Example of compliance**:
+```ts
+import { cn } from "@/lib/utils/utils";
+```
+
+---
+
+## Section 8 — Breaking change detection rules
+
+### RULE-B-001: `lib/api.ts` interface stability (WPGraphQL data layer)
+**What this module provides**: All WordPress/WPGraphQL reads for posts/tags/authors/content; central `fetchAPI` with auth header support and error throwing; response normalization.  
+**Files that depend on it**:
+- `pages/index.tsx`
+- `pages/community/index.tsx`
+- `pages/technology/index.tsx`
+- `pages/community/[slug].tsx`
+- `pages/technology/[slug].tsx`
+- `pages/search.tsx`
+- `pages/community/search.tsx`
+- `pages/tag/index.tsx`
+- `pages/tag/[slug].tsx`
+- `pages/authors/index.tsx`
+- `pages/authors/[slug].tsx`
+- `pages/404.tsx`
+- `pages/api/nav-latest.ts`
+- `pages/api/search-all.ts`
+- `pages/api/preview.ts`
+- `components/more-stories.tsx`
+**What a change here can break**:
+- Build/ISR crashes if errors stop being thrown/caught or if functions start returning different shapes
+- Runtime null crashes if `normalizePostEdges` is removed/changed
+- Tests relying on mock-server’s query routing (it matches query names/strings)
+**What to check when this file is modified**:
+- [ ] GraphQL selection sets still include fields that UI expects (title, excerpt, slug, date, featuredImage, categories, etc.)
+- [ ] Any renamed query strings still match `tests/mock-server.js` routing rules
+- [ ] Call sites in the dependent files still compile and logically handle `pageInfo` / `edges` changes
+
+### RULE-B-002: `types/post.ts` interface stability (shared UI contract)
+**What this module provides**: The canonical `Post` shape used across components and pages.  
+**Files that depend on it**: Multiple components (`Layout`, `Meta`, `PostCard`, `HeroPost`, `PostBody`, etc.) and search pages.  
+**What a change here can break**:
+- Type-level drift that hides runtime shape mismatches (tsconfig `strict: false`)
+- Wide downstream refactors due to indexed-access typing (e.g. `Post["featuredImage"]["node"]["sourceUrl"]`)
+**What to check when this file is modified**:
+- [ ] Update any components that use indexed-access types from `Post`
+- [ ] Confirm GraphQL functions in `lib/api.ts` still fetch the fields required by the type
+
+### RULE-B-003: `lib/structured-data.ts` stability (SEO + tests)
+**What this module provides**: `SITE_URL` and schema builders for JSON-LD structured data used by pages and `_document.tsx`.  
+**Files that depend on it**: Most top-level pages and both `[slug]` pages.  
+**What a change here can break**:
+- `tests/e2e/SeoMeta.spec.ts` assertions for JSON-LD validity and canonical/og URL formats
+- SEO regressions if `SITE_URL` changes unexpectedly
+**What to check when this file is modified**:
+- [ ] `SITE_URL` remains consistent with production basePath (`https://keploy.io/blog`)
+- [ ] Pages that set `canonicalUrl` still align with the updated scheme
+- [ ] Update `tests/e2e/SeoMeta.spec.ts` if output changes are intended
+
+### RULE-B-004: `utils/sanitizeStringForUrl.ts` stability (anchors + slugs)
+**What this module provides**: `sanitizeStringForURL`, used to generate heading anchors and author slugs.  
+**Files that depend on it**:
+- `components/post-body.tsx` (heading IDs)
+- `components/TableContents.tsx` (lookup + scroll)
+- `utils/sanitizeAuthorSlug.ts`
+**What a change here can break**:
+- Deep links (`#heading`) no longer matching, TOC scrolling/active tracking failures
+- Author page URLs no longer matching previously indexed links
+**What to check when this file is modified**:
+- [ ] Heading IDs are still deterministic and URL-safe
+- [ ] Existing hyphen/character normalization semantics remain compatible
+
+### RULE-B-005: `next.config.js` stability (basePath, env exposure, CSP)
+**What this module provides**: `basePath`/`assetPrefix` (`/blog`), CSP headers, redirects, and exposing `NEXT_PUBLIC_WORDPRESS_API_URL`.  
+**What a change here can break**:
+- All internal links and asset URLs
+- Next build failing early due to missing/invalid `WORDPRESS_API_URL` (`URL.canParse` guard)
+- Production CSP violations if connect-src/frame-src/img-src gets too strict
+**What to check when this file is modified**:
+- [ ] Any new env vars are added to `.env.local.example` and `.env.test.example` (if relevant)
+- [ ] Playwright baseURL and tests still match the deployed basePath
+
+### RULE-B-006: `components/container.tsx` layout contract (global page width)
+**What this module provides**: The standard page wrapper (`max-w-7xl mx-auto ...`) used by most pages.  
+**Files that depend on it**: Many Pages Router pages and components (top 10 by coupling in `codebase_map.json`).  
+**What a change here can break**:
+- Widespread layout regressions and responsive test failures (e.g. `tests/responsive/MobileLayout.spec.ts`)
+**What to check when this file is modified**:
+- [ ] Mobile/tablet tests still pass the “no horizontal overflow” assertions
+- [ ] Page-level spacing (notably `main` padding in `components/layout.tsx`) still composes correctly
+
+### RULE-B-007: `components/layout.tsx` app-shell stability (meta + scripts + footer)
+**What this module provides**: Global app shell: `Meta`, page fade-in wrapper, footer, scroll-to-top, and analytics scripts.  
+**Files that depend on it**: Most `pages/*.tsx` use `Layout` directly.  
+**What a change here can break**:
+- SEO meta expectations (via `Meta`)
+- Footer presence (`tests/components/Footer.spec.ts`)
+- Scroll-to-top (`tests/components/ScrollToTop.spec.ts`)
+**What to check when this file is modified**:
+- [ ] Any meta-related behavior changes are reflected in `components/meta.tsx` and `tests/e2e/SeoMeta.spec.ts`
+- [ ] Footer and scroll-to-top still render on pages where tests expect them
+
+### RULE-B-008: `components/header.tsx` + navbar stability (navigation + reading progress)
+**What this module provides**: Fixed header and reading-progress bar on slug pages (`/technology/[slug]`, `/community/[slug]`).  
+**Files that depend on it**: Most pages render `Header`; slug pages pass `readProgress`.  
+**What a change here can break**:
+- Navigation visibility / selectors (`tests/components/Navigation.spec.ts`, `tests/responsive/MobileNavigation.spec.ts`)
+- Reading progress bar behavior on article pages
+**What to check when this file is modified**:
+- [ ] `data-testid="navbar"` still exists (comes from `components/navbar/FloatingNavbar.tsx`)
+- [ ] Slug routes still detect reading pages correctly (`router.pathname` checks)
+
+### RULE-B-009: `lib/constants.ts` stability (SEO images and branding constants)
+**What this module provides**: `HOME_OG_IMAGE_URL` and other constants used across pages/components.  
+**Files that depend on it**: `pages/index.tsx`, `components/meta.tsx`, tag/authors pages, etc.  
+**What a change here can break**:
+- OG image fallbacks and SEO tests that expect a truthy `og:image` (`tests/e2e/SeoMeta.spec.ts`)
+**What to check when this file is modified**:
+- [ ] `HOME_OG_IMAGE_URL` remains a valid image URL or tests are updated accordingly
+
+### RULE-B-010: `lib/utils/utils.ts` (`cn`) stability (Tailwind class merging)
+**What this module provides**: `cn(...inputs)` wrapper around `clsx` + `tailwind-merge`.  
+**Files that depend on it**: Header and navigation components, plus other UI pieces.  
+**What a change here can break**:
+- Class merging regressions that are hard to spot, especially across responsive breakpoints
+**What to check when this file is modified**:
+- [ ] `cn` still accepts a variadic set of inputs and returns a string
+- [ ] No behavioral changes without updating dependent components
+
+### RULE-B-011: `utils/excerpt.ts` stability (feed/search display behavior)
+**What this module provides**: `getExcerpt(content, maxWords)` used in feeds and cards to prevent overlong previews.  
+**Files that depend on it**: `components/more-stories.tsx`, `components/topBlogs.tsx`, listing pages.  
+**What a change here can break**:
+- Card layout and test expectations for excerpt presence/length (`tests/components/HeroPost.spec.ts`)
+**What to check when this file is modified**:
+- [ ] `getExcerpt` still returns a string (never `null`)
+- [ ] Word counting remains consistent (split-by-space behavior)
+
+### RULE-B-012: `components/post-body.tsx` stability (TOC + code blocks + author cards)
+**What this module provides**: Article rendering: TOC generation, heading IDs, code block rendering (CodeMirror), and author cards.  
+**Files that depend on it**:
+- `pages/technology/[slug].tsx`
+- `pages/community/[slug].tsx`
+**What a change here can break**:
+- TOC behavior and anchor scrolling (`tests/components/TableContents.spec.ts`)
+- Code block rendering and copy button (`tests/components/PostBody.spec.ts`)
+**What to check when this file is modified**:
+- [ ] `data-testid` contracts used by tests still exist (`post-content`, `code-block`, `copy-button`, `mobile-toc`, `desktop-toc`)
+- [ ] Heading ID generation still uses `sanitizeStringForURL` and stays deterministic
+
+### RULE-B-013: `playwright.config.ts` + `tests/mock-server.js` stability (test harness)
+**What this provides**: The E2E harness: base URL defaults to `/blog`, and a mock GraphQL server that routes by query strings.  
+**What a change here can break**:
+- CI E2E tests (`.github/workflows/playwright.yml`) and local `npm run test:e2e`
+**What to check when this file is modified**:
+- [ ] `BASE_URL` still defaults to `http://localhost:3000/blog`
+- [ ] Mock server still serves the queries that `lib/api.ts` emits (query string matching in `handleGraphQL`)
+
+---
+
+## Section 9 — PR checklist
+
+- [ ] PR has a description (use `.github/PULL_REQUEST_TEMPLATE.md` structure)
+- [ ] PR description explains WHY not just WHAT
+- [ ] No new `console.log(...)` added in non-test code (repo already has accidental logs like `pages/technology/index.tsx`)
+- [ ] No new proxy/network endpoints added without validation/allowlists (see `pages/api/proxy-image.ts`)
+- [ ] No new environment variables added without updating `.env.local.example` and `.env.test.example`
+- [ ] Diff does not include lock file changes without `package.json` changes
+- [ ] If `basePath`/`assetPrefix` changes: asset references and Playwright config/tests are updated
+- [ ] If `lib/api.ts` changes: confirm affected pages and `tests/mock-server.js` query routing still work
+- [ ] If `types/post.ts` changes: confirm all importing components still match runtime shapes
+- [ ] New dependencies are justified in the PR description
+
+---
+
+## Section 10 — Severity levels
+
+**CRITICAL** — must be fixed before merge. Breaks existing functionality, introduces security issue, or violates a rule with no safe exceptions.
+
+**WARNING** — should be fixed, but merge is not blocked. Inconsistent with conventions, reduces quality, or introduces technical debt.
+
+**INFO** — observation or suggestion. Improvement opportunity, not a violation.
+
+**QUESTION** — the agent cannot determine if this is correct without human context. Flags for reviewer attention.

--- a/qa-agent/README.md
+++ b/qa-agent/README.md
@@ -1,0 +1,46 @@
+# QA Agent
+
+Automated QA review system. Reviews PRs against guidelines derived from this repo’s own patterns, and flags second-order breakage using a codebase dependency map.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `QA_GUIDELINES.md` | The rules. Derived from codebase analysis. Edit via PR. |
+| `codebase_map.json` | Reverse dependency graph. Auto-updated when `main`/`master` changes. |
+| `scripts/qa_review.py` | Review agent — runs on PRs / manual trigger / comment trigger |
+| `scripts/build_codebase_map.py` | Builds the dependency graph |
+| `requirements.txt` | Python dependencies |
+
+## How it works
+
+1. A PR is opened/updated (or a reviewer comments `/qa-review`, or workflow is manually triggered)
+2. Agent loads `QA_GUIDELINES.md`
+3. Agent loads `codebase_map.json` (pre-built dependency graph)
+4. Agent fetches the PR diff via GitHub API
+5. Agent finds all files that depend on changed files (second-order analysis)
+6. Agent sends everything to Claude with a structured review prompt
+7. Review is posted as a PR comment
+
+## Triggers
+
+| Event | What happens |
+|---|---|
+| PR opened / commits pushed to PR | Full review runs automatically (`pull_request` + `synchronize`) |
+| Comment `/qa-review` on PR | Re-runs full review |
+| Comment `/qa-review fast` | Re-runs without second-order analysis |
+| `workflow_dispatch` | Manual — enter PR number in Actions tab |
+| Push to `main`/`master` | Codebase map is rebuilt and committed |
+
+## Secrets required
+
+- `ANTHROPIC_API_KEY` — add to repo/org secrets
+- `GITHUB_TOKEN` — provided automatically by GitHub Actions
+
+## Running locally
+
+```bash
+pip install -r qa-agent/requirements.txt
+python qa-agent/scripts/build_codebase_map.py
+```
+

--- a/qa-agent/codebase_map.json
+++ b/qa-agent/codebase_map.json
@@ -1,0 +1,356 @@
+{
+  "components/AuthorCard.tsx": [
+    "components/post-body.tsx"
+  ],
+  "components/AuthorHero.tsx": [
+    "components/postByAuthorMapping.tsx"
+  ],
+  "components/AuthorMapping.tsx": [
+    "pages/authors/index.tsx"
+  ],
+  "components/BlogSidebar.tsx": [
+    "components/post-body.tsx"
+  ],
+  "components/Marquee.tsx": [
+    "components/testimonials.tsx"
+  ],
+  "components/NotFoundPage.tsx": [
+    "pages/404.tsx"
+  ],
+  "components/PageLoader.tsx": [
+    "pages/_app.tsx"
+  ],
+  "components/PostHeaderAuthors.tsx": [
+    "components/post-header.tsx"
+  ],
+  "components/ScrollToTop.tsx": [
+    "components/layout.tsx"
+  ],
+  "components/TableContents.tsx": [
+    "components/post-body.tsx"
+  ],
+  "components/TagsStories.tsx": [
+    "pages/tag/[slug].tsx"
+  ],
+  "components/alert.tsx": [
+    "components/layout.tsx"
+  ],
+  "components/avatar.tsx": [
+    "components/TagsPostPreview.tsx",
+    "components/hero-post.tsx",
+    "components/latest-post.tsx",
+    "components/post-card.tsx",
+    "components/post-preview.tsx"
+  ],
+  "components/categories.tsx": [
+    "components/post-header.tsx"
+  ],
+  "components/container.tsx": [
+    "components/NotFoundPage.tsx",
+    "components/alert.tsx",
+    "pages/authors/[slug].tsx",
+    "pages/authors/index.tsx",
+    "pages/community/[slug].tsx",
+    "pages/community/index.tsx",
+    "pages/community/search.tsx",
+    "pages/index.tsx",
+    "pages/search.tsx",
+    "pages/tag/[slug].tsx",
+    "pages/tag/index.tsx",
+    "pages/technology/[slug].tsx",
+    "pages/technology/index.tsx"
+  ],
+  "components/containerSlug.tsx": [
+    "pages/community/[slug].tsx",
+    "pages/technology/[slug].tsx"
+  ],
+  "components/cover-image.tsx": [
+    "components/TagsPostPreview.tsx",
+    "components/hero-post.tsx",
+    "components/latest-post.tsx",
+    "components/post-card.tsx",
+    "components/post-header.tsx",
+    "components/post-preview.tsx"
+  ],
+  "components/date.tsx": [
+    "components/TagsPostPreview.tsx",
+    "components/hero-post.tsx",
+    "components/latest-post.tsx",
+    "components/post-card.tsx",
+    "components/post-preview.tsx"
+  ],
+  "components/footer.tsx": [
+    "components/layout.tsx"
+  ],
+  "components/header.tsx": [
+    "components/NotFoundPage.tsx",
+    "pages/authors/[slug].tsx",
+    "pages/authors/index.tsx",
+    "pages/community/[slug].tsx",
+    "pages/community/index.tsx",
+    "pages/community/search.tsx",
+    "pages/index.tsx",
+    "pages/tag/[slug].tsx",
+    "pages/tag/index.tsx",
+    "pages/technology/[slug].tsx",
+    "pages/technology/index.tsx"
+  ],
+  "components/hero-post.tsx": [
+    "pages/community/index.tsx",
+    "pages/community/search.tsx",
+    "pages/technology/index.tsx"
+  ],
+  "components/json-diff-viewer.tsx": [
+    "components/post-body.tsx"
+  ],
+  "components/layout.tsx": [
+    "pages/authors/[slug].tsx",
+    "pages/authors/index.tsx",
+    "pages/community/[slug].tsx",
+    "pages/community/index.tsx",
+    "pages/community/search.tsx",
+    "pages/index.tsx",
+    "pages/search.tsx",
+    "pages/tag/[slug].tsx",
+    "pages/tag/index.tsx",
+    "pages/technology/[slug].tsx",
+    "pages/technology/index.tsx"
+  ],
+  "components/meta.tsx": [
+    "components/layout.tsx"
+  ],
+  "components/more-stories.tsx": [
+    "pages/community/[slug].tsx",
+    "pages/community/index.tsx",
+    "pages/community/search.tsx",
+    "pages/search.tsx",
+    "pages/technology/[slug].tsx",
+    "pages/technology/index.tsx"
+  ],
+  "components/navbar/FloatingNavbar.tsx": [
+    "components/header.tsx"
+  ],
+  "components/navbar/FloatingNavbarClient.tsx": [
+    "components/navbar/FloatingNavbar.tsx"
+  ],
+  "components/navbar/github-stars.tsx": [
+    "components/navbar/FloatingNavbarClient.tsx"
+  ],
+  "components/navbar/icons.tsx": [
+    "config/nav.ts"
+  ],
+  "components/navbar/nav-card.tsx": [
+    "components/navbar/main-nav.tsx"
+  ],
+  "components/navbar/vscode-number.tsx": [
+    "components/navbar/FloatingNavbarClient.tsx"
+  ],
+  "components/post-body.tsx": [
+    "pages/community/[slug].tsx",
+    "pages/technology/[slug].tsx"
+  ],
+  "components/post-card.tsx": [
+    "components/NotFoundPage.tsx",
+    "components/TagsStories.tsx",
+    "components/more-stories.tsx",
+    "components/postByAuthorMapping.tsx",
+    "components/topBlogs.tsx"
+  ],
+  "components/post-grid.tsx": [
+    "components/NotFoundPage.tsx",
+    "components/TagsStories.tsx",
+    "components/more-stories.tsx",
+    "components/postByAuthorMapping.tsx",
+    "components/topBlogs.tsx"
+  ],
+  "components/post-header.tsx": [
+    "pages/community/[slug].tsx",
+    "pages/technology/[slug].tsx"
+  ],
+  "components/post-title.tsx": [
+    "components/post-header.tsx",
+    "pages/community/[slug].tsx",
+    "pages/technology/[slug].tsx"
+  ],
+  "components/postByAuthorMapping.tsx": [
+    "pages/authors/[slug].tsx"
+  ],
+  "components/section-separator.tsx": [
+    "pages/community/[slug].tsx",
+    "pages/technology/[slug].tsx"
+  ],
+  "components/tag.tsx": [
+    "pages/community/[slug].tsx",
+    "pages/technology/[slug].tsx"
+  ],
+  "components/testimonials.tsx": [
+    "pages/index.tsx"
+  ],
+  "components/topBlogs.tsx": [
+    "pages/index.tsx"
+  ],
+  "components/ui/accordion.tsx": [
+    "components/navbar/mobile-nav.tsx"
+  ],
+  "components/ui/button.tsx": [
+    "components/NotFoundPage.tsx",
+    "components/navbar/FloatingNavbarClient.tsx",
+    "components/navbar/mobile-nav.tsx"
+  ],
+  "components/ui/card.tsx": [
+    "components/navbar/main-nav.tsx",
+    "components/navbar/nav-card.tsx"
+  ],
+  "components/ui/collapsible.tsx": [
+    "components/navbar/FloatingNavbarClient.tsx"
+  ],
+  "components/ui/navigation-menu.tsx": [
+    "components/navbar/main-nav.tsx"
+  ],
+  "components/ui/sheet.tsx": [
+    "components/navbar/FloatingNavbarClient.tsx",
+    "components/navbar/mobile-nav.tsx"
+  ],
+  "config/nav.ts": [
+    "components/navbar/main-nav.tsx",
+    "components/navbar/mobile-nav.tsx"
+  ],
+  "config/redirect.ts": [
+    "pages/community/[slug].tsx",
+    "pages/technology/[slug].tsx"
+  ],
+  "hooks/useGithubStars.tsx": [
+    "components/navbar/github-stars.tsx"
+  ],
+  "hooks/useVSCodeInstalls.tsx": [
+    "components/navbar/vscode-number.tsx"
+  ],
+  "lib/api.ts": [
+    "components/more-stories.tsx",
+    "pages/404.tsx",
+    "pages/api/nav-latest.ts",
+    "pages/api/preview.ts",
+    "pages/api/search-all.ts",
+    "pages/authors/[slug].tsx",
+    "pages/authors/index.tsx",
+    "pages/community/[slug].tsx",
+    "pages/community/index.tsx",
+    "pages/community/search.tsx",
+    "pages/index.tsx",
+    "pages/search.tsx",
+    "pages/tag/[slug].tsx",
+    "pages/tag/index.tsx",
+    "pages/technology/[slug].tsx",
+    "pages/technology/index.tsx"
+  ],
+  "lib/constants.ts": [
+    "components/alert.tsx",
+    "components/intro.tsx",
+    "components/meta.tsx",
+    "pages/authors/[slug].tsx",
+    "pages/authors/index.tsx",
+    "pages/community/search.tsx",
+    "pages/index.tsx",
+    "pages/search.tsx",
+    "pages/tag/[slug].tsx",
+    "pages/tag/index.tsx"
+  ],
+  "lib/structured-data.ts": [
+    "pages/404.tsx",
+    "pages/_document.tsx",
+    "pages/authors/[slug].tsx",
+    "pages/authors/index.tsx",
+    "pages/community/[slug].tsx",
+    "pages/community/index.tsx",
+    "pages/community/search.tsx",
+    "pages/index.tsx",
+    "pages/search.tsx",
+    "pages/tag/[slug].tsx",
+    "pages/tag/index.tsx",
+    "pages/technology/[slug].tsx",
+    "pages/technology/index.tsx"
+  ],
+  "lib/utils/utils.ts": [
+    "components/header.tsx",
+    "components/navbar/main-nav.tsx",
+    "components/navbar/mobile-nav.tsx",
+    "components/ui/accordion.tsx",
+    "components/ui/button.tsx",
+    "components/ui/card.tsx",
+    "components/ui/collapsible.tsx",
+    "components/ui/navigation-menu.tsx",
+    "components/ui/sheet.tsx"
+  ],
+  "services/Tweets.tsx": [
+    "components/testimonials.tsx"
+  ],
+  "services/constants.ts": [
+    "components/subscribe-newsletter.tsx"
+  ],
+  "types/author.ts": [
+    "types/post.ts"
+  ],
+  "types/post.ts": [
+    "components/AuthorMapping.tsx",
+    "components/NotFoundPage.tsx",
+    "components/TagsPostPreview.tsx",
+    "components/avatar.tsx",
+    "components/cover-image.tsx",
+    "components/hero-post.tsx",
+    "components/latest-post.tsx",
+    "components/layout.tsx",
+    "components/meta.tsx",
+    "components/more-stories.tsx",
+    "components/post-body.tsx",
+    "components/post-card.tsx",
+    "components/post-preview.tsx",
+    "components/postByAuthorMapping.tsx",
+    "pages/authors/index.tsx",
+    "pages/community/search.tsx",
+    "pages/search.tsx"
+  ],
+  "types/tag.ts": [
+    "components/tag.tsx",
+    "types/post.ts"
+  ],
+  "utils/aiReferralTracker.ts": [
+    "pages/_app.tsx"
+  ],
+  "utils/calculateReadingTime.ts": [
+    "pages/community/[slug].tsx",
+    "pages/technology/[slug].tsx"
+  ],
+  "utils/excerpt.ts": [
+    "components/NotFoundPage.tsx",
+    "components/TagsStories.tsx",
+    "components/more-stories.tsx",
+    "components/topBlogs.tsx",
+    "pages/community/search.tsx",
+    "pages/technology/index.tsx"
+  ],
+  "utils/extractAuthorData.ts": [
+    "components/postByAuthorMapping.tsx"
+  ],
+  "utils/sanitizeAuthorSlug.ts": [
+    "components/AuthorCard.tsx",
+    "components/AuthorMapping.tsx",
+    "components/PostHeaderAuthors.tsx",
+    "components/ReviewingAuthor.tsx",
+    "components/author-description.jsx",
+    "lib/structured-data.ts",
+    "pages/authors/[slug].tsx"
+  ],
+  "utils/sanitizeStringForUrl.ts": [
+    "components/TableContents.tsx",
+    "components/post-body.tsx",
+    "utils/sanitizeAuthorSlug.ts"
+  ],
+  "utils/seo.ts": [
+    "pages/community/[slug].tsx",
+    "pages/technology/[slug].tsx"
+  ],
+  "utils/tagIcons.ts": [
+    "components/tag.tsx",
+    "pages/tag/index.tsx"
+  ]
+}

--- a/qa-agent/requirements.txt
+++ b/qa-agent/requirements.txt
@@ -1,0 +1,3 @@
+anthropic>=0.40.0
+PyGithub>=2.1.1
+

--- a/qa-agent/scripts/build_codebase_map.py
+++ b/qa-agent/scripts/build_codebase_map.py
@@ -1,0 +1,165 @@
+"""
+Codebase Map Builder
+Scans the repository and builds a reverse dependency map:
+  { "lib/api.ts": ["pages/index.tsx", "pages/community/index.tsx", ...] }
+
+This tells the QA agent: "if lib/api.ts changes, these files might be affected."
+
+Run this:
+  - Once during initial setup
+  - In CI on merges to main (to keep the map current)
+  - Output: qa-agent/codebase_map.json
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import defaultdict
+from pathlib import Path
+
+ROOT = Path(".").resolve()
+OUTPUT = ROOT / "qa-agent" / "codebase_map.json"
+
+SKIP_DIRS = {
+    "node_modules",
+    ".git",
+    ".next",
+    "dist",
+    "build",
+    "coverage",
+    ".turbo",
+    "test-results",
+    "playwright-report",
+}
+
+SOURCE_EXTENSIONS = {
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+}
+
+# TypeScript/JavaScript import patterns (this repo is TS/Next.js)
+IMPORT_PATTERNS: list[re.Pattern[str]] = [
+    # import ... from '...'
+    re.compile(r"""from\s+['"]([^'"]+)['"]"""),
+    # export ... from '...'
+    re.compile(r"""export\s+.*from\s+['"]([^'"]+)['"]"""),
+    # require('...')
+    re.compile(r"""require\s*\(\s*['"]([^'"]+)['"]\s*\)"""),
+    # dynamic import('...') / import('...')
+    re.compile(r"""import\s*\(\s*['"]([^'"]+)['"]\s*\)"""),
+]
+
+
+def is_skipped_path(path: Path) -> bool:
+    return any(part in SKIP_DIRS for part in path.parts)
+
+
+def get_all_source_files() -> list[Path]:
+    files: list[Path] = []
+    for path in ROOT.rglob("*"):
+        if not path.is_file():
+            continue
+        if is_skipped_path(path):
+            continue
+        if path.suffix in SOURCE_EXTENSIONS:
+            files.append(path)
+    return files
+
+
+def normalize_repo_relative(path: Path) -> str:
+    return path.resolve().relative_to(ROOT).as_posix()
+
+
+def resolve_import(importer: Path, import_path: str, all_files: set[str]) -> str | None:
+    """
+    Resolve an import string to a repo-relative file path, if it points to a local file.
+
+    This repo uses tsconfig paths:
+      "@/*": ["./*"]
+    So "@/lib/api" resolves to "lib/api.ts" (no "src/" folder).
+    """
+    # External packages: ignore
+    if not (import_path.startswith(".") or import_path.startswith("@/") or import_path.startswith("~/")):
+        return None
+
+    # Path aliases
+    if import_path.startswith("@/"):
+        import_path = import_path[2:]  # repo-root relative
+        base = (ROOT / import_path).resolve()
+    elif import_path.startswith("~/"):
+        import_path = import_path[2:]
+        base = (ROOT / import_path).resolve()
+    else:
+        base = (importer.parent / import_path).resolve()
+
+    try:
+        base_rel = base.relative_to(ROOT)
+    except Exception:
+        return None
+
+    base_rel_str = base_rel.as_posix()
+
+    # If import already includes extension
+    if base_rel_str in all_files:
+        return base_rel_str
+
+    # Try with extensions
+    for ext in SOURCE_EXTENSIONS:
+        candidate = f"{base_rel_str}{ext}"
+        if candidate in all_files:
+            return candidate
+
+    # Try directory index
+    for ext in SOURCE_EXTENSIONS:
+        candidate = f"{base_rel_str}/index{ext}"
+        if candidate in all_files:
+            return candidate
+
+    return None
+
+
+def build_map() -> dict[str, list[str]]:
+    print("Scanning source files...")
+    all_files = get_all_source_files()
+    all_file_paths = {normalize_repo_relative(f) for f in all_files}
+    print(f"Found {len(all_files)} source files.")
+
+    reverse_deps: dict[str, set[str]] = defaultdict(set)
+
+    for source_file in all_files:
+        repo_rel_importer = normalize_repo_relative(source_file)
+        try:
+            content = source_file.read_text(encoding="utf-8", errors="ignore")
+        except Exception:
+            continue
+
+        for pattern in IMPORT_PATTERNS:
+            for match in pattern.findall(content):
+                resolved = resolve_import(source_file, match, all_file_paths)
+                if resolved and resolved != repo_rel_importer:
+                    reverse_deps[resolved].add(repo_rel_importer)
+
+    return {k: sorted(v) for k, v in reverse_deps.items()}
+
+
+def main() -> None:
+    codebase_map = build_map()
+
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text(json.dumps(codebase_map, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    print("\nCodebase map built:")
+    print(f"  {len(codebase_map)} files have dependents")
+    print("  Top 10 most depended-upon files:")
+    top = sorted(codebase_map.items(), key=lambda x: len(x[1]), reverse=True)[:10]
+    for path, dependents in top:
+        print(f"    {path}: {len(dependents)} dependents")
+    print(f"\nWritten to {normalize_repo_relative(OUTPUT)}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/qa-agent/scripts/qa_review.py
+++ b/qa-agent/scripts/qa_review.py
@@ -1,0 +1,344 @@
+"""
+QA Review Agent
+Reads QA_GUIDELINES.md, fetches the PR diff, and runs a structured review.
+
+Triggered by GitHub Actions on:
+- pull_request (opened, synchronize, reopened, ready_for_review)
+- push (attempts to resolve PR for the commit; skips if none)
+- issue_comment containing /qa-review
+- workflow_dispatch (manual, with pr-number input)
+
+Environment variables required:
+  ANTHROPIC_API_KEY    — Anthropic API key
+  GITHUB_TOKEN         — GitHub token (provided by Actions or a PAT)
+  PR_NUMBER            — PR number to review
+  GITHUB_REPOSITORY    — e.g. keploy/blog-website
+  REVIEW_MODE          — "full" (default) or "fast" (skip second-order analysis)
+Optional:
+  ANTHROPIC_MODEL      — default: "claude-sonnet-4-20250514"
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import anthropic
+from github import Github
+
+# --- configuration ---
+ANTHROPIC_API_KEY = os.environ["ANTHROPIC_API_KEY"]
+GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+PR_NUMBER = int(os.environ["PR_NUMBER"])
+REPO_NAME = os.environ["GITHUB_REPOSITORY"]
+REVIEW_MODE = os.environ.get("REVIEW_MODE", "full")
+
+ANTHROPIC_MODEL = os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-20250514")
+
+GUIDELINES_PATH = Path(__file__).parent.parent / "QA_GUIDELINES.md"
+CODEBASE_MAP_PATH = Path(__file__).parent.parent / "codebase_map.json"
+
+# This repo is a Next.js + TS codebase. Review config + source + CI.
+REVIEWABLE_EXTENSIONS = {
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".css",
+    ".md",
+    ".json",
+    ".yaml",
+    ".yml",
+}
+
+# Files to always skip (noise or huge diffs)
+SKIP_BASENAMES = {
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    ".gitignore",
+    ".prettierignore",
+}
+
+
+def load_guidelines() -> str:
+    if not GUIDELINES_PATH.exists():
+        return "WARNING: QA_GUIDELINES.md not found. Reviewing against general best practices only."
+    return GUIDELINES_PATH.read_text(encoding="utf-8", errors="ignore")
+
+
+def load_codebase_map() -> dict[str, list[str]]:
+    """
+    Load the pre-built codebase dependency map.
+    This tells the agent which files depend on which, so it can do second-order analysis.
+    Built by build_codebase_map.py.
+    """
+    if not CODEBASE_MAP_PATH.exists():
+        return {}
+    try:
+        return json.loads(CODEBASE_MAP_PATH.read_text(encoding="utf-8", errors="ignore"))
+    except Exception:
+        return {}
+
+
+def get_pr_data(repo, pr_number: int):
+    pr = repo.get_pull(pr_number)
+    files = pr.get_files()
+
+    changed_files: list[str] = []
+    diff_sections: list[str] = []
+    skipped: list[str] = []
+
+    for f in files:
+        filename = f.filename
+        ext = Path(filename).suffix
+        basename = Path(filename).name
+
+        if basename in SKIP_BASENAMES:
+            skipped.append(filename)
+            continue
+        if ext not in REVIEWABLE_EXTENSIONS:
+            skipped.append(filename)
+            continue
+        if not f.patch:
+            skipped.append(filename)
+            continue
+
+        changed_files.append(filename)
+        diff_sections.append(
+            f"### {filename} (status: {f.status}, +{f.additions}/-{f.deletions})\n"
+            f"```diff\n{f.patch}\n```"
+        )
+
+    diff_text = "\n\n".join(diff_sections)
+    return pr, changed_files, diff_text, skipped
+
+
+def find_downstream_files(changed_files: list[str], codebase_map: dict[str, list[str]]) -> dict[str, list[str]]:
+    """
+    Given a list of changed files, find all files that import them.
+    This is how the agent detects second-order breakage risk.
+    """
+    downstream: dict[str, list[str]] = {}
+    for changed_file in changed_files:
+        dependents = codebase_map.get(changed_file, [])
+        if dependents:
+            downstream[changed_file] = dependents
+    return downstream
+
+
+def build_review_prompt(
+    guidelines: str,
+    diff_text: str,
+    changed_files: list[str],
+    downstream: dict[str, list[str]],
+    pr_title: str,
+    pr_body: str,
+    commits: list[str],
+) -> str:
+    downstream_section = ""
+    if downstream:
+        lines = ["## Files that depend on changed files (second-order breakage risk)\n"]
+        for changed, dependents in downstream.items():
+            lines.append(f"**{changed}** is imported by:")
+            for dep in dependents:
+                lines.append(f"  - {dep}")
+        downstream_section = "\n".join(lines)
+    else:
+        downstream_section = "## Second-order analysis\nNo dependency-map downstream files detected for changed files."
+
+    commits_section = "\n".join(f"- {c}" for c in commits) if commits else "(no commit messages available)"
+
+    return f"""You are a QA engineer reviewing a pull request.
+Your job is to check this PR against the project's QA guidelines.
+
+You are not just checking the diff in isolation. You are checking whether these changes
+could break anything else in the codebase, based on the dependency information provided.
+
+---
+
+## QA Guidelines (derived from this codebase)
+
+{guidelines}
+
+---
+
+## PR information
+
+**Title**: {pr_title}
+**Description**: {pr_body or "(no description provided — this itself may be a violation, check Section 9)"}
+
+**Commits in this PR**:
+{commits_section}
+
+**Files changed** ({len(changed_files)} reviewable files):
+{chr(10).join(f"- {f}" for f in changed_files)}
+
+{downstream_section}
+
+---
+
+## Diff
+
+{diff_text}
+
+---
+
+## Your review instructions
+
+Go through the following in order:
+
+**Pass 1 — PR checklist (Section 9 of guidelines)**
+Run every item in the PR checklist. Report each item as PASS or FAIL with a brief reason.
+
+**Pass 2 — Rule-by-rule check**
+For each section of the guidelines (Architecture, Type safety, Error handling, API/data layer, Testing, Naming, Dependencies):
+Check whether the diff introduces any violations.
+For each violation found: state the rule ID, what was violated, where in the diff (filename), and what the fix should be.
+
+**Pass 3 — Second-order breakage analysis**
+Look at the downstream dependency information above.
+For each file that changed AND has downstream dependents:
+- Does the change alter any exported interface, function signature, type, or behavior?
+- If yes: which downstream files are at risk, and how?
+- Flag all risks, even if they might be fine — let the human decide.
+
+**Pass 4 — Test coverage check**
+- Does the diff include new or modified business logic?
+- If yes: are there corresponding test changes in the diff?
+- If no tests are present: is there a test file that should have been updated?
+- Name the specific test file that is missing or should be updated.
+
+---
+
+## Output format
+
+Use EXACTLY this structure:
+
+## QA Review
+
+### PR Checklist
+| Item | Result | Note |
+|---|---|---|
+[one row per checklist item from Section 9 of guidelines]
+
+### Verdict
+[APPROVED / NEEDS_CHANGES / CRITICAL_ISSUES]
+[One sentence on the overall state of this PR]
+
+### Issues found
+[Numbered list. For each issue:]
+**[SEVERITY] RULE-[ID]: [Short title]**
+File: `[filename]`
+Problem: [specific description of what is wrong]
+Fix: [specific description of what to change]
+
+If no issues: write "No violations found."
+
+### Second-order risks
+[For each downstream risk identified:]
+**Changed**: `[file that changed]`
+**At risk**: `[downstream file]`
+**Reason**: [what specifically might break and why]
+
+If no risks: write "No second-order risks detected."
+
+### Missing tests
+[List any test files that should exist or be updated]
+If none: write "Test coverage appears adequate for this diff."
+
+### Suggestions (INFO level)
+[Optional improvements that are not violations]
+"""
+
+
+def run_review(prompt: str) -> str:
+    client = anthropic.Anthropic(api_key=ANTHROPIC_API_KEY)
+    message = client.messages.create(
+        model=ANTHROPIC_MODEL,
+        max_tokens=4000,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    # anthropic>=0.40.0 returns content blocks
+    return message.content[0].text
+
+
+def post_comment(repo, pr, review_text: str, skipped: list[str]) -> None:
+    skipped_note = ""
+    if skipped:
+        skipped_note = (
+            f"\n\n<details><summary>Skipped {len(skipped)} non-reviewable files</summary>\n\n"
+            + "\n".join(f"- {f}" for f in skipped)
+            + "\n\n</details>"
+        )
+
+    body = (
+        f"## 🔍 QA Review\n\n"
+        f"{review_text}"
+        f"{skipped_note}\n\n"
+        f"---\n"
+        f"*qa-agent · Guidelines: `qa-agent/QA_GUIDELINES.md` · "
+        f"Comment `/qa-review` to re-trigger · "
+        f"Comment `/qa-review fast` to skip second-order analysis*"
+    )
+    pr.create_issue_comment(body)
+
+
+def get_commit_messages(pr) -> list[str]:
+    try:
+        return [c.commit.message.split("\n")[0] for c in pr.get_commits()]
+    except Exception:
+        return []
+
+
+def main() -> None:
+    g = Github(GITHUB_TOKEN)
+    repo = g.get_repo(REPO_NAME)
+
+    print(f"Loading guidelines from {GUIDELINES_PATH}...")
+    guidelines = load_guidelines()
+
+    print("Loading codebase dependency map...")
+    codebase_map = load_codebase_map()
+
+    print(f"Fetching PR #{PR_NUMBER}...")
+    pr, changed_files, diff_text, skipped = get_pr_data(repo, PR_NUMBER)
+
+    if not changed_files:
+        pr.create_issue_comment("## 🔍 QA Review\n\nNo reviewable files changed in this PR. Skipping. ✅")
+        return
+
+    commits = get_commit_messages(pr)
+
+    print("Analysing downstream dependencies...")
+    downstream = find_downstream_files(changed_files, codebase_map) if REVIEW_MODE == "full" else {}
+
+    print("Building review prompt...")
+    prompt = build_review_prompt(
+        guidelines=guidelines,
+        diff_text=diff_text,
+        changed_files=changed_files,
+        downstream=downstream,
+        pr_title=pr.title,
+        pr_body=pr.body or "",
+        commits=commits,
+    )
+
+    print("Running Claude review...")
+    review = run_review(prompt)
+
+    print("Posting comment...")
+    post_comment(repo, pr, review, skipped)
+
+    print("Done.")
+
+    # exit 1 if critical issues — marks the GitHub check as failed
+    if "CRITICAL_ISSUES" in review:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
Implemented a fully autonomous QA Review Agent integrated directly into GitHub Actions. The agent acts as an automated repository maintainer that reviews every Pull Request against a highly specific rulebook derived from this repo’s actual Next.js Pages Router + WPGraphQL architecture, and flags second‑order breakage risk using a static dependency graph.

This is purpose-built for this codebase’s failure modes:
- `/blog` `basePath` / `assetPrefix` correctness (SEO + asset stability)
- WPGraphQL query/shape changes that silently break multiple pages/components
- `data-testid` contract stability that Playwright relies on
- security-critical API route validation (e.g. image proxy allowlists)

---

## How It Validates Changes (The Workflow)

When a contributor opens or pushes to a PR, the workflow (`.github/workflows/qa-review.yml`) triggers our Python agent and executes the following pipeline.

### 1) Diff & Context Gathering
The workflow runs the agent script (`qa-agent/scripts/qa_review.py`), which:
- Loads the repo-derived rulebook (`qa-agent/QA_GUIDELINES.md`)
- Fetches the PR file list + patch hunks via GitHub’s API (no local diff heuristics)
- Skips non-reviewable/noisy files (e.g. lockfiles) consistently

> **Verified Baseline**: The workflow uses `pull_request` + minimal permissions for the `$GITHUB_TOKEN` (`pull-requests: write`, `contents: read`) to post comments without granting broad write access.
> - Local source of truth: `.github/workflows/qa-review.yml`
> - External source of truth: GitHub Actions automatic token authentication & permissions — https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication

> **Verified Baseline**: PR diff fetching is implemented via PyGithub’s Pull Request APIs (patch hunks are taken from GitHub’s computed diff view rather than executing untrusted code).
> - Local source of truth: `qa-agent/scripts/qa_review.py`
> - External source of truth: PyGithub PullRequest docs — https://pygithub.readthedocs.io/en/latest/github_objects/PullRequest.html

### 2) Second-Order Impact Mapping (Dependency Graph)
Before the agent evaluates changes, it cross-references the changed files against `qa-agent/codebase_map.json` (a reverse dependency graph built from repo imports).

Example in *this* repo:
- If `lib/api.ts` changes, the map links it to downstream pages like:
  `pages/index.tsx`, `pages/community/[slug].tsx`, `pages/technology/[slug].tsx`, API routes, and search components.

> **Verified Baseline**: The map builder (`qa-agent/scripts/build_codebase_map.py`) is tuned to this repo’s TS path alias (`@/* -> ./*`) from `tsconfig.json`, so imports like `@/utils/aiReferralTracker` resolve to real files.
> - Local sources of truth: `qa-agent/scripts/build_codebase_map.py`, `tsconfig.json`, `qa-agent/codebase_map.json`
> - External source of truth: Python `pathlib` iteration — https://docs.python.org/3/library/pathlib.html

### 3) The 4-Pass AI Validation
The agent packages:
- the guidelines (`qa-agent/QA_GUIDELINES.md`)
- the PR diff (patch hunks)
- the downstream dependency list (from `codebase_map.json`)


Claude executes 4 strict passes (defined in the prompt template inside `qa-agent/scripts/qa_review.py`):
1. **Pass 1 (Mechanical):** PR checklist (no stray `console.log`, no unexplained lockfile changes, env var hygiene, etc.)
2. **Pass 2 (Rule-by-rule):** Architecture/type/error/API/testing conventions derived from this repo
3. **Pass 3 (Topological):** Second-order breakage analysis using dependency map blast-radius
4. **Pass 4 (Test coverage):** Ensures changes that affect behavior update Playwright tests (selectors + flows)

> **Verified Baseline**: The “brain” of the agent is a repo-derived ruleset with explicit pass/fail checks and concrete examples grounded in local code (e.g. `/blog` basePath, WPGraphQL access via `lib/api.ts`, proxy allowlists).
> - Local sources of truth: `qa-agent/QA_GUIDELINES.md`, `next.config.js`, `lib/api.ts`, `pages/api/proxy-image.ts`, `playwright.config.ts`, `tests/**/*.spec.ts`
> - External source of truth: Anthropic prompt engineering docs — https://docs.anthropic.com/

### 4) Automated Feedback Delivery
The agent posts a structured PR comment, with issues grouped by severity:
- **CRITICAL**: must fix before merge (security regressions, routing/SEO breakage, test harness breakage)
- **WARNING**: should fix (convention drift, risk of downstream breakage)
- **INFO/QUESTION**: suggestions or human-context questions

> **Verified Baseline**: Feedback is posted using the GitHub API directly as an issue comment on the PR.
> - Local source of truth: `qa-agent/scripts/qa_review.py`
> - External source of truth: GitHub Pull Requests API — https://docs.github.com/en/rest/pulls

---

## Setup

Required repository secrets:
- `ANTHROPIC_API_KEY` (configure in GitHub Actions secrets)

Provided automatically by GitHub Actions:
- `GITHUB_TOKEN`

Local run (map builder):
```bash
python3 -m pip install -r qa-agent/requirements.txt
python3 qa-agent/scripts/build_codebase_map.py
```

Local sources of truth:
- Dependencies: `qa-agent/requirements.txt`
- Agent scripts: `qa-agent/scripts/*`
- Workflow: `.github/workflows/qa-review.yml`

---

## Architecture Origins & Verified Sources

This section is an explicit bibliography of the core engineering sources-of-truth used by the QA agent design.

### 1) Why dependency graphs matter for LLM review
**Challenge:** A diff-only LLM review misses blast-radius failures (e.g. changing `types/post.ts` breaks many components).  
**Solution:** A static reverse dependency graph (`qa-agent/codebase_map.json`) provides topological context without sending the entire repo.

- Local sources of truth: `qa-agent/scripts/build_codebase_map.py`, `qa-agent/codebase_map.json`
- External sources of truth:
  - Python `re` (safe pattern matching without executing code) — https://docs.python.org/3/library/re.html
  - Python `pathlib` — https://docs.python.org/3/library/pathlib.html

### 2) Secure PR data retrieval in CI
**Challenge:** Review untrusted PRs without executing their code to compute a diff.  
**Solution:** Fetch patches via GitHub’s PR file APIs (PyGithub), and comment back via PR issue comments.

- Local sources of truth: `qa-agent/scripts/qa_review.py`, `.github/workflows/qa-review.yml`
- External sources of truth:
  - PyGithub PullRequest objects — https://pygithub.readthedocs.io/en/latest/github_objects/PullRequest.html
  - GitHub Actions token permissions — https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication

### 3) Next.js / basePath correctness is a first-class invariant here
This repo hard-requires `/blog` basePath + assetPrefix:
- Local source of truth: `next.config.js`
- Test harness source of truth: `playwright.config.ts` defaults `BASE_URL` to `http://localhost:3000/blog`
- External source of truth: Next.js `basePath` documentation — https://nextjs.org/docs/pages/api-reference/next-config-js/basePath

