### PR TITLE
docs(community-slug): correct "SSR-friendly" comment — PostBody is ssr:false

### DIFF
--- a/pages/community/[slug].tsx
+++ b/pages/community/[slug].tsx
@@ -35,8 +35,15 @@ const PostBody = dynamic(() => import("../../components/post-body"), {
 });
 
 // Apply all HTML transformations in one synchronous pass so the
-// transformed content is available at render time (SSR-friendly) and
-// no useEffect/setState round-trip is needed:
+// transformed content is ready on React's first client commit — no
+// useState/useEffect round-trip, no extra re-render after hydration.
+//
+// This only affects the *first client render*, not the SSR HTML.
+// PostBody is imported via dynamic(..., { ssr: false }), so its
+// content is never present in the server-rendered payload that
+// crawlers receive. The benefit of computing the transform up-front
+// is purely client-side: no wasted render pass between hydration
+// and the effect-driven state update that previously set updatedContent.
 //   1. Wrap every <table> in <div class="overflow-x-auto"> so wide
 //      tables scroll horizontally on narrow screens instead of
 //      breaking the page layout.


### PR DESCRIPTION
## Summary

Follow-up to merged PR #373. Fixes the incorrect comment wording Copilot flagged after merge.

The comment above `transformPostContent()` in `pages/community/[slug].tsx` described the synchronous transform as "SSR-friendly" and claimed it kept the "SSR HTML correct." That was wrong — `PostBody` is imported via `dynamic(..., { ssr: false })`, so its content is never in the server-rendered HTML that crawlers receive.

Rewrote the comment block to reflect what the transform actually does:
- Runs during React's first *client* render (post-hydration), not SSR
- Benefit: no wasted render pass between hydration and an effect-driven state update — the old `useEffect(..., setUpdatedContent)` pattern caused exactly that
- Crawlers don't see the post body at all on this route; the PostHeader (author + reviewer + title) is the only schema-bearing SSR content here

Comment-only change. Zero behaviour impact.

## Test plan
- [x] `git diff` shows only comment text changed
- [x] `transformPostContent()` logic unchanged; PostBody call site unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)