### PR TITLE
fix(footer): correct Twitter/X handle to official @keploy account

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -75,7 +75,8 @@ export default function Footer() {
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-gray-500 hover:text-gray-500 transition-colors"
-                href="https://x.com/Keployio"
+                href="https://x.com/keploy"
+                aria-label="Keploy on Twitter / X"
               >
                 <span className="sr-only">Twitter</span>
                 <svg


### PR DESCRIPTION
## Summary
Fixes keploy/keploy#3622 — footer X/Twitter link redirected to a non-existent \`@Keployio\` account.

## Problem
\`components/footer.tsx\` pointed the Twitter icon to \`https://x.com/Keployio\`. Keploy's official X profile (linked from keploy.io) is \`twitter.com/keploy\`.

## Fix
- Change \`href\` to \`https://x.com/keploy\`
- Add \`aria-label\` so screen readers announce it consistently with the other social icons (LinkedIn, YouTube, etc. already have implicit labels via \`sr-only\` spans; this normalizes the Twitter case)

## Test plan
- [x] Manual — click the X/Twitter icon in footer → lands on Keploy's real X profile.
- [x] Keyboard: Tab to the link, screen reader reads "Keploy on Twitter / X".