### PR TITLE
feat: create automated ai powered design agent for prs and commits on the prs

### DIFF
--- a/.github/workflows/design-review.yml
+++ b/.github/workflows/design-review.yml
@@ -1,0 +1,114 @@
+name: Design Review Agent
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "components/**"
+      - "pages/**"
+      - "styles/**"
+      - "public/images/**"
+      - "public/videos/**"
+      - "design-agent/**"
+      - ".github/workflows/design-review.yml"
+      - "tailwind.config.*"
+      - "next.config.*"
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to review"
+        required: true
+        type: string
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  design-review:
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name != 'issue_comment' ||
+      (github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/design-review') &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'))
+
+    steps:
+      - name: Resolve PR number
+        id: pr_number
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            echo "value=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_EVENT_NAME}" == "issue_comment" ]]; then
+            echo "value=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve PR metadata (safe checkout)
+        id: pr
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr_number.outputs.value }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+
+            const headSha = pr.head.sha;
+            const headRepo = pr.head.repo.full_name;
+            const baseRepo = pr.base.repo.full_name;
+            const defaultBranch = pr.base.repo.default_branch;
+            const isExternal = headRepo.toLowerCase() !== baseRepo.toLowerCase();
+
+            const checkoutRepo = isExternal ? baseRepo : headRepo;
+            const checkoutRef = isExternal ? defaultBranch : headSha;
+
+            core.setOutput("number", String(prNumber));
+            core.setOutput("head_sha", headSha);
+            core.setOutput("head_repo_full_name", headRepo);
+            core.setOutput("base_repo_full_name", baseRepo);
+            core.setOutput("is_external", isExternal ? "true" : "false");
+            core.setOutput("checkout_repo", checkoutRepo);
+            core.setOutput("checkout_ref", checkoutRef);
+
+      - name: Checkout (internal PR => head.sha, external PR => default branch)
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.pr.outputs.checkout_repo }}
+          ref: ${{ steps.pr.outputs.checkout_ref }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r design-agent/requirements.txt
+
+      - name: Run design review
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          DESIGN_COMMONS_TOKEN: ${{ secrets.DESIGN_COMMONS_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          COMMON_GUIDELINES_REPO: ${{ vars.COMMON_GUIDELINES_REPO || 'keploy/landing-page' }}
+          COMMON_GUIDELINES_PATH: ${{ vars.COMMON_GUIDELINES_PATH || 'design-agent/COMMON_DESIGN_GUIDELINES.md' }}
+          COMMON_GUIDELINES_REF: ${{ vars.COMMON_GUIDELINES_REF || 'main' }}
+          ALLOW_EXTERNAL_PR_REVIEW: ${{ vars.ALLOW_EXTERNAL_PR_REVIEW || 'false' }}
+        run: python3 design-agent/scripts/design_review.py
+

--- a/design-agent/BLOG_DESIGN_GUIDELINES.md
+++ b/design-agent/BLOG_DESIGN_GUIDELINES.md
@@ -1,0 +1,122 @@
+# Blog Design Guidelines (Repo-Local)
+
+This file is **blog-specific** and is merged **after** the private common guidelines fetched at runtime. Keep this focused on *project realities* in `keploy/blog-website` and avoid duplicating the shared/common rules.
+
+## 1) Tech stack
+
+- Framework: Next.js (Pages Router) with `basePath: '/blog'` (`next.config.js`).
+- Styling: Tailwind CSS (`tailwind.config.js`) + global CSS (`styles/index.css`) + component CSS modules (e.g. `components/post-body.module.css`).
+- UI primitives: shadcn-style components under `components/ui/*` (CVA + `cn()` helper).
+- Icons: `lucide-react`.
+- Motion: `@react-spring/web`, `framer-motion`, `gsap` (prefer subtle/intentional use).
+- Images: `next/image` with `images.remotePatterns` and `images.domains` in `next.config.js`.
+
+## 2) Colors/tokens and brand mapping
+
+Prefer Tailwind tokens over ad-hoc hex values.
+
+- Brand accent: Orange → Red gradients are common.
+  - Examples:
+    - Button gradient: `from-orange-500 to-red-500` (`components/ui/button.tsx`).
+    - Article links / accents: `#f97316` (orange) in `components/post-body.module.css`.
+- Base surfaces:
+  - Global page background: `#fbfcff`, base text: `#222222` (`styles/index.css`).
+  - Article text: `#637277` / `#374151`; headings: `#1D2022` (`components/post-body.module.css`).
+- Tailwind theme extensions:
+  - `primary.*`, `secondary.*`, `accent.*`, plus gradients like `accent.gradient` (`tailwind.config.js`).
+
+Guideline:
+- When introducing new colors, first try mapping to existing Tailwind palette usage (`primary`, `secondary`, `accent`, `neutral`) or existing semantic colors in the article styles.
+- Avoid mixing multiple near-identical grays/oranges in the same component unless there is a clear hierarchy reason.
+
+## 3) Typography (Baloo 2 / DM Sans)
+
+Fonts are loaded via Google Fonts in `pages/_document.tsx`:
+- Baloo 2: preloaded then loaded as stylesheet.
+- DM Sans: preloaded globally.
+
+Project conventions:
+- **DM Sans** is the primary font for blog reading experiences:
+  - Used in article content (`components/post-body.module.css`) and many blog UI pieces (e.g. `components/post-title.tsx`, `components/post-card.tsx`).
+- **Baloo 2** remains in global CSS utility classes (`styles/index.css`) and is used for some non-article surfaces.
+
+Guideline:
+- Do not add new font families without explicit product approval.
+- Prefer CSS/Tailwind-driven typography for consistency; avoid one-off inline typography unless matching existing patterns.
+
+## 4) Spacing/layout conventions
+
+- Main container pattern: centered, wide layout with consistent horizontal padding:
+  - `components/container.tsx`: `max-w-7xl mx-auto px-5 sm:px-6`.
+- Navigation uses rounded, glassy surfaces with generous padding and responsive width changes (`components/navbar/FloatingNavbar.tsx`).
+- Cards commonly use:
+  - `rounded-lg`, `border border-gray-200`, subtle hover shadow and border color shift (`components/post-card.tsx`).
+
+Guideline:
+- Use Tailwind spacing scale (`p-*`, `gap-*`, `mt-*`) rather than custom pixel values, unless matching a proven existing component.
+- Maintain consistent vertical rhythm in reading pages: headings/top borders in article CSS already define spacing—avoid reintroducing conflicting margins in MD/HTML renderers.
+
+## 5) Components (buttons/cards/nav/forms)
+
+Buttons (`components/ui/button.tsx`):
+- Default button is gradient + rounded-full + shadow, with hover transitions.
+
+Cards (`components/ui/card.tsx`, `components/post-card.tsx`):
+- Favor `rounded-lg` + border + subtle shadows; interactive cards should have predictable hover states.
+
+Nav (`components/navbar/*`):
+- Glassmorphism patterns: blur + gradient + soft ring/border + large rounded radii.
+- Mobile menu uses `Sheet` + `Collapsible` primitives (Radix-based).
+
+Forms:
+- Tailwind forms plugin is enabled (`@tailwindcss/forms` in deps); prefer it for input baseline styling.
+
+Guideline:
+- Reuse primitives from `components/ui/*` before creating new bespoke patterns.
+- Keep interactive states (hover/focus/active/disabled) accessible and consistent with existing components.
+
+## 6) Motion/icons/images
+
+Motion:
+- Prefer subtle transitions (150–300ms) and low-amplitude transforms.
+- Avoid “always-on” heavy animations that distract from reading.
+
+Icons:
+- Prefer `lucide-react` for consistency.
+
+Images:
+- Use `next/image` for local assets and remote WP assets when feasible.
+- Respect existing `next.config.js` `images.remotePatterns` / `domains`—do not introduce broad `*` or unsafe patterns.
+
+## 7) Dark mode and responsive behavior
+
+- Tailwind `darkMode: ['class']` is enabled (`tailwind.config.js`).
+
+Guideline:
+- If you add UI that can appear on pages using dark mode, ensure colors work with `dark:` variants or use semantic tokens.
+- Ensure components are responsive (mobile first), especially navigation and post cards:
+  - Prefer `clamp()` for typography where already used (e.g. post title).
+  - Avoid fixed widths that break at `sm`/`md` breakpoints.
+
+## 8) Anti-patterns (project-specific)
+
+- Adding new brand colors without mapping to existing tokens (`primary/secondary/accent`) first.
+- Introducing render-blocking font loads (do not use `@import` for fonts; keep font loading in `_document.tsx`).
+- Shipping components with missing focus-visible states or relying only on hover for discoverability.
+- Hardcoding many hex values in a single component when Tailwind tokens exist for the same roles.
+- Adding large animations to reading pages without a clear UX reason.
+
+## 9) PR checklist (design/UI changes)
+
+- Visual regression check: verify navbar, post cards, and article pages (`/technology/*`, `/community/*`) at `sm`, `md`, `lg`.
+- Accessibility: keyboard focus states, contrast for text/icons, no trapped scroll in overlays.
+- Performance: avoid shipping large unoptimized images; confirm `next/image` usage.
+- Consistency: reuse `components/ui/*` primitives and existing layout spacing.
+
+## 10) Project-only “improvement suggestions” policy
+
+When the design agent outputs **Improvement suggestions**, they must be:
+- Non-blocking.
+- Max 3 items.
+- Specific to this repo’s patterns (e.g., “replace ad-hoc gray with existing article gray tokens”), not generic design advice.
+

--- a/design-agent/README.md
+++ b/design-agent/README.md
@@ -1,0 +1,64 @@
+# Design Review Agent (blog-website)
+
+This repo includes a hardened Design Review Agent that reviews **design/UI-relevant diffs** on pull requests and posts a single upserted PR comment.
+
+## Guideline architecture (private common + local blog)
+
+At runtime, the agent merges guidelines in this order:
+
+1. **COMMON (private, remote)**: fetched via GitHub API from `keploy/landing-page` at `design-agent/COMMON_DESIGN_GUIDELINES.md`
+2. **BLOG (local, this repo)**: `design-agent/BLOG_DESIGN_GUIDELINES.md`
+
+The common guideline file is **not copied into this repo**; it is fetched per run using `DESIGN_COMMONS_TOKEN`.
+
+## Triggers
+
+Workflow file: `.github/workflows/design-review.yml`
+
+- `pull_request`: runs automatically on UI/design paths (components/pages/styles/public + configs + `design-agent/**`)
+- `issue_comment`: runs only when a trusted actor comments `/design-review` on a PR
+- `workflow_dispatch`: manual run with `pr_number`
+
+## Required secrets
+
+- `ANTHROPIC_API_KEY`: Anthropic API key used for the review call.
+- `DESIGN_COMMONS_TOKEN`: GitHub token with read access to the private common guidelines repo (`keploy/landing-page`).
+
+## Security behavior (forks / external PRs)
+
+The workflow and script are hardened for forks/external PRs:
+
+- Checkout strategy:
+  - Internal PR: checks out `pr.head.sha`
+  - External PR: checks out the base repo default branch (safe)
+- Script enforcement:
+  - External PRs are **skipped** unless `ALLOW_EXTERNAL_PR_REVIEW=true`
+- `/design-review` comment trigger:
+  - Only `OWNER`, `MEMBER`, or `COLLABORATOR` can trigger via comment (workflow + script defense-in-depth).
+
+## Configuration (env vars)
+
+Provided by the workflow (overridable via repo `vars`):
+
+- `COMMON_GUIDELINES_REPO` (default `keploy/landing-page`)
+- `COMMON_GUIDELINES_PATH` (default `design-agent/COMMON_DESIGN_GUIDELINES.md`)
+- `COMMON_GUIDELINES_REF` (default `main`)
+
+Optional:
+
+- `ANTHROPIC_MODEL` (default `claude-3-5-sonnet-latest`)
+- `DESIGN_DIFF_MAX_CHARS` (default `120000`)
+- `ALLOW_EXTERNAL_PR_REVIEW` (default `false`)
+
+## Troubleshooting
+
+- Missing keys:
+  - If `ANTHROPIC_API_KEY` or `DESIGN_COMMONS_TOKEN` is missing, the job fails when those are required.
+- No textual patch:
+  - If only design-relevant files without textual patches are detected (images/binary/too-large diffs), the agent posts a `MANUAL_REVIEW_REQUIRED` comment and **does not call** Anthropic.
+- Empty LLM response:
+  - The agent retries once (2 attempts). If still empty, it fails the job.
+- Verdict parse failures:
+  - The agent requires **exactly one** verdict token and requires the `## Verdict` section to contain only that token.
+  - If verdict cannot be parsed, the job fails to prevent silent “looks OK” output.
+

--- a/design-agent/requirements.txt
+++ b/design-agent/requirements.txt
@@ -1,0 +1,3 @@
+anthropic==0.40.0
+PyGithub==2.1.1
+

--- a/design-agent/scripts/design_review.py
+++ b/design-agent/scripts/design_review.py
@@ -1,0 +1,547 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+from anthropic import Anthropic
+from github import Github
+from github.GithubException import GithubException
+
+
+MARKER_COMMENT = "<!-- design-agent-review-comment -->"
+
+KNOWN_VERDICTS = (
+    "APPROVE",
+    "APPROVE_WITH_NITS",
+    "CHANGES_REQUESTED",
+    "MANUAL_REVIEW_REQUIRED",
+)
+
+
+DESIGN_PATH_PREFIXES = (
+    "components/",
+    "pages/",
+    "styles/",
+    "public/images/",
+    "public/videos/",
+    "design-agent/",
+)
+
+ROOT_CONFIG_FILES = (
+    "tailwind.config.js",
+    "tailwind.config.cjs",
+    "tailwind.config.ts",
+    "next.config.js",
+    "next.config.mjs",
+    "next.config.cjs",
+)
+
+ALLOWED_EXTENSIONS = (
+    ".css",
+    ".scss",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".md",
+    ".mdx",
+    ".svg",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".webp",
+    ".gif",
+)
+
+EXCLUDED_DIFF_PATHS = {
+    "design-agent/BLOG_DESIGN_GUIDELINES.md",
+}
+
+TRUSTED_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
+
+
+def _env_required(name: str) -> str:
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        raise RuntimeError(f"Missing required env var: {name}")
+    return value.strip()
+
+
+def _env_optional(name: str, default: str) -> str:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    value = value.strip()
+    return value if value else default
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "y", "on")
+
+
+def _is_allowed_extension(path: str) -> bool:
+    lower = path.lower()
+    return any(lower.endswith(ext) for ext in ALLOWED_EXTENSIONS)
+
+
+def _is_design_relevant_path(path: str) -> bool:
+    if path in ROOT_CONFIG_FILES:
+        return True
+    return any(path.startswith(prefix) for prefix in DESIGN_PATH_PREFIXES)
+
+
+@dataclass(frozen=True)
+class DiffFilterResult:
+    textual_patch_files: Tuple[str, ...]
+    textual_patch_payload: str
+    skipped_non_design: Tuple[str, ...]
+    skipped_excluded: Tuple[str, ...]
+    skipped_no_patch: Tuple[str, ...]
+
+
+def _filter_design_diff(pr_files: Sequence[object]) -> DiffFilterResult:
+    textual_patch_files: List[str] = []
+    skipped_non_design: List[str] = []
+    skipped_excluded: List[str] = []
+    skipped_no_patch: List[str] = []
+
+    chunks: List[str] = []
+
+    for f in pr_files:
+        filename = getattr(f, "filename", None)
+        if not filename:
+            continue
+
+        if filename in EXCLUDED_DIFF_PATHS:
+            skipped_excluded.append(filename)
+            continue
+
+        if not _is_design_relevant_path(filename) or not _is_allowed_extension(filename):
+            skipped_non_design.append(filename)
+            continue
+
+        patch = getattr(f, "patch", None)
+        if not patch or not str(patch).strip():
+            skipped_no_patch.append(filename)
+            continue
+
+        textual_patch_files.append(filename)
+        chunks.append(f"---\nFile: {filename}\n{patch}\n")
+
+    payload = "\n".join(chunks).strip()
+    return DiffFilterResult(
+        textual_patch_files=tuple(textual_patch_files),
+        textual_patch_payload=payload,
+        skipped_non_design=tuple(skipped_non_design),
+        skipped_excluded=tuple(skipped_excluded),
+        skipped_no_patch=tuple(skipped_no_patch),
+    )
+
+
+def _fetch_common_guidelines() -> str:
+    commons_token = _env_required("DESIGN_COMMONS_TOKEN")
+    repo_full_name = _env_optional("COMMON_GUIDELINES_REPO", "keploy/landing-page")
+    path = _env_optional(
+        "COMMON_GUIDELINES_PATH", "design-agent/COMMON_DESIGN_GUIDELINES.md"
+    )
+    ref = _env_optional("COMMON_GUIDELINES_REF", "main")
+
+    gh = Github(commons_token, per_page=100)
+    repo = gh.get_repo(repo_full_name)
+    content = repo.get_contents(path, ref=ref)
+    if isinstance(content, list):
+        raise RuntimeError(
+            "COMMON_GUIDELINES_PATH resolved to a directory, expected a file."
+        )
+    data = content.decoded_content.decode("utf-8", errors="replace")
+    if not data.strip():
+        raise RuntimeError("Fetched common design guidelines are empty.")
+    return data
+
+
+def _load_blog_guidelines(repo_root: Path) -> str:
+    blog_path = repo_root / "design-agent" / "BLOG_DESIGN_GUIDELINES.md"
+    if not blog_path.exists():
+        raise RuntimeError(f"Missing local blog guidelines at {blog_path.as_posix()}")
+    data = blog_path.read_text(encoding="utf-8", errors="replace")
+    if not data.strip():
+        raise RuntimeError("Local blog design guidelines are empty.")
+    return data
+
+
+def _build_review_prompt(guidelines: str, diff_payload: str) -> Tuple[str, str]:
+    system = (
+        "You are a production-grade Design Review Agent for a Next.js + Tailwind blog.\n"
+        "You must follow the provided design guidelines exactly.\n"
+        "\n"
+        "Output format (STRICT):\n"
+        "## Design review summary\n"
+        "## Verdict\n"
+        "(single token only, exactly one of: "
+        + ", ".join(KNOWN_VERDICTS)
+        + ")\n"
+        "## Violations\n"
+        "## Improvement suggestions (non-blocking, max 3)\n"
+        "## Flagged for discussion\n"
+        "(always present; write 'None.' if none)\n"
+        "## Approved changes\n"
+        "\n"
+        "Rules:\n"
+        "- Keep the Verdict section to ONLY the verdict token on its own line.\n"
+        "- Do not include markdown tables (lines containing '|') anywhere.\n"
+        "- Only judge what is in the diff payload.\n"
+        "- Cite files/paths when referencing issues.\n"
+        "\n"
+        "Design guidelines (COMMON then BLOG):\n"
+        "-----\n"
+        f"{guidelines}\n"
+        "-----\n"
+    )
+
+    user = (
+        "Review the following PR diff for design/UI quality against the guidelines.\n"
+        "Only consider the included files and patches.\n"
+        "\n"
+        "Diff payload:\n"
+        "-----\n"
+        f"{diff_payload}\n"
+        "-----\n"
+    )
+    return system, user
+
+
+def _concat_anthropic_text(response: object) -> str:
+    content = getattr(response, "content", None)
+    if not content:
+        return ""
+    parts: List[str] = []
+    for block in content:
+        text = getattr(block, "text", None)
+        if text:
+            parts.append(str(text))
+    return "\n".join(parts).strip()
+
+
+def _extract_verdict(output_text: str) -> str:
+    matches: List[str] = []
+    token_re = re.compile(r"\b(" + "|".join(map(re.escape, KNOWN_VERDICTS)) + r")\b")
+
+    for line in output_text.splitlines():
+        if "|" in line:
+            continue
+        for m in token_re.findall(line):
+            matches.append(m)
+
+    unique = sorted(set(matches))
+    if len(unique) != 1:
+        raise RuntimeError(
+            f"Verdict parse failed: expected exactly 1 token, found {unique or 'none'}"
+        )
+    verdict = unique[0]
+
+    # Enforce: Verdict section contains ONLY the token.
+    verdict_line = _first_verdict_section_line(output_text)
+    if verdict_line != verdict:
+        raise RuntimeError(
+            "Verdict section invalid: expected a single token line matching the verdict."
+        )
+
+    return verdict
+
+
+def _first_verdict_section_line(output_text: str) -> Optional[str]:
+    lines = output_text.splitlines()
+    start_idx: Optional[int] = None
+    for i, line in enumerate(lines):
+        if line.strip().lower() == "## verdict":
+            start_idx = i + 1
+            break
+    if start_idx is None:
+        return None
+
+    for j in range(start_idx, len(lines)):
+        candidate = lines[j].strip()
+        if not candidate:
+            continue
+        if "|" in candidate:
+            continue
+        return candidate
+    return None
+
+
+def _validate_required_sections(output_text: str) -> None:
+    required = (
+        "## Design review summary",
+        "## Verdict",
+        "## Violations",
+        "## Improvement suggestions",
+        "## Flagged for discussion",
+        "## Approved changes",
+    )
+    missing = [h for h in required if h.lower() not in output_text.lower()]
+    if missing:
+        raise RuntimeError(f"LLM output missing required sections: {missing}")
+
+
+def _upsert_pr_comment(issue: object, body: str) -> None:
+    comments = issue.get_comments()
+    for c in comments:
+        existing = getattr(c, "body", "") or ""
+        if MARKER_COMMENT in existing:
+            c.edit(body)
+            return
+    issue.create_comment(body)
+
+
+def _manual_review_comment(
+    *,
+    summary: str,
+    violations: Sequence[str],
+    approved: Sequence[str],
+    flagged: str = "None.",
+) -> str:
+    violations_block = "\n".join(f"- {v}" for v in violations) if violations else "None."
+    approved_block = "\n".join(f"- {a}" for a in approved) if approved else "None."
+    return "\n".join(
+        [
+            MARKER_COMMENT,
+            "## Design review summary",
+            summary,
+            "## Verdict",
+            "MANUAL_REVIEW_REQUIRED",
+            "## Violations",
+            violations_block,
+            "## Improvement suggestions (non-blocking, max 3)",
+            "None.",
+            "## Flagged for discussion",
+            flagged or "None.",
+            "## Approved changes",
+            approved_block,
+        ]
+    ).strip()
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+
+    _enforce_trusted_issue_comment_trigger()
+
+    github_token = _env_required("GITHUB_TOKEN")
+    github_repository = _env_required("GITHUB_REPOSITORY")
+    pr_number = int(_env_required("PR_NUMBER"))
+
+    allow_external = _env_bool("ALLOW_EXTERNAL_PR_REVIEW", default=False)
+
+    gh = Github(github_token, per_page=100)
+    repo = gh.get_repo(github_repository)
+    pr = repo.get_pull(pr_number)
+
+    head_sha = pr.head.sha
+    head_repo_full_name = pr.head.repo.full_name
+    base_repo_full_name = pr.base.repo.full_name
+    is_external_pr = head_repo_full_name.lower() != base_repo_full_name.lower()
+
+    if is_external_pr and not allow_external:
+        print(
+            f"External PR detected ({head_repo_full_name}); skipping design review "
+            "because ALLOW_EXTERNAL_PR_REVIEW is not enabled.",
+            file=sys.stderr,
+        )
+        return 0
+
+    pr_files = list(pr.get_files())
+    filtered = _filter_design_diff(pr_files)
+
+    if not filtered.textual_patch_files:
+        if filtered.skipped_no_patch:
+            issue = pr.as_issue()
+            body = _manual_review_comment(
+                summary=(
+                    "Design-relevant files were changed but GitHub did not provide a textual patch "
+                    "(binary or too-large diff). Manual design review is required."
+                ),
+                violations=[
+                    "No textual patch available for one or more design-relevant files.",
+                ],
+                approved=[
+                    f"Detected {len(filtered.skipped_no_patch)} design-relevant file(s) without patch.",
+                ],
+                flagged="Consider adding screenshots/video in the PR description for these changes.",
+            )
+            body = _with_footer_links(
+                body=body,
+                pr_number=pr_number,
+                base_repo_full_name=base_repo_full_name,
+                head_repo_full_name=head_repo_full_name,
+                head_sha=head_sha,
+                filtered=filtered,
+            )
+            _upsert_pr_comment(issue, body)
+        else:
+            print("No design-relevant textual diff found; not posting a PR comment.")
+        return 0
+
+    max_payload_chars = int(_env_optional("DESIGN_DIFF_MAX_CHARS", "120000"))
+    if len(filtered.textual_patch_payload) > max_payload_chars:
+        issue = pr.as_issue()
+        body = _manual_review_comment(
+            summary=(
+                "Design-relevant diff is too large to review safely in the automated design agent. "
+                "Manual review is required."
+            ),
+            violations=[
+                "Diff payload exceeded the configured size limit for automated review.",
+            ],
+            approved=[
+                f"Detected {len(filtered.textual_patch_files)} design-relevant file(s) with textual patches.",
+            ],
+            flagged="Consider splitting the PR or attaching screenshots/videos for quick review.",
+        )
+        body = _with_footer_links(
+            body=body,
+            pr_number=pr_number,
+            base_repo_full_name=base_repo_full_name,
+            head_repo_full_name=head_repo_full_name,
+            head_sha=head_sha,
+            filtered=filtered,
+        )
+        _upsert_pr_comment(issue, body)
+        return 0
+
+    common = _fetch_common_guidelines()
+    blog = _load_blog_guidelines(repo_root)
+    merged_guidelines = f"{common.strip()}\n\n{blog.strip()}"
+
+    system, user = _build_review_prompt(
+        guidelines=merged_guidelines, diff_payload=filtered.textual_patch_payload
+    )
+
+    anthropic_api_key = _env_required("ANTHROPIC_API_KEY")
+    model = _env_optional("ANTHROPIC_MODEL", "claude-3-5-sonnet-latest")
+
+    client = Anthropic(api_key=anthropic_api_key)
+
+    output_text = ""
+    for attempt in (1, 2):
+        response = client.messages.create(
+            model=model,
+            max_tokens=1600,
+            temperature=0.2,
+            system=system,
+            messages=[{"role": "user", "content": user}],
+        )
+        output_text = _concat_anthropic_text(response)
+        if output_text.strip():
+            break
+        if attempt == 1:
+            print("Empty LLM response; retrying once...", file=sys.stderr)
+
+    if not output_text.strip():
+        raise RuntimeError("LLM returned an empty response after 2 attempts.")
+
+    _validate_required_sections(output_text)
+    verdict = _extract_verdict(output_text)
+    print(f"Parsed verdict: {verdict}")
+
+    issue = pr.as_issue()
+    body = "\n".join([MARKER_COMMENT, output_text.strip()]).strip()
+    body = _with_footer_links(
+        body=body,
+        pr_number=pr_number,
+        base_repo_full_name=base_repo_full_name,
+        head_repo_full_name=head_repo_full_name,
+        head_sha=head_sha,
+        filtered=filtered,
+    )
+    _upsert_pr_comment(issue, body)
+    return 0
+
+
+def _enforce_trusted_issue_comment_trigger() -> None:
+    """
+    Defense-in-depth: even if the workflow is misconfigured, only run `/design-review`
+    when the comment author is trusted (OWNER/MEMBER/COLLABORATOR).
+    """
+    if os.getenv("GITHUB_EVENT_NAME") != "issue_comment":
+        return
+
+    event_path = os.getenv("GITHUB_EVENT_PATH")
+    if not event_path:
+        raise RuntimeError("Missing GITHUB_EVENT_PATH for issue_comment event.")
+
+    payload = json.loads(Path(event_path).read_text(encoding="utf-8"))
+    comment_body = (payload.get("comment") or {}).get("body") or ""
+    author_association = (payload.get("comment") or {}).get("author_association") or ""
+
+    if "/design-review" not in comment_body:
+        print("issue_comment event without /design-review; skipping.", file=sys.stderr)
+        raise SystemExit(0)
+
+    if author_association not in TRUSTED_ASSOCIATIONS:
+        print(
+            f"Untrusted comment author_association={author_association}; skipping.",
+            file=sys.stderr,
+        )
+        raise SystemExit(0)
+
+
+def _with_footer_links(
+    *,
+    body: str,
+    pr_number: int,
+    base_repo_full_name: str,
+    head_repo_full_name: str,
+    head_sha: str,
+    filtered: DiffFilterResult,
+) -> str:
+    commit_url = f"https://github.com/{head_repo_full_name}/commit/{head_sha}"
+    tree_url = f"https://github.com/{head_repo_full_name}/tree/{head_sha}"
+    pr_commits_url = (
+        f"https://github.com/{base_repo_full_name}/pull/{pr_number}/commits/{head_sha}"
+    )
+
+    meta_lines = [
+        "",
+        "---",
+        f"Reviewed commit: `{head_sha}`",
+        f"- Commit: {commit_url}",
+        f"- Tree: {tree_url}",
+        f"- PR commits (pinned): {pr_commits_url}",
+        "",
+        "Design diff filter stats:",
+        f"- `textual_patch_files`: {len(filtered.textual_patch_files)}",
+        f"- `skipped_no_patch`: {len(filtered.skipped_no_patch)}",
+        f"- `skipped_excluded`: {len(filtered.skipped_excluded)}",
+        f"- `skipped_non_design`: {len(filtered.skipped_non_design)}",
+    ]
+
+    if filtered.textual_patch_files:
+        meta_lines.append(
+            "- Files reviewed:\n" + "\n".join(f"  - `{p}`" for p in filtered.textual_patch_files)
+        )
+    if filtered.skipped_no_patch:
+        meta_lines.append(
+            "- Design files without textual patch:\n"
+            + "\n".join(f"  - `{p}`" for p in filtered.skipped_no_patch)
+        )
+
+    return (body.rstrip() + "\n" + "\n".join(meta_lines).rstrip() + "\n").strip()
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except GithubException as e:
+        print(f"GitHub API error: {e}", file=sys.stderr)
+        raise
+    except Exception as e:
+        print(str(e), file=sys.stderr)
+        raise

--- a/design-agent/tests/test_design_review.py
+++ b/design-agent/tests/test_design_review.py
@@ -1,0 +1,198 @@
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def _load_design_review_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "design-agent" / "scripts" / "design_review.py"
+    spec = importlib.util.spec_from_file_location("design_review", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Failed to load design_review module spec.")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakePRFile:
+    def __init__(self, filename: str, patch=None):
+        self.filename = filename
+        self.patch = patch
+
+
+class TestDiffFiltering(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load_design_review_module()
+
+    def test_filters_textual_patches_and_tracks_skips(self):
+        files = [
+            _FakePRFile("design-agent/BLOG_DESIGN_GUIDELINES.md", patch="x"),
+            _FakePRFile("components/ui/button.tsx", patch="@@\n+change\n"),
+            _FakePRFile("components/ui/logo.svg", patch=None),  # no patch -> skipped_no_patch
+            _FakePRFile("lib/server.ts", patch="@@\n+no\n"),  # non-design path
+            _FakePRFile("pages/_document.tsx", patch="@@\n+ok\n"),
+            _FakePRFile("styles/index.css", patch="   "),  # empty patch -> skipped_no_patch
+            _FakePRFile("next.config.js", patch="@@\n+ok\n"),
+            _FakePRFile("README.md", patch="@@\n+no\n"),
+        ]
+
+        res = self.mod._filter_design_diff(files)
+
+        self.assertIn("components/ui/button.tsx", res.textual_patch_files)
+        self.assertIn("pages/_document.tsx", res.textual_patch_files)
+        self.assertIn("next.config.js", res.textual_patch_files)
+        self.assertNotIn("design-agent/BLOG_DESIGN_GUIDELINES.md", res.textual_patch_files)
+
+        self.assertIn("design-agent/BLOG_DESIGN_GUIDELINES.md", res.skipped_excluded)
+        self.assertIn("lib/server.ts", res.skipped_non_design)
+        self.assertIn("README.md", res.skipped_non_design)
+
+        self.assertIn("components/ui/logo.svg", res.skipped_no_patch)
+        self.assertIn("styles/index.css", res.skipped_no_patch)
+
+        self.assertIn("File: components/ui/button.tsx", res.textual_patch_payload)
+        self.assertIn("File: pages/_document.tsx", res.textual_patch_payload)
+
+
+class TestVerdictParsing(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load_design_review_module()
+
+    def test_valid_sections_and_verdict(self):
+        output = "\n".join(
+            [
+                "## Design review summary",
+                "Looks good.",
+                "## Verdict",
+                "APPROVE_WITH_NITS",
+                "## Violations",
+                "None.",
+                "## Improvement suggestions (non-blocking, max 3)",
+                "- Consider ...",
+                "## Flagged for discussion",
+                "None.",
+                "## Approved changes",
+                "- Good stuff.",
+            ]
+        )
+        self.mod._validate_required_sections(output)
+        verdict = self.mod._extract_verdict(output)
+        self.assertEqual(verdict, "APPROVE_WITH_NITS")
+
+    def test_rejects_missing_verdict_section_line(self):
+        output = "\n".join(
+            [
+                "## Design review summary",
+                "OK",
+                "## Verdict",
+                "",
+                "APPROVE",
+                "## Violations",
+                "None.",
+                "## Improvement suggestions (non-blocking, max 3)",
+                "None.",
+                "## Flagged for discussion",
+                "None.",
+                "## Approved changes",
+                "None.",
+            ]
+        )
+        # Blank line is allowed as long as first non-empty line is the token.
+        verdict = self.mod._extract_verdict(output)
+        self.assertEqual(verdict, "APPROVE")
+
+    def test_rejects_verdict_section_with_extra_text(self):
+        output = "\n".join(
+            [
+                "## Design review summary",
+                "OK",
+                "## Verdict",
+                "APPROVE (looks good)",
+                "## Violations",
+                "None.",
+                "## Improvement suggestions (non-blocking, max 3)",
+                "None.",
+                "## Flagged for discussion",
+                "None.",
+                "## Approved changes",
+                "None.",
+            ]
+        )
+        with self.assertRaises(RuntimeError):
+            self.mod._extract_verdict(output)
+
+    def test_rejects_multiple_verdict_tokens(self):
+        output = "\n".join(
+            [
+                "## Design review summary",
+                "OK",
+                "## Verdict",
+                "APPROVE",
+                "## Violations",
+                "None.",
+                "## Improvement suggestions (non-blocking, max 3)",
+                "None.",
+                "## Flagged for discussion",
+                "CHANGES_REQUESTED (maybe)  ",
+                "## Approved changes",
+                "None.",
+            ]
+        )
+        with self.assertRaises(RuntimeError):
+            self.mod._extract_verdict(output)
+
+
+class TestTrustedCommentEnforcement(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load_design_review_module()
+        self._old_env = os.environ.copy()
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self._old_env)
+
+    def _write_event(self, payload: dict) -> str:
+        fd, path = tempfile.mkstemp(prefix="gh-event-", suffix=".json")
+        os.close(fd)
+        Path(path).write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    def test_skips_issue_comment_without_command(self):
+        path = self._write_event(
+            {
+                "comment": {"body": "hello", "author_association": "OWNER"},
+            }
+        )
+        os.environ["GITHUB_EVENT_NAME"] = "issue_comment"
+        os.environ["GITHUB_EVENT_PATH"] = path
+        with self.assertRaises(SystemExit) as cm:
+            self.mod._enforce_trusted_issue_comment_trigger()
+        self.assertEqual(cm.exception.code, 0)
+
+    def test_skips_untrusted_author(self):
+        path = self._write_event(
+            {
+                "comment": {"body": "/design-review", "author_association": "NONE"},
+            }
+        )
+        os.environ["GITHUB_EVENT_NAME"] = "issue_comment"
+        os.environ["GITHUB_EVENT_PATH"] = path
+        with self.assertRaises(SystemExit) as cm:
+            self.mod._enforce_trusted_issue_comment_trigger()
+        self.assertEqual(cm.exception.code, 0)
+
+    def test_allows_trusted_author(self):
+        path = self._write_event(
+            {
+                "comment": {"body": "please /design-review", "author_association": "MEMBER"},
+            }
+        )
+        os.environ["GITHUB_EVENT_NAME"] = "issue_comment"
+        os.environ["GITHUB_EVENT_PATH"] = path
+        # Should not raise
+        self.mod._enforce_trusted_issue_comment_trigger()


### PR DESCRIPTION


Adds a **Design Review Agent** that automatically reviews **design/UI-relevant diffs** in PRs for `keploy/blog-website`, using:

- **Private shared guidelines (COMMON)** fetched at runtime from `keploy/landing-page` 
- **Repo-local blog guidelines (BLOG)** generated from this codebase
- A hardened GitHub Actions workflow that is safe for forks/external PRs and supports manual `/design-review` triggers

Output is posted as a **single upserted PR comment** (marker-based) with pinned commit links.

## What’s included (files)

- `.github/workflows/design-review.yml`
  - Triggers: `pull_request`, `issue_comment`, `workflow_dispatch`
  - Strict permissions: `pull-requests: write`, `issues: write`, `contents: read`
  - Trusted-actor gating for `/design-review` comments (OWNER/MEMBER/COLLABORATOR)
  - Safe checkout strategy (internal PR vs external PR)
- `design-agent/scripts/design_review.py`
  - PR number resolution + PR metadata (`head.sha`, `head.repo.full_name`)
  - External PR skip logic unless explicitly allowed
  - Common guideline fetch via GitHub API using `DESIGN_COMMONS_TOKEN`
  - Diff filtering for blog UI paths + extension allowlist + excluded files
  - Robust LLM response handling and strict verdict parsing
  - Comment upsert (single marker comment per PR) + footer links pinned to `pr.head.sha`
- `design-agent/BLOG_DESIGN_GUIDELINES.md`
  - Blog-specific guidelines derived from actual code patterns and UI primitives in this repo
- `design-agent/README.md`
  - Architecture, secrets, fork behavior, manual triggers, troubleshooting
- `design-agent/requirements.txt`
  - Pinned dependencies:
    - `anthropic==0.40.0`
    - `PyGithub==2.1.1`
- `design-agent/tests/test_design_review.py`
  - Unit tests for the pure logic: diff filtering, verdict parsing, trusted comment enforcement

## Workflow behavior (security + reliability)

### Triggers

- `pull_request`:
  - Runs when UI/design-relevant paths change:
    - `components/**`, `pages/**`, `styles/**`, `public/images/**`, `public/videos/**`
    - `design-agent/**`, `.github/workflows/design-review.yml`
    - root configs: `tailwind.config.*`, `next.config.*`
- `issue_comment`:
  - Runs only when comment contains `/design-review`
  - Only if commenter is `OWNER` / `MEMBER` / `COLLABORATOR`
- `workflow_dispatch`:
  - Manual run with `pr_number`

### Permissions

Explicitly limited to what’s required:

- `pull-requests: write` + `issues: write` for comment upsert
- `contents: read` for repository reads / checkout

### Safe PR checkout (internal vs external)

The workflow resolves PR metadata first and checks out safely:

- Internal PR (`head.repo.full_name == base.repo.full_name`): checkout `pr.head.sha`
- External PR (fork): checkout base repo **default branch** (safe)

In addition, the script enforces:

- External PRs are skipped unless `ALLOW_EXTERNAL_PR_REVIEW=true`

## Design diff filtering rules

Only a scoped subset of PR changes are sent to the LLM:

- Path allowlist:
  - `components/`, `pages/`, `styles/`, `public/images/`, `public/videos/`, `design-agent/`
  - plus root configs: `tailwind.config.*`, `next.config.*`
- Extension allowlist:
  - `.css`, `.scss`, `.module.css`, `.ts`, `.tsx`, `.js`, `.jsx`, `.md`, `.mdx`, `.svg`, `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`
- Exclusions (never included in diff payload):
  - `design-agent/BLOG_DESIGN_GUIDELINES.md`
- Tracking metrics (included in footer):
  - `skipped_non_design`, `skipped_excluded`, `skipped_no_patch`, `textual_patch_files`

Edge handling:

- If there are **no design-relevant textual patches**:
  - No PR comment is posted
- If only design-relevant files exist but **without a textual patch** (binary / too large for GitHub patch):
  - The agent posts `MANUAL_REVIEW_REQUIRED` and **skips the LLM call**

## LLM robustness + strict output contract

The agent requires a **strict response format** with these sections:

- Design review summary
- Verdict (single token only; exactly one of `APPROVE`, `APPROVE_WITH_NITS`, `CHANGES_REQUESTED`, `MANUAL_REVIEW_REQUIRED`)
- Violations
- Improvement suggestions (non-blocking, max 3)
- Flagged for discussion (always present; “None.” if none)
- Approved changes

Additional hardening:

- Empty LLM response → retry once (2 attempts total) → fail if still empty
- Verdict parsing:
  - Preserves underscores
  - Skips lines containing `|`
  - Requires exactly one known verdict token match
  - Requires the `## Verdict` section’s first non-empty line to be **only** the verdict token
- If output exists but verdict cannot be parsed → **fail the job** (prevents ambiguous/unsafe automation)

## Comment behavior

- Upserts **one** marker comment per PR run: `<!-- design-agent-review-comment -->`
- Footer contains:
  - Links pinned to `pr.head.sha` (commit/tree/PR commits)
  - Diff filter stats and reviewed file list (when available)

## Why this is implemented as a Python script

Rationale:

- **Security/hardening logic is easier to keep explicit** in a single program:
  - external PR detection + skip policy
  - strict diff filtering/size limits
  - strict output parsing + failure modes
  - marker-based comment upsert behavior
- **Strong ecosystem support** for GitHub API + LLM SDK:
  - `PyGithub` simplifies authenticated GitHub API access (PR files, comments, metadata)
  - `anthropic` SDK supports structured message responses
- **Workflow portability**: runs on `ubuntu-latest` with standard Python setup; does not require Node build tooling.

Implementation approach:

- Keep all decision points deterministic and fail-closed:
  - “no safe diff” → no comment
  - “manual review required” → comment with `MANUAL_REVIEW_REQUIRED` and no LLM call
  - “unparseable verdict” → fail

## Required configuration

### Secrets (required)

- `ANTHROPIC_API_KEY`
- `DESIGN_COMMONS_TOKEN` (must be able to read the private commons repo + file)

### Environment / vars (workflow provides defaults)

- `GITHUB_TOKEN: ${{ github.token }}`
- `PR_NUMBER`
- `GITHUB_REPOSITORY`
- `COMMON_GUIDELINES_REPO` (default `keploy/landing-page`)
- `COMMON_GUIDELINES_PATH` (default `design-agent/COMMON_DESIGN_GUIDELINES.md`)
- `COMMON_GUIDELINES_REF` (default `main`)
- `ALLOW_EXTERNAL_PR_REVIEW` (default `false`)

## Testing / validation performed

- `python3 -m py_compile design-agent/scripts/design_review.py`
- `python3 -m unittest discover -s design-agent/tests -p 'test_*.py'`

## Sources / references used for the implementation

Within this repo:

- UI + styling conventions for BLOG guidelines:
  - `package.json`, `tailwind.config.js`, `styles/index.css`, `pages/_document.tsx`
  - UI primitives and patterns in `components/ui/*`, `components/navbar/*`, `components/post-*`
- Workflow and script hardening requirements:
  - This PR’s specification (security triggers, checkout policy, diff filtering rules, strict verdict contract)

External (conceptual references; implemented without embedding any private file):

- GitHub Actions event model and security posture for fork PRs:
  - `issue_comment` trigger behavior and `author_association` gating
  - “checkout untrusted code” risks and safe fallback to base default branch
- GitHub REST API concepts:
  - Pull request metadata (`head.sha`, `head.repo.full_name`)
  - Pull request file patches (textual `patch` may be missing for large/binary diffs)

Private shared policy source:

- `keploy/landing-page` → `design-agent/COMMON_DESIGN_GUIDELINES.md` fetched at runtime via GitHub API using `DESIGN_COMMONS_TOKEN`

