### PR TITLE
feat: create qa agent skill for detailed code reviews

### DIFF
--- a/.claude/skills/qa-agent/SKILL.md
+++ b/.claude/skills/qa-agent/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: qa-agent
+description: "Run a full QA review of this codebase. Traces cross-file impact, checks framework best practices, security, performance, and accessibility. Use /qa-agent for full review, /qa-agent [filepath] for targeted review, /qa-agent --diff for changed files only, /qa-agent --hotspots for most-changed files only."
+allowed-tools: Read, Grep, Glob, Bash
+memory: project
+---
+
+# QA Agent
+
+Use this skill to run a production-style QA review against the Keploy blog codebase.
+
+This repository is a Next.js Pages Router site backed by WordPress GraphQL. It has high SEO sensitivity, Vercel deployment, Playwright end-to-end coverage, and several high-churn route and metadata files. Review for correctness first, then security, SEO, accessibility, and performance.
+
+## Always Load Context First
+
+Before reviewing any file, read these in order:
+
+1. `context/codebase-map.md`
+2. `context/hotspots.md`
+3. `context/known-suppressions.md`
+4. `context/ignore.md`
+
+Then load only the rules and checklists that apply to the current scope.
+
+## Argument Parsing
+
+Parse `$ARGUMENTS` exactly once before reviewing:
+
+- Empty arguments:
+  - Run `git diff HEAD --name-only`.
+  - If that returns files, review those files.
+  - If that is empty, fall back to the 10 most recently changed tracked files from git history:
+    - `git log --name-only --pretty=format: -n 25 | awk 'NF && !seen[$0]++' | head -10`
+- A single filepath:
+  - Review that file.
+  - Also review its dependents and impacted files discovered by the subagents.
+- `--diff`:
+  - Review only `git diff HEAD --name-only`.
+  - If empty, print `No files in git diff HEAD; nothing to review.` and stop.
+- `--full`:
+  - Review the entire codebase.
+  - Prioritize order using `context/hotspots.md`, then expand to the rest of the repo excluding ignored paths.
+- `--hotspots`:
+  - Review only the files listed in `context/hotspots.md`.
+
+If a requested path matches any pattern in `context/ignore.md`, skip it and say why.
+
+## Review Scope Resolution
+
+After choosing the starting file list:
+
+1. Remove ignored files and generated artifacts using `context/ignore.md`.
+2. Deduplicate paths.
+3. For empty scope after filtering, print `No reviewable files found after ignore filtering.` and stop.
+
+## Parallel Subagents
+
+Spawn these three subagents in parallel with the Task tool.
+
+### Subagent A
+
+- Definition: `agents/codebase-explorer.md`
+- `subagent_type`: `Explore`
+- Prompt:
+
+```text
+Read the file(s) being reviewed. Identify all import/export relationships. Which other files import from these files? Which files do these files import from? Return a structured dependency map.
+```
+
+### Subagent B
+
+- Definition: `agents/impact-tracer.md`
+- `subagent_type`: `general-purpose`
+- Prompt:
+
+```text
+Given the files being reviewed: [list]. Use Grep and Glob to find every file in the project that imports from or references these files. Also check for dynamic imports, re-exports, and barrel files (index.ts). Return a list of impacted files with their relationship type.
+```
+
+### Subagent C
+
+- Definition: `agents/qa-reviewer.md`
+- `subagent_type`: `general-purpose`
+- memory: `project`
+- Prompt:
+
+```text
+Load rules from rules/ directory relevant to this project. Load relevant checklists. Review the target files + any impacted files identified by subagent B. Apply all rules. Return structured findings.
+```
+
+## Merge The Results
+
+After all subagents complete:
+
+1. Merge the dependency map from A and the impact data from B.
+2. Expand the QA review findings from C with any breakage risks implied by A or B.
+3. Do not re-flag anything already listed in `context/known-suppressions.md` unless the suppression itself is incorrect, stale, or too broad.
+4. For impacted files not directly changed, use lower scrutiny:
+   - Check for runtime breakage, broken imports, routing mismatch, SEO regressions, auth gaps, and metadata drift.
+   - Do not spend time on stylistic nits in untouched dependents.
+
+## Output Contract
+
+Use `templates/report.md` to assemble the final report.
+
+Severity values must be one of:
+
+- `blocking`
+- `warning`
+- `suggestion`
+- `nitpick`
+
+Order findings by severity, then by file path.
+
+For every finding include:
+
+- severity
+- file
+- line
+- rule
+- what
+- why
+- fix
+
+## Write The Report
+
+Write the final report to:
+
+`qa-reports/YYYY-MM-DD-HH-MM.md`
+
+Create `qa-reports/` only if it does not exist at runtime.
+
+## Terminal Summary
+
+After writing the report, print a compact terminal summary:
+
+- total files reviewed
+- total impacted files
+- total skipped files
+- total findings by severity
+
+Use this format:
+
+```text
+QA review complete
+Blocking: N
+Warning: N
+Suggestion: N
+Nitpick: N
+Report: qa-reports/YYYY-MM-DD-HH-MM.md
+```

--- a/.claude/skills/qa-agent/agents/codebase-explorer.md
+++ b/.claude/skills/qa-agent/agents/codebase-explorer.md
@@ -1,0 +1,59 @@
+# Codebase Explorer
+
+Role: read-only Explore agent
+
+Mission:
+
+- Map the relevant project structure for the files under review.
+- Identify the active framework and routing strategy.
+- Trace import and export relationships around the review scope.
+- Highlight shared component, utility, and config patterns.
+
+## What To Inspect
+
+1. The file list passed into the task.
+2. Their direct imports and exports.
+3. Files that import them.
+4. Nearby route files, config files, and shared utilities.
+5. Barrel files such as `index.ts` and `index.tsx` if they exist.
+
+## Project-Specific Expectations
+
+- Detect that this repo uses Next.js Pages Router via `pages/`.
+- Confirm there is no `app/` directory.
+- Note shared metadata patterns through `components/layout.tsx` and `components/meta.tsx`.
+- Note WordPress GraphQL access through `lib/api.ts`.
+- Note Vercel deployment configuration through `vercel.json` and `.github/workflows/`.
+
+## Return Format
+
+Return a compact JSON-like summary. Do not paste raw file contents.
+
+```text
+{
+  framework: "Next.js",
+  router: "Pages Router",
+  reviewFiles: ["..."],
+  importsByFile: {
+    "fileA": ["dep1", "dep2"]
+  },
+  importedByFile: {
+    "fileA": ["consumer1", "consumer2"]
+  },
+  barrelFiles: ["..."],
+  sharedPatterns: [
+    "Metadata flows through components/layout.tsx -> components/meta.tsx",
+    "Routes fetch WordPress data through lib/api.ts"
+  ],
+  notes: [
+    "High-risk route file",
+    "Touches shared SEO surface"
+  ]
+}
+```
+
+## Constraints
+
+- Stay read-only.
+- Prefer concise structure over prose.
+- Focus on dependency facts and project conventions, not style commentary.

--- a/.claude/skills/qa-agent/agents/impact-tracer.md
+++ b/.claude/skills/qa-agent/agents/impact-tracer.md
@@ -1,0 +1,61 @@
+# Impact Tracer
+
+Role: general-purpose impact analysis agent
+
+Mission:
+
+- Given a list of changed files, find every direct and indirect dependent that could regress.
+- Include runtime, type-level, config-level, and routing-level references.
+
+## Required Checks
+
+For each changed file:
+
+1. Find direct imports:
+   - `import ... from`
+   - `export ... from`
+   - `require(...)`
+   - `import(...)`
+2. Find re-export paths through barrel files:
+   - `index.ts`
+   - `index.tsx`
+3. Find indirect usage:
+   - shared types flowing into components
+   - helpers used by other helpers used by pages
+   - layout/meta utilities consumed by multiple routes
+4. Find config references:
+   - `next.config.js`
+   - `vercel.json`
+   - `.github/workflows/*`
+   - `playwright.config.ts`
+   - route or nav config files such as `config/nav.ts` and `config/redirect.ts`
+5. Include string-path or slug-based references when a route file changes.
+
+## Project-Specific Guidance
+
+- Treat `pages/community/[slug].tsx`, `pages/technology/[slug].tsx`, `components/meta.tsx`, `components/layout.tsx`, `lib/api.ts`, `utils/seo.ts`, and `lib/structured-data.ts` as broad blast-radius files.
+- When a file under `pages/api/` changes, inspect preview, proxy, search, sitemap, and workflow references.
+- When metadata files change, include SEO tests such as `tests/e2e/SeoMeta.spec.ts`.
+
+## Return Format
+
+```text
+{
+  changedFiles: [],
+  directDependents: [
+    { file: "", relationship: "imports|dynamic-import|re-export|config-reference|test-coverage" }
+  ],
+  indirectDependents: [
+    { file: "", via: "", relationship: "transitive-import|shared-type|shared-helper|route-contract" }
+  ],
+  configReferences: [
+    { file: "", relationship: "workflow|deploy-config|runtime-config|navigation-config" }
+  ]
+}
+```
+
+## Constraints
+
+- Return only impacted files that actually exist in the repo.
+- Deduplicate results.
+- Prefer accuracy over exhaustive speculation.

--- a/.claude/skills/qa-agent/agents/qa-reviewer.md
+++ b/.claude/skills/qa-agent/agents/qa-reviewer.md
@@ -1,0 +1,59 @@
+# QA Reviewer
+
+Role: project-memory QA review agent
+
+Mission:
+
+- Review the target files and impacted dependents using the repo rules.
+- Prioritize runtime bugs, SEO regressions, broken metadata, auth gaps, performance traps, accessibility issues, and weak TypeScript contracts.
+
+## Required Inputs
+
+Read these before reviewing:
+
+- `../context/codebase-map.md`
+- `../context/hotspots.md`
+- `../context/known-suppressions.md`
+- `../context/ignore.md`
+- `../rules/framework.md`
+- `../rules/typescript.md`
+- `../rules/security.md`
+- `../rules/performance.md`
+- `../rules/content.md`
+- `../checklists/pr-review.md`
+- `../checklists/accessibility.md`
+- `../checklists/seo.md`
+
+## Review Behavior
+
+1. Review the requested files with full scrutiny.
+2. Review impacted dependents with lower scrutiny:
+   - import breakage
+   - runtime contract mismatch
+   - broken metadata or SEO propagation
+   - route and link regressions
+   - auth or config gaps
+3. Skip anything listed in `ignore.md`.
+4. Skip any pattern listed in `known-suppressions.md` unless the suppression itself is the problem.
+5. Update project memory with project-specific patterns you discover that are not already captured in the rules.
+
+## Output Format
+
+Return one object per finding:
+
+```text
+{ severity: "blocking|warning|suggestion|nitpick", file: "", line: "", rule: "", what: "", why: "", fix: "" }
+```
+
+## Severity Calibration
+
+- `blocking`: user-facing bug, SEO breakage on production pages, security bug, broken route, broken metadata contract, broken accessibility requirement, or likely deployment failure
+- `warning`: meaningful regression risk or maintainability issue that should be fixed soon
+- `suggestion`: quality improvement that is worthwhile but not urgent
+- `nitpick`: optional cleanup with low risk
+
+## Repo-Specific Priorities
+
+- For this blog site, treat missing `og:image`, missing `og:description`, and missing canonical URL as blocking on pages that ship to production.
+- Treat broken internal navigation, sitemap regressions, and preview/auth mistakes as high severity.
+- Treat metadata drift between `Layout`, `Meta`, `structured-data`, and page-local `<Head>` as a real risk.

--- a/.claude/skills/qa-agent/checklists/accessibility.md
+++ b/.claude/skills/qa-agent/checklists/accessibility.md
@@ -1,0 +1,12 @@
+# Accessibility Checklist
+
+- [ ] Page has a clear heading hierarchy and does not skip major levels without reason
+- [ ] Interactive controls have accessible names
+- [ ] Icon-only buttons and links have labels or visible text
+- [ ] All meaningful images have descriptive alt text
+- [ ] Keyboard navigation still works for header, mobile nav, search, and TOC interactions
+- [ ] Focus states remain visible after styling changes
+- [ ] Motion-heavy UI has acceptable reduced-motion behavior where relevant
+- [ ] Color contrast stays readable for text, links, and active states
+- [ ] Tables and code blocks remain usable on narrow screens
+- [ ] Route-level pages keep landmarks such as `header`, `main`, `article`, and `footer`

--- a/.claude/skills/qa-agent/checklists/pr-review.md
+++ b/.claude/skills/qa-agent/checklists/pr-review.md
@@ -1,0 +1,11 @@
+# PR Review Gate
+
+- [ ] No blocking-severity findings
+- [ ] All new files have appropriate TypeScript types
+- [ ] No secrets introduced
+- [ ] Tests exist for new utility functions (warn if missing, not block)
+- [ ] No new `any` types
+- [ ] No `console.log` left in production paths
+- [ ] New pages preserve the shared metadata contract via `Layout` and `Meta`
+- [ ] New API routes have auth or secret checks if they modify data or enable privileged behavior
+- [ ] Impacted files have been checked and show no regressions

--- a/.claude/skills/qa-agent/checklists/seo.md
+++ b/.claude/skills/qa-agent/checklists/seo.md
@@ -1,0 +1,12 @@
+# SEO Checklist
+
+- [ ] Every production page reviewed has a canonical URL
+- [ ] Every production page reviewed has `og:title`, `og:description`, and `og:image`
+- [ ] Missing canonical URL is blocking
+- [ ] Missing `og:description` is blocking
+- [ ] Missing `og:image` is blocking
+- [ ] Twitter card metadata remains present for shareable pages
+- [ ] JSON-LD remains valid and aligned with the rendered page
+- [ ] Sitemap and robots behavior stays correct for changed route or metadata work
+- [ ] Titles and descriptions remain unique enough across route templates
+- [ ] Redirects preserve the intended canonical destination under the `/blog` base path

--- a/.claude/skills/qa-agent/context/codebase-map.md
+++ b/.claude/skills/qa-agent/context/codebase-map.md
@@ -1,0 +1,105 @@
+# Codebase Map
+
+## Project Identity
+
+- Project: Keploy blog website
+- Framework: Next.js Pages Router
+- Runtime language: TypeScript with some legacy JavaScript files
+- Data source: WordPress via WPGraphQL
+- Notable dependency state: `next` is declared as `latest`, while `eslint-config-next` is pinned to `14.1.0`
+
+## Router Strategy
+
+- Active router: Pages Router
+- Evidence:
+  - `pages/` directory exists
+  - `app/` directory does not exist
+  - Dynamic routes live in `pages/community/[slug].tsx`, `pages/technology/[slug].tsx`, `pages/tag/[slug].tsx`, and `pages/authors/[slug].tsx`
+- Base path: `/blog` from `next.config.js`
+
+## Top-Level Structure
+
+- `.claude/`: Claude-specific local config; skill directory was absent before this task
+- `.github/`: CI workflows for build, Playwright, Lighthouse, and IndexNow submission
+- `components/`: shared page sections, metadata wrappers, navbar, UI primitives, and content renderers
+- `config/`: navigation and redirect mapping
+- `design-agent/`: separate local agent-related work, not part of app runtime
+- `docs/`: setup screenshots for README and project documentation assets
+- `hooks/`: browser-side hooks such as header scroll and GitHub star count
+- `lib/`: WordPress API client, constants, structured data, shared helpers
+- `lottiefiles/`: animation assets
+- `pages/`: Next.js routes, including API routes and dynamic content routes
+- `public/`: static assets, favicon set, robots, llms files, avatars, and images
+- `services/`: service wrappers such as tweet-related code
+- `styles/`: global CSS
+- `tests/`: Playwright component, page, responsive, and SEO coverage
+- `types/`: shared post, author, and tag types
+- `utils/`: SEO sanitizers, slug cleanup, reading time, and content helpers
+
+## Key Shared Files
+
+- `pages/_app.tsx`: global CSS, page loader, telemetry SDK, route change handling
+- `pages/_document.tsx`: global font loading and organization/blog JSON-LD
+- `components/layout.tsx`: wraps pages, injects metadata, footer, scroll-to-top, analytics, and third-party scripts
+- `components/meta.tsx`: canonical, OG, Twitter, favicon, and structured data tags
+- `lib/api.ts`: WordPress GraphQL fetch layer and shared CMS data helpers
+- `lib/structured-data.ts`: central JSON-LD builders and site URL constants
+- `utils/seo.ts`: title and description sanitization/fallback logic
+- `next.config.js`: basePath, assetPrefix, CSP header, image config, and redirect rules
+- `vercel.json`: deploy-time redirects and headers
+
+## State Management
+
+- No centralized state library detected
+- No Redux, Zustand, React Query, or SWR detected
+- State is mostly local component state with React hooks
+- One local React context exists in `components/ui/collapsible.tsx`
+
+## Data Fetching Pattern
+
+- Primary pattern: `getStaticProps` and `getStaticPaths` for content pages
+- `getServerSideProps` used for `pages/sitemap.xml.tsx`
+- Shared data access through `lib/api.ts`
+- Client-side fetch usage exists for lightweight enhancements such as `hooks/useGithubStars.tsx`
+- Dynamic imports are used for client-only or heavier pieces such as `components/post-body.tsx` and `components/PageLoader`
+
+## Quality Tooling
+
+- ESLint: `.eslintrc.json` extends `next/core-web-vitals`
+- TypeScript: `tsconfig.json` with `strict: false`, `allowJs: true`, and alias `@/*`
+- End-to-end testing: Playwright via `playwright.config.ts`
+- CI quality checks:
+  - build on push and PR
+  - Playwright E2E on push and PR
+  - Lighthouse comparison on PR
+  - IndexNow submission on push and schedule
+- No Vale, markdownlint, or spell-check configuration detected
+
+## Deployment And Hosting
+
+- Deployment target: Vercel
+- Evidence:
+  - `vercel.json`
+  - Vercel-specific headers and redirects
+  - workflow and code comments referencing Vercel Functions and cron behavior
+
+## CI/CD Pipeline
+
+- `.github/workflows/build.yml`: installs dependencies and builds with production-like WordPress env vars
+- `.github/workflows/playwright.yml`: runs Playwright Chromium tests
+- `.github/workflows/lighthouse_runner.yml`: builds PR and main branches, runs Lighthouse against both
+- `.github/workflows/indexnow.yml`: submits recently modified blog URLs to IndexNow on push and schedule
+
+## Project-Specific Conventions And Risks
+
+- SEO is a primary concern; recent history is dominated by meta, sitemap, redirect, and structured-data fixes
+- Metadata is centralized, but pages still set route-local `<Head>` titles in addition to `Layout` and `Meta`
+- The site depends on correct `/blog` base path behavior everywhere
+- WordPress API URL is exposed to the browser as `NEXT_PUBLIC_WORDPRESS_API_URL`; new env exposure should be scrutinized carefully
+- Existing Google Fonts links in `pages/_document.tsx` are legacy baseline, not the preferred pattern for new work
+- The highest-risk regression areas are:
+  - `pages/community/[slug].tsx`
+  - `pages/technology/[slug].tsx`
+  - `components/post-body.tsx`
+  - `lib/api.ts`
+  - `components/meta.tsx`

--- a/.claude/skills/qa-agent/context/hotspots.md
+++ b/.claude/skills/qa-agent/context/hotspots.md
@@ -1,0 +1,103 @@
+# Hotspots
+
+Top 20 most frequently changed files from git history.
+
+1. `pages/community/[slug].tsx`
+   - Commits touching file: 45
+   - Why high-churn: primary community article route with SEO, content rendering, redirects, and fallback logic
+   - Review priority: HIGH
+
+2. `pages/technology/[slug].tsx`
+   - Commits touching file: 44
+   - Why high-churn: primary technology article route with similar metadata, routing, and content complexity
+   - Review priority: HIGH
+
+3. `components/post-body.tsx`
+   - Commits touching file: 40
+   - Why high-churn: shared article body renderer with HTML/content behavior and TOC interactions
+   - Review priority: HIGH
+
+4. `lib/api.ts`
+   - Commits touching file: 38
+   - Why high-churn: central WordPress GraphQL client and shared data contract surface
+   - Review priority: HIGH
+
+5. `components/more-stories.tsx`
+   - Commits touching file: 26
+   - Why high-churn: shared listing component used across route pages and post detail views
+   - Review priority: HIGH
+
+6. `components/layout.tsx`
+   - Commits touching file: 21
+   - Why high-churn: wraps every page and owns scripts, footer, and metadata plumbing
+   - Review priority: HIGH
+
+7. `components/header.tsx`
+   - Commits touching file: 21
+   - Why high-churn: global navigation and reading-progress surface with desktop/mobile variants
+   - Review priority: HIGH
+
+8. `pages/community/index.tsx`
+   - Commits touching file: 20
+   - Why high-churn: category landing page with search, listing, and metadata behavior
+   - Review priority: HIGH
+
+9. `package-lock.json`
+   - Commits touching file: 20
+   - Why high-churn: dependency lockfile changes whenever packages or versions move
+   - Review priority: MEDIUM
+
+10. `styles/index.css`
+    - Commits touching file: 19
+    - Why high-churn: global styling entrypoint with broad blast radius
+    - Review priority: HIGH
+
+11. `pages/technology/index.tsx`
+    - Commits touching file: 19
+    - Why high-churn: technology listing page with metadata and filtering behavior
+    - Review priority: HIGH
+
+12. `components/meta.tsx`
+    - Commits touching file: 19
+    - Why high-churn: central SEO, favicon, canonical, and OG tag component
+    - Review priority: HIGH
+
+13. `pages/index.tsx`
+    - Commits touching file: 18
+    - Why high-churn: homepage metadata and hero/listing composition change frequently
+    - Review priority: HIGH
+
+14. `components/footer.tsx`
+    - Commits touching file: 18
+    - Why high-churn: global footer links and social/navigation references
+    - Review priority: MEDIUM
+
+15. `package.json`
+    - Commits touching file: 16
+    - Why high-churn: script and dependency manifest for build and test tooling
+    - Review priority: MEDIUM
+
+16. `next.config.js`
+    - Commits touching file: 16
+    - Why high-churn: central runtime config for basePath, CSP, redirects, and images
+    - Review priority: HIGH
+
+17. `pages/authors/[slug].tsx`
+    - Commits touching file: 15
+    - Why high-churn: dynamic author page with slug normalization and content mapping
+    - Review priority: HIGH
+
+18. `pages/_document.tsx`
+    - Commits touching file: 13
+    - Why high-churn: global document shell, font loading, and schema injection
+    - Review priority: HIGH
+
+19. `components/postByAuthorMapping.tsx`
+    - Commits touching file: 13
+    - Why high-churn: author-to-post relationship rendering used by author pages
+    - Review priority: MEDIUM
+
+20. `components/post-preview.tsx`
+    - Commits touching file: 13
+    - Why high-churn: shared card component reused across lists and search surfaces
+    - Review priority: MEDIUM

--- a/.claude/skills/qa-agent/context/ignore.md
+++ b/.claude/skills/qa-agent/context/ignore.md
@@ -1,0 +1,49 @@
+# Ignore Rules
+
+Always skip these paths and patterns during QA review unless the user explicitly asks to inspect them:
+
+- `node_modules/`
+- `.next/`
+- `out/`
+- `dist/`
+- `build/`
+- `.git/`
+- `*.min.js`
+- `*.generated.*`
+- `__generated__/`
+- `coverage/`
+- `.cache/`
+
+Build and tooling artifacts from `.gitignore`:
+
+- `.pnp/`
+- `.pnp.js`
+- `.yarn/install-state.gz`
+- `.vercel/`
+- `*.tsbuildinfo`
+- `next-env.d.ts`
+- `.early.coverage`
+- `test-results/`
+- `playwright-report/`
+- `blob-report/`
+- `playwright/.cache/`
+- `playwright/.auth/`
+
+Environment and local-only files:
+
+- `.env`
+- `.env*.local`
+- `.env.test`
+- `*.pem`
+- `.DS_Store`
+- `.idea/`
+
+Project-specific generated or non-review targets discovered during reconnaissance:
+
+- `public/llms.txt`
+- `public/llms-full.txt`
+
+Guidance:
+
+- Skip screenshots, binary assets, and favicon bitmaps unless the change is explicitly about those assets.
+- Do not review files matched by these patterns when computing impact or review scope.

--- a/.claude/skills/qa-agent/context/known-suppressions.md
+++ b/.claude/skills/qa-agent/context/known-suppressions.md
@@ -1,0 +1,26 @@
+# Known Suppressions
+
+## Explicit Suppressions Found
+
+1. `components/TableContents.tsx:73`
+   - Suppression: `eslint-disable-next-line react-hooks/exhaustive-deps`
+   - Context: the effect measures rendered TOC height and attaches a resize listener once; it intentionally avoids dependency churn around refs and setter usage
+   - Reviewer instruction: do not flag this unless the effect behavior changes or the suppression becomes broader than necessary
+
+## TypeScript Ignore-Style Suppressions
+
+- No `@ts-ignore` found in tracked `.ts` or `.tsx` files during reconnaissance
+- No `@ts-expect-error` found in tracked `.ts` or `.tsx` files during reconnaissance
+- No `noinspection` markers found in tracked `.ts` or `.tsx` files during reconnaissance
+
+## Deliberate Pattern Deviations
+
+1. `pages/_document.tsx`
+   - Uses Google Fonts CDN `<link>` tags instead of `next/font`
+   - Treat as legacy baseline; flag only when a change adds more CDN font usage or worsens the pattern
+
+2. Mixed JS and TS codebase
+   - Existing `.jsx` and `.js` files are intentional legacy carryovers in an otherwise TypeScript codebase
+   - Do not flag their mere existence as a violation during review
+
+Instruction: Do not flag these as violations unless the suppression itself is the problem.

--- a/.claude/skills/qa-agent/rules/content.md
+++ b/.claude/skills/qa-agent/rules/content.md
@@ -1,0 +1,32 @@
+# Content Rules
+
+This repo is a blog website. Even though most article content is fetched from WordPress instead of stored locally, review content quality through the rendering, metadata, and test surfaces in this repo.
+
+1. All images must have non-empty, descriptive alt text.
+   - Check React-rendered image usage and any CMS-derived image wrappers.
+
+2. Links must use meaningful text.
+   - Avoid vague text such as `click here`, `read more`, or unlabeled icon-only links without accessible names.
+
+3. No duplicate page titles across major route templates unless intentional.
+   - Review title generation in `components/meta.tsx`, `components/layout.tsx`, `utils/seo.ts`, and route pages.
+
+4. No broken internal anchor links.
+   - This is especially important for TOC and article heading navigation in `components/TableContents.tsx` and `components/post-body.tsx`.
+
+5. Front matter rule equivalence:
+   - For locally stored markdown, require `title` and `description`.
+   - For this repo’s runtime blog pages, require the rendered equivalent through metadata props and structured data.
+
+6. Thin-content warning:
+   - If a page template or rendered post path produces an obviously stub-like experience, flag it as a warning.
+
+7. Code examples should be complete enough to follow or run.
+   - Flag obviously truncated snippets or stub-like ellipses in locally maintained docs or components.
+
+8. Future-dated content should not ship without an explicit draft or preview guard.
+   - This mostly applies to CMS-fed content assumptions and test fixtures in this repo.
+
+9. For this blog site, SEO metadata is a content requirement:
+   - `og:image`, `og:description`, and canonical URL are blocking on production pages.
+   - JSON-LD should remain valid and aligned with visible content.

--- a/.claude/skills/qa-agent/rules/framework.md
+++ b/.claude/skills/qa-agent/rules/framework.md
@@ -1,0 +1,50 @@
+# Framework Rules
+
+Project framework: Next.js Pages Router with TypeScript and a WordPress GraphQL backend.
+
+Review against these repo-specific framework rules:
+
+1. Pages Router only:
+   - Do not introduce App Router-only conventions such as `app/`, `layout.tsx`, `page.tsx`, route segment config, or Server Actions into this repo.
+   - Follow the existing `pages/` structure used by `pages/index.tsx`, `pages/community/[slug].tsx`, and `pages/technology/[slug].tsx`.
+
+2. Metadata must flow through the shared metadata layer:
+   - Route pages should continue to use `components/layout.tsx` and `components/meta.tsx` for canonical, OG, Twitter, and JSON-LD metadata.
+   - Page-local `<Head>` usage is acceptable only for route-specific title overrides like `pages/index.tsx` and `pages/community/[slug].tsx`.
+   - Blocking for blog pages: missing canonical URL, `og:image`, or `og:description`.
+
+3. Internal navigation must use Next primitives:
+   - Use `next/link` for internal navigation.
+   - Use `next/image` for images rendered in React components.
+   - New raw `<img>` tags in page or component code are a blocking issue unless there is a documented technical exception.
+
+4. Dynamic route safety:
+   - Files such as `pages/community/[slug].tsx`, `pages/technology/[slug].tsx`, `pages/tag/[slug].tsx`, and `pages/authors/[slug].tsx` must validate params, handle fallback states, and return `notFound` or a redirect for invalid slugs.
+   - Category and slug mismatches must be guarded the way the existing community and technology routes do.
+
+5. Data fetching must match Pages Router contracts:
+   - `getStaticProps`, `getStaticPaths`, and `getServerSideProps` must return valid Next.js shapes.
+   - New route data loaders should prefer parallel requests with `Promise.all` where independent.
+   - Revalidation values should be explicit for cached content routes.
+
+6. API routes must validate input and restrict side effects:
+   - Query params must be parsed and validated before use.
+   - Allowlists are required for external proxying, following `pages/api/proxy-image.ts`.
+   - Preview and mutation-like endpoints must verify secrets or auth, following `pages/api/preview.ts`.
+
+7. SEO and structured data are part of framework correctness here:
+   - Changes touching `components/meta.tsx`, `components/layout.tsx`, `lib/structured-data.ts`, `utils/seo.ts`, `pages/_document.tsx`, or `pages/sitemap.xml.tsx` require careful cross-file review.
+   - Structured data should come from `lib/structured-data.ts`, not ad hoc inline objects scattered across pages.
+
+8. Base path awareness:
+   - This site runs under `/blog` via `next.config.js`.
+   - Review links, redirects, sitemap output, asset URLs, and Playwright navigation for base-path correctness.
+
+9. Font handling:
+   - Existing Google Fonts `<link>` tags in `pages/_document.tsx` are a known legacy pattern.
+   - Do not re-flag them unless a change expands or duplicates the pattern.
+   - For new font additions, prefer self-hosting or `next/font` where feasible.
+
+10. Runtime config exposure:
+   - `next.config.js` currently mirrors `WORDPRESS_API_URL` into `NEXT_PUBLIC_WORDPRESS_API_URL`.
+   - Do not expose new server-only secrets through `env` or client bundles.

--- a/.claude/skills/qa-agent/rules/performance.md
+++ b/.claude/skills/qa-agent/rules/performance.md
@@ -1,0 +1,39 @@
+# Performance Rules
+
+1. No synchronous file I/O in request handlers, API routes, or build-time hot paths.
+
+2. `useEffect` that fetches data should guard against stale updates.
+   - Use aborting, cancellation, or mount guards for longer-lived async work.
+   - Lightweight fire-and-forget fetches such as `hooks/useGithubStars.tsx` should still handle failures quietly and avoid repeated refetches.
+
+3. Consider `React.memo` for components rendered repeatedly in lists when they receive complex object props and profile as hot.
+   - Do not add it blindly.
+
+4. Do not use anonymous functions as default props in shared components.
+
+5. Prefer dynamic imports for heavy client-only components.
+   - Existing examples: `components/PageLoader` in `pages/_app.tsx` and `components/post-body` in `pages/community/[slug].tsx`.
+   - Review new heavy editors, animations, or diff viewers for lazy loading opportunities.
+
+6. Do not import whole utility libraries when named imports will do.
+   - Avoid whole-package `lodash` or large `date-fns` entrypoints.
+
+7. Images above the fold must declare stable sizing.
+   - Missing width and height, or missing `fill`, is blocking if it can trigger layout shift.
+
+8. No blocking third-party scripts in `<head>`.
+   - Use `next/script` with an appropriate strategy, following `components/layout.tsx` and `pages/_app.tsx`.
+
+9. Prefer `Promise.all()` for independent async calls.
+   - This is especially relevant in route data fetching and API aggregation.
+
+10. Broad shared files deserve extra scrutiny:
+    - `lib/api.ts`
+    - `components/post-body.tsx`
+    - `components/layout.tsx`
+    - `components/meta.tsx`
+    - `pages/community/[slug].tsx`
+    - `pages/technology/[slug].tsx`
+
+11. Base path regressions are performance bugs too:
+    - broken asset URLs under `/blog` often show up as failed requests and layout flashes.

--- a/.claude/skills/qa-agent/rules/security.md
+++ b/.claude/skills/qa-agent/rules/security.md
@@ -1,0 +1,32 @@
+# Security Rules
+
+1. No hardcoded secrets, API keys, tokens, passwords, or bearer secrets in committed source, config, workflows, or tests.
+
+2. `NEXT_PUBLIC_` variables must be truly public.
+   - Never expose credentials, refresh tokens, preview secrets, or admin-only endpoints to the client.
+   - Review `next.config.js`, `pages/_app.tsx`, and any client-side fetch code carefully.
+
+3. `dangerouslySetInnerHTML` requires trusted or sanitized content.
+   - JSON-LD script injection in `components/meta.tsx`, `components/layout.tsx`, and `pages/_document.tsx` is acceptable because it serializes locally constructed objects.
+   - Any HTML derived from user or CMS content must be sanitized or tightly controlled before injection.
+
+4. No `eval()` or `new Function()` usage.
+
+5. Redirect targets and external proxy URLs must be allowlisted.
+   - Follow the validation pattern in `pages/api/proxy-image.ts`.
+   - Preview redirects must not trust arbitrary request targets, following `pages/api/preview.ts`.
+
+6. Cookies or preview tokens carrying auth state must use secure framework helpers or secure flags where applicable.
+
+7. No SQL or query string interpolation into backend databases or remote admin APIs.
+   - If a new data store is added, use parameterized queries only.
+
+8. File uploads or fetched blobs must be validated server-side for type and size before use or storage.
+
+9. No `console.log` of user data, secrets, auth tokens, or raw API errors that might include sensitive payloads.
+
+10. Client-side `fetch()` calls must not expose server-only credentials.
+    - Review `hooks/`, `components/`, and `pages/` for accidental leakage.
+
+11. External script additions require justification and least privilege.
+    - This repo already loads analytics and telemetry scripts in `components/layout.tsx` and `pages/_app.tsx`; new additions should be treated as a security and performance decision.

--- a/.claude/skills/qa-agent/rules/typescript.md
+++ b/.claude/skills/qa-agent/rules/typescript.md
@@ -1,0 +1,31 @@
+# TypeScript Rules
+
+This repo uses TypeScript with `strict: false`, `allowJs: true`, and the `@/*` path alias from `tsconfig.json`. Review new code to a higher standard than the current baseline.
+
+1. No `any` in new or changed code.
+   - Use `unknown` plus narrowing, or define real interfaces and response types.
+   - Be especially strict in shared files such as `lib/api.ts`, `components/layout.tsx`, and route props.
+
+2. No non-null assertions (`!`) without an inline comment explaining why the value is guaranteed.
+
+3. No `@ts-ignore`.
+   - Prefer `@ts-expect-error` with a reason.
+   - If an ignore-style suppression appears, treat it as a warning unless it is already documented in `context/known-suppressions.md`.
+
+4. All exported functions should declare explicit return types.
+   - This matters most in `lib/`, `utils/`, `hooks/`, and `pages/api/`.
+
+5. Do not cast external data with `as Type` without validation.
+   - WordPress GraphQL responses, environment variables, request query values, and JSON payloads must be checked before being trusted.
+
+6. Prefer string literal unions over enums for UI and route state unless an enum provides a clear runtime benefit.
+
+7. Do not accept implicit `any` from untyped packages.
+   - Add `@types/*` or a local declaration when needed.
+
+8. Generic parameters should be descriptive when the abstraction is non-trivial.
+   - `T` is acceptable for a tiny generic helper.
+   - For larger abstractions, prefer names like `TPost`, `TResponse`, or `TNode`.
+
+9. Mixed JS and TS is allowed in this repo, but new shared logic should prefer `.ts` or `.tsx`.
+   - Existing JS files such as `components/author-description.jsx`, `components/waitlistBanner.jsx`, and `tests/mock-server.js` are legacy patterns, not the preferred default.

--- a/.claude/skills/qa-agent/templates/report.md
+++ b/.claude/skills/qa-agent/templates/report.md
@@ -1,0 +1,60 @@
+# QA Review — [filename or "Full Codebase"] — [date]
+
+## Summary
+
+| Severity | Count |
+| --- | --- |
+| 🔴 Blocking | [N] |
+| 🟡 Warning | [N] |
+| 🔵 Suggestion | [N] |
+| ⚪ Nitpick | [N] |
+
+Files reviewed: [N]  
+Files impacted (cross-file): [N]  
+Skipped (auto-generated/ignored): [N]
+
+## 🔴 Blocking — Must fix before merge
+
+[File path] — Line [N]  
+Rule: [rule name from rules/*.md]  
+What: [one sentence]  
+Why: [one sentence on impact]  
+Fix:  
+[exact code fix or instructions]
+
+## 🟡 Warnings — Should fix soon
+
+[File path] — Line [N]  
+Rule: [rule name from rules/*.md]  
+What: [one sentence]  
+Why: [one sentence on impact]  
+Fix:  
+[exact code fix or instructions]
+
+## 🔵 Suggestions — Improve quality
+
+[File path] — Line [N]  
+Rule: [rule name from rules/*.md]  
+What: [one sentence]  
+Why: [one sentence on impact]  
+Fix:  
+[exact code fix or instructions]
+
+## ⚪ Nitpicks — Optional
+
+[File path] — Line [N]  
+Rule: [rule name from rules/*.md]  
+What: [one sentence]  
+Why: [one sentence on impact]  
+Fix:  
+[exact code fix or instructions]
+
+## Cross-file impact map
+
+Files changed: [list]  
+Impacted dependents: [list with relationship type]  
+Config files referencing changed files: [list]
+
+## What was NOT reviewed
+
+[list any skipped files and why]


### PR DESCRIPTION
Adds a repo-aware `/qa-agent` skill to the devrel-team repo, covering all three Keploy repositories. Install once, works everywhere.

## How It Works

A router detects the active repo via `git remote get-url origin` and loads the matching skill. Each repo's skill fans work out to three parallel subagents  dependency mapper, impact tracer, QA reviewer — then merges results into a timestamped report written to `qa-reports/` inside the target repo.

## What's In The Box

```
qa-agents/
├── SKILL.md                     ← router
└── references/
    ├── keploy-docs/            
    ├── keploy-landing/        
    └── keploy-blog/           
```

Each repo folder contains:

- `SKILL.md` - orchestrator with argument parsing (`--diff`, `--full`, `--hotspots`, filepath)
- `agents/` - codebase-explorer, impact-tracer, qa-reviewer
- `rules/` - framework, security, performance, content, typescript (+ seo for docs)
- `checklists/` - pr-review, accessibility, seo
- `context/` - codebase-map, hotspots, known-suppressions, ignore
- `templates/` - report.md

## Install

```bash
./install-qa.sh        # installs qa-agent
./install.sh           # installs design-agent (separate)
```

## Usage

```bash
/qa-agent              # reviews git diff HEAD, falls back to recent files
/qa-agent --diff       # changed files only
/qa-agent --hotspots   # top churn files only
/qa-agent --full       # entire codebase
/qa-agent path/to/file # targeted review + impact tracing
```
