### PR TITLE
feat: add anouncement bar ui and update for gittogether

### DIFF
--- a/components/Announcements.tsx
+++ b/components/Announcements.tsx
@@ -18,6 +18,8 @@ const setAnnouncementHeight = (value: string) => {
   document.documentElement.style.setProperty("--announcement-h", value);
 };
 
+const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
 function MarqueeContent() {
   const items = [
     "Keploy is hosting a community meetup in San Francisco!",
@@ -57,9 +59,9 @@ export function Announcements() {
     setIsVisible(true);
   }, []);
 
-  // useLayoutEffect so --announcement-h is written before the browser paints,
+  // useLayoutEffect on the client so --announcement-h is written before paint,
   // preventing the one-frame flicker where the bar is visible but offsets are still 0.
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (!isVisible || !containerRef.current) {
       setAnnouncementHeight("0px");
       return;
@@ -143,7 +145,7 @@ export function Announcements() {
   return (
     <div
       ref={containerRef}
-      role="banner"
+      role="region"
       aria-label="Event announcement"
       className="fixed inset-x-0 top-0 z-[60] border-b border-white/40 bg-cover bg-center bg-no-repeat shadow-[0_12px_30px_rgba(234,88,12,0.16)] backdrop-blur"
       onTouchStart={handleTouchStart}

--- a/components/Announcements.tsx
+++ b/components/Announcements.tsx
@@ -103,8 +103,16 @@ export function Announcements() {
   }, []);
 
   const handleDismiss = () => {
+    if (dismissTimerRef.current !== null) {
+      clearTimeout(dismissTimerRef.current);
+      dismissTimerRef.current = null;
+    }
+
     // Reset height immediately so the header/nav offsets collapse on the same frame.
     setAnnouncementHeight("0px");
+    setDismissing(false);
+    setDragY(0);
+    touchStartY.current = null;
     setIsVisible(false);
   };
 

--- a/components/Announcements.tsx
+++ b/components/Announcements.tsx
@@ -24,7 +24,7 @@ function MarqueeContent() {
   const items = [
     "Keploy is hosting a community meetup in San Francisco!",
     "GitTogether SF • May 14, 2026 • San Francisco",
-    "Tickets are selling fast, limited seats available register now!",
+    "Tickets are selling fast, limited seats available-register now!",
   ];
 
   return (

--- a/components/Announcements.tsx
+++ b/components/Announcements.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { ArrowRight, X } from "lucide-react";
+import { Marquee } from "./Marquee";
+
+const ANNOUNCEMENT_ENABLED = true;
+
+const ANNOUNCEMENT = {
+  enabled: ANNOUNCEMENT_ENABLED,
+  storageKey: "keploy_announcement_gittogether_sf_may_14_2026",
+  eyebrow: "Registrations LIVE",
+  href: "https://luma.com/lr79szro",
+  ctaLabel: "Register Now",
+};
+
+const setAnnouncementHeight = (value: string) => {
+  document.documentElement.style.setProperty("--announcement-h", value);
+};
+
+function MarqueeContent() {
+  const items = [
+    "Keploy is hosting a community meetup in San Francisco!",
+    "GitTogether SF • May 14, 2026 • San Francisco",
+    "Tickets are selling fast, limited seats available register now!",
+  ];
+
+  return (
+    <>
+      {items.map((item) => (
+        <span
+          key={item}
+          className="inline-flex items-center gap-3 whitespace-nowrap text-[12px] text-[#23120a] sm:text-[13px] lg:text-[14px]"
+        >
+          <span
+            className={
+              item.includes("community meetup")
+                ? "font-semibold"
+                : item.includes("limited seats")
+                ? "font-normal text-[#3f1807]"
+                : "font-normal"
+            }
+          >
+            {item}
+          </span>
+          <span className="text-[15px] font-semibold text-[#23120a]/45">|</span>
+        </span>
+      ))}
+    </>
+  );
+}
+
+export function Announcements() {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [isVisible, setIsVisible] = useState(false);
+  const [isMarqueePaused, setIsMarqueePaused] = useState(false);
+
+  useEffect(() => {
+    if (!ANNOUNCEMENT.enabled) {
+      setAnnouncementHeight("0px");
+      return;
+    }
+
+    try {
+      setIsVisible(!localStorage.getItem(ANNOUNCEMENT.storageKey));
+    } catch {
+      setIsVisible(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isVisible || !containerRef.current) {
+      setAnnouncementHeight("0px");
+      return;
+    }
+
+    const node = containerRef.current;
+    const syncHeight = () => setAnnouncementHeight(`${node.offsetHeight}px`);
+
+    syncHeight();
+
+    const resizeObserver = new ResizeObserver(syncHeight);
+    resizeObserver.observe(node);
+    window.addEventListener("resize", syncHeight);
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener("resize", syncHeight);
+    };
+  }, [isVisible]);
+
+  const handleDismiss = () => {
+    setIsVisible(false);
+
+    try {
+      localStorage.setItem(ANNOUNCEMENT.storageKey, "dismissed");
+    } catch {
+      // Ignore storage failures and just close for this session.
+    }
+  };
+
+  if (!ANNOUNCEMENT.enabled || !isVisible) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      role="banner"
+      aria-label="Event announcement"
+      className="fixed inset-x-0 top-0 z-[60] border-b border-white/40 bg-cover bg-center bg-no-repeat shadow-[0_12px_30px_rgba(234,88,12,0.16)] backdrop-blur"
+      style={{ backgroundImage: "url('https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/announcement-bar-bg.webp')" }}
+    >
+      <div aria-hidden="true" className="pointer-events-none absolute inset-0 bg-white/10" />
+
+      <div className="relative mx-auto max-w-[1440px] px-3 pt-1 pb-2 pr-14 sm:px-5 lg:px-12 lg:py-1.5">
+        {/* Mobile layout */}
+        <div className="flex w-full flex-col gap-2 lg:hidden">
+          <div
+            onMouseEnter={() => setIsMarqueePaused(true)}
+            onMouseLeave={() => setIsMarqueePaused(false)}
+            onPointerEnter={() => setIsMarqueePaused(true)}
+            onPointerLeave={() => setIsMarqueePaused(false)}
+            className="min-w-0"
+          >
+            <Marquee
+              paused={isMarqueePaused}
+              repeat={10}
+              className="max-w-full px-0 py-0 [--duration:30s] [--gap:1.25rem]"
+            >
+              <MarqueeContent />
+            </Marquee>
+          </div>
+
+          <div className="grid w-full grid-cols-2 gap-2 pr-1">
+            <span className="inline-flex h-7 w-full items-center justify-center gap-2 rounded-full border border-white/50 bg-white/20 px-3 text-[9px] font-semibold tracking-[0.08em] leading-none text-[#b43b15] shadow-[inset_0_1px_0_rgba(255,255,255,0.6)] backdrop-blur-sm">
+              <span className="relative flex h-2.5 w-2.5">
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-500/75" />
+                <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-red-500" />
+              </span>
+              {ANNOUNCEMENT.eyebrow}
+            </span>
+
+            <Link
+              href={ANNOUNCEMENT.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex h-7 w-full items-center justify-center gap-1.5 rounded-full border border-black/90 bg-black px-3 text-[11px] font-semibold text-white shadow-[0_10px_26px_rgba(0,0,0,0.28)] transition hover:-translate-y-0.5 hover:bg-[#141414] hover:shadow-[0_14px_30px_rgba(0,0,0,0.36)]"
+            >
+              <span>{ANNOUNCEMENT.ctaLabel}</span>
+              <ArrowRight className="h-3 w-3" />
+            </Link>
+          </div>
+        </div>
+
+        {/* Desktop layout */}
+        <div className="hidden min-w-0 items-center gap-4 lg:flex">
+          <span className="inline-flex h-8 shrink-0 items-center justify-center gap-2 rounded-full border border-white/50 bg-white/20 px-4 text-[10px] font-semibold tracking-[0.08em] leading-none text-[#b43b15] shadow-[inset_0_1px_0_rgba(255,255,255,0.6)] backdrop-blur-sm">
+            <span className="relative flex h-2.5 w-2.5">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-500/75" />
+              <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-red-500" />
+            </span>
+            {ANNOUNCEMENT.eyebrow}
+          </span>
+
+          <div
+            className="min-w-0 flex-1"
+            onMouseEnter={() => setIsMarqueePaused(true)}
+            onMouseLeave={() => setIsMarqueePaused(false)}
+            onPointerEnter={() => setIsMarqueePaused(true)}
+            onPointerLeave={() => setIsMarqueePaused(false)}
+          >
+            <Marquee
+              paused={isMarqueePaused}
+              repeat={10}
+              className="max-w-full px-0 py-0 [--duration:35s] [--gap:1.5rem]"
+            >
+              <MarqueeContent />
+            </Marquee>
+          </div>
+
+          <Link
+            href={ANNOUNCEMENT.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-full border border-black/90 bg-black px-4 text-[13px] font-semibold text-white shadow-[0_12px_28px_rgba(0,0,0,0.28)] transition hover:-translate-y-0.5 hover:bg-[#141414] hover:shadow-[0_16px_34px_rgba(0,0,0,0.36)]"
+          >
+            <span>{ANNOUNCEMENT.ctaLabel}</span>
+            <ArrowRight className="h-3.5 w-3.5" />
+          </Link>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={handleDismiss}
+        aria-label="Dismiss announcement"
+        className="absolute right-3 top-1/2 inline-flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full border border-white/75 bg-white/18 text-[#6f2b00] transition hover:bg-white/30 lg:right-4"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/components/Announcements.tsx
+++ b/components/Announcements.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { ArrowRight, X } from "lucide-react";
 import { Marquee } from "./Marquee";
@@ -43,6 +43,7 @@ function MarqueeContent() {
 export function Announcements() {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const touchStartY = useRef<number | null>(null);
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [isVisible, setIsVisible] = useState(false);
   const [isMarqueePaused, setIsMarqueePaused] = useState(false);
   const [dragY, setDragY] = useState(0);
@@ -56,7 +57,9 @@ export function Announcements() {
     setIsVisible(true);
   }, []);
 
-  useEffect(() => {
+  // useLayoutEffect so --announcement-h is written before the browser paints,
+  // preventing the one-frame flicker where the bar is visible but offsets are still 0.
+  useLayoutEffect(() => {
     if (!isVisible || !containerRef.current) {
       setAnnouncementHeight("0px");
       return;
@@ -65,19 +68,43 @@ export function Announcements() {
     const node = containerRef.current;
     const syncHeight = () => setAnnouncementHeight(`${node.offsetHeight}px`);
 
+    // rAF-debounced handler so rapid resize events collapse into a single measurement.
+    let animationFrameId: number | null = null;
+    const scheduleSyncHeight = () => {
+      if (animationFrameId !== null) window.cancelAnimationFrame(animationFrameId);
+      animationFrameId = window.requestAnimationFrame(() => {
+        animationFrameId = null;
+        syncHeight();
+      });
+    };
+
     syncHeight();
 
-    const resizeObserver = new ResizeObserver(syncHeight);
-    resizeObserver.observe(node);
-    window.addEventListener("resize", syncHeight);
+    // ResizeObserver is widely supported but guard for SSR / older environments.
+    let resizeObserver: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== "undefined") {
+      resizeObserver = new ResizeObserver(scheduleSyncHeight);
+      resizeObserver.observe(node);
+    }
+    window.addEventListener("resize", scheduleSyncHeight);
 
     return () => {
-      resizeObserver.disconnect();
-      window.removeEventListener("resize", syncHeight);
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", scheduleSyncHeight);
+      if (animationFrameId !== null) window.cancelAnimationFrame(animationFrameId);
     };
   }, [isVisible]);
 
+  // Clear the swipe-dismiss timer if the component unmounts mid-animation.
+  useEffect(() => {
+    return () => {
+      if (dismissTimerRef.current !== null) clearTimeout(dismissTimerRef.current);
+    };
+  }, []);
+
   const handleDismiss = () => {
+    // Reset height immediately so the header/nav offsets collapse on the same frame.
+    setAnnouncementHeight("0px");
     setIsVisible(false);
   };
 
@@ -94,7 +121,7 @@ export function Announcements() {
   const handleTouchEnd = () => {
     if (dragY < -50) {
       setDismissing(true);
-      setTimeout(handleDismiss, 220);
+      dismissTimerRef.current = setTimeout(handleDismiss, 220);
     } else {
       setDragY(0);
     }
@@ -123,7 +150,7 @@ export function Announcements() {
     >
       <div aria-hidden="true" className="pointer-events-none absolute inset-0 bg-white/10" />
 
-      <div className="relative mx-auto max-w-[1440px] px-3 py-1 sm:px-5 sm:pr-12 lg:px-12 lg:py-1.5">
+      <div className="relative mx-auto max-w-[1440px] pl-3 pr-12 py-1 sm:px-5 sm:pr-12 lg:px-12 lg:py-1.5">
         {/* Mobile: single row — marquee + compact CTA. Swipe up to dismiss. */}
         <div className="flex min-w-0 items-center gap-2 lg:hidden">
           <div
@@ -199,7 +226,7 @@ export function Announcements() {
         type="button"
         onClick={handleDismiss}
         aria-label="Dismiss announcement"
-        className="absolute right-3 top-1/2 hidden h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full border border-white/75 bg-white/18 text-[#6f2b00] transition hover:bg-white/30 lg:right-4 lg:inline-flex"
+        className="absolute right-3 top-1/2 inline-flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full border border-white/75 bg-white/18 text-[#6f2b00] transition hover:bg-white/30 lg:right-4"
       >
         <X className="h-4 w-4" />
       </button>

--- a/components/Announcements.tsx
+++ b/components/Announcements.tsx
@@ -9,10 +9,9 @@ const ANNOUNCEMENT_ENABLED = true;
 
 const ANNOUNCEMENT = {
   enabled: ANNOUNCEMENT_ENABLED,
-  storageKey: "keploy_announcement_gittogether_sf_may_14_2026",
-  eyebrow: "Registrations LIVE",
+  eyebrow: "Event LIVE",
   href: "https://luma.com/lr79szro",
-  ctaLabel: "Register Now",
+  ctaLabel: "Register NOW",
 };
 
 const setAnnouncementHeight = (value: string) => {
@@ -33,18 +32,8 @@ function MarqueeContent() {
           key={item}
           className="inline-flex items-center gap-3 whitespace-nowrap text-[12px] text-[#23120a] sm:text-[13px] lg:text-[14px]"
         >
-          <span
-            className={
-              item.includes("community meetup")
-                ? "font-semibold"
-                : item.includes("limited seats")
-                ? "font-normal text-[#3f1807]"
-                : "font-normal"
-            }
-          >
-            {item}
-          </span>
-          <span className="text-[15px] font-semibold text-[#23120a]/45">|</span>
+          <span className="font-semibold">{item}</span>
+          <span className="inline-block h-[5px] w-[5px] shrink-0 rounded-full bg-[#23120a]/35" />
         </span>
       ))}
     </>
@@ -53,20 +42,18 @@ function MarqueeContent() {
 
 export function Announcements() {
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const touchStartY = useRef<number | null>(null);
   const [isVisible, setIsVisible] = useState(false);
   const [isMarqueePaused, setIsMarqueePaused] = useState(false);
+  const [dragY, setDragY] = useState(0);
+  const [dismissing, setDismissing] = useState(false);
 
   useEffect(() => {
     if (!ANNOUNCEMENT.enabled) {
       setAnnouncementHeight("0px");
       return;
     }
-
-    try {
-      setIsVisible(!localStorage.getItem(ANNOUNCEMENT.storageKey));
-    } catch {
-      setIsVisible(true);
-    }
+    setIsVisible(true);
   }, []);
 
   useEffect(() => {
@@ -92,12 +79,26 @@ export function Announcements() {
 
   const handleDismiss = () => {
     setIsVisible(false);
+  };
 
-    try {
-      localStorage.setItem(ANNOUNCEMENT.storageKey, "dismissed");
-    } catch {
-      // Ignore storage failures and just close for this session.
+  const handleTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
+    touchStartY.current = e.touches[0].clientY;
+  };
+
+  const handleTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
+    if (touchStartY.current === null) return;
+    const dy = e.touches[0].clientY - touchStartY.current;
+    if (dy < 0) setDragY(dy);
+  };
+
+  const handleTouchEnd = () => {
+    if (dragY < -50) {
+      setDismissing(true);
+      setTimeout(handleDismiss, 220);
+    } else {
+      setDragY(0);
     }
+    touchStartY.current = null;
   };
 
   if (!ANNOUNCEMENT.enabled || !isVisible) {
@@ -110,56 +111,56 @@ export function Announcements() {
       role="banner"
       aria-label="Event announcement"
       className="fixed inset-x-0 top-0 z-[60] border-b border-white/40 bg-cover bg-center bg-no-repeat shadow-[0_12px_30px_rgba(234,88,12,0.16)] backdrop-blur"
-      style={{ backgroundImage: "url('https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/announcement-bar-bg.webp')" }}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+      style={{
+        backgroundImage: "url('https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/announcement-bar-bg.webp')",
+        transform: dismissing ? "translateY(-110%)" : dragY < 0 ? `translateY(${dragY}px)` : undefined,
+        opacity: dismissing ? 0 : dragY < 0 ? Math.max(0.15, 1 + dragY / 60) : undefined,
+        transition: dragY !== 0 && !dismissing ? "none" : "transform 0.22s ease, opacity 0.18s ease",
+      }}
     >
       <div aria-hidden="true" className="pointer-events-none absolute inset-0 bg-white/10" />
 
-      <div className="relative mx-auto max-w-[1440px] px-3 pt-1 pb-2 pr-14 sm:px-5 lg:px-12 lg:py-1.5">
-        {/* Mobile layout */}
-        <div className="flex w-full flex-col gap-2 lg:hidden">
+      <div className="relative mx-auto max-w-[1440px] px-3 py-1 sm:px-5 sm:pr-12 lg:px-12 lg:py-1.5">
+        {/* Mobile: single row — marquee + compact CTA. Swipe up to dismiss. */}
+        <div className="flex min-w-0 items-center gap-2 lg:hidden">
           <div
             onMouseEnter={() => setIsMarqueePaused(true)}
             onMouseLeave={() => setIsMarqueePaused(false)}
             onPointerEnter={() => setIsMarqueePaused(true)}
             onPointerLeave={() => setIsMarqueePaused(false)}
-            className="min-w-0"
+            className="min-w-0 flex-1 overflow-hidden"
           >
             <Marquee
               paused={isMarqueePaused}
               repeat={10}
-              className="max-w-full px-0 py-0 [--duration:30s] [--gap:1.25rem]"
+              className="max-w-full px-0 py-0 [--duration:25s] [--gap:1.25rem]"
             >
               <MarqueeContent />
             </Marquee>
           </div>
 
-          <div className="grid w-full grid-cols-2 gap-2 pr-1">
-            <span className="inline-flex h-7 w-full items-center justify-center gap-2 rounded-full border border-white/50 bg-white/20 px-3 text-[9px] font-semibold tracking-[0.08em] leading-none text-[#b43b15] shadow-[inset_0_1px_0_rgba(255,255,255,0.6)] backdrop-blur-sm">
-              <span className="relative flex h-2.5 w-2.5">
-                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-500/75" />
-                <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-red-500" />
-              </span>
-              {ANNOUNCEMENT.eyebrow}
+          <Link
+            href={ANNOUNCEMENT.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group shrink-0 inline-flex h-6 items-center gap-1 rounded-full border border-black/90 bg-black px-2.5 text-[10px] font-semibold text-white transition hover:bg-[#0a0a0a]"
+          >
+            <span className="transition-all group-hover:bg-gradient-to-r group-hover:from-[#39ff14] group-hover:to-[#00f5ff] group-hover:bg-clip-text group-hover:text-transparent">
+              {ANNOUNCEMENT.ctaLabel}
             </span>
-
-            <Link
-              href={ANNOUNCEMENT.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex h-7 w-full items-center justify-center gap-1.5 rounded-full border border-black/90 bg-black px-3 text-[11px] font-semibold text-white shadow-[0_10px_26px_rgba(0,0,0,0.28)] transition hover:-translate-y-0.5 hover:bg-[#141414] hover:shadow-[0_14px_30px_rgba(0,0,0,0.36)]"
-            >
-              <span>{ANNOUNCEMENT.ctaLabel}</span>
-              <ArrowRight className="h-3 w-3" />
-            </Link>
-          </div>
+            <ArrowRight className="h-2.5 w-2.5 transition-colors group-hover:text-[#39ff14]" />
+          </Link>
         </div>
 
         {/* Desktop layout */}
         <div className="hidden min-w-0 items-center gap-4 lg:flex">
-          <span className="inline-flex h-8 shrink-0 items-center justify-center gap-2 rounded-full border border-white/50 bg-white/20 px-4 text-[10px] font-semibold tracking-[0.08em] leading-none text-[#b43b15] shadow-[inset_0_1px_0_rgba(255,255,255,0.6)] backdrop-blur-sm">
+          <span className="inline-flex h-8 shrink-0 items-center justify-center gap-2 rounded-full border border-white/20 bg-black px-4 text-[10px] font-extrabold tracking-[0.08em] leading-none text-white">
             <span className="relative flex h-2.5 w-2.5">
-              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-500/75" />
-              <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-red-500" />
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[#00ff87]/75" />
+              <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-[#00ff87]" />
             </span>
             {ANNOUNCEMENT.eyebrow}
           </span>
@@ -184,10 +185,12 @@ export function Announcements() {
             href={ANNOUNCEMENT.href}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-full border border-black/90 bg-black px-4 text-[13px] font-semibold text-white shadow-[0_12px_28px_rgba(0,0,0,0.28)] transition hover:-translate-y-0.5 hover:bg-[#141414] hover:shadow-[0_16px_34px_rgba(0,0,0,0.36)]"
+            className="group inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-full border border-black/90 bg-black px-4 text-[13px] font-semibold text-white shadow-[0_12px_28px_rgba(0,0,0,0.28)] transition hover:-translate-y-0.5 hover:bg-[#0a0a0a] hover:shadow-[0_16px_34px_rgba(0,0,0,0.36)]"
           >
-            <span>{ANNOUNCEMENT.ctaLabel}</span>
-            <ArrowRight className="h-3.5 w-3.5" />
+            <span className="transition-all group-hover:bg-gradient-to-r group-hover:from-[#39ff14] group-hover:to-[#00f5ff] group-hover:bg-clip-text group-hover:text-transparent">
+              {ANNOUNCEMENT.ctaLabel}
+            </span>
+            <ArrowRight className="h-3.5 w-3.5 transition-colors group-hover:text-[#39ff14]" />
           </Link>
         </div>
       </div>
@@ -196,7 +199,7 @@ export function Announcements() {
         type="button"
         onClick={handleDismiss}
         aria-label="Dismiss announcement"
-        className="absolute right-3 top-1/2 inline-flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full border border-white/75 bg-white/18 text-[#6f2b00] transition hover:bg-white/30 lg:right-4"
+        className="absolute right-3 top-1/2 hidden h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full border border-white/75 bg-white/18 text-[#6f2b00] transition hover:bg-white/30 lg:right-4 lg:inline-flex"
       >
         <X className="h-4 w-4" />
       </button>

--- a/components/Marquee.tsx
+++ b/components/Marquee.tsx
@@ -5,6 +5,7 @@ interface MarqueeProps {
   children?: React.ReactNode;
   vertical?: boolean;
   repeat?: number;
+  paused?: boolean;
   [key: string]: any;
 }
 
@@ -15,6 +16,7 @@ export function Marquee({
   children,
   vertical = false,
   repeat = 4,
+  paused = false,
   ...props
 }: MarqueeProps) {
   return (
@@ -28,6 +30,7 @@ export function Marquee({
           <div
             key={i}
             className={`flex shrink-0 justify-around [gap:var(--gap)] will-change-transform [backface-visibility:hidden] ${vertical ? 'animate-marquee-vertical flex-col' : 'animate-marquee flex-row'} ${pauseOnHover ? 'group-hover:[animation-play-state:paused]' : ''} ${reverse ? '[animation-direction:reverse]' : ''}`}
+            style={{ animationPlayState: paused ? 'paused' : 'running' }}
           >
             {children}
           </div>

--- a/components/Marquee.tsx
+++ b/components/Marquee.tsx
@@ -30,7 +30,7 @@ export function Marquee({
           <div
             key={i}
             className={`flex shrink-0 justify-around [gap:var(--gap)] will-change-transform [backface-visibility:hidden] ${vertical ? 'animate-marquee-vertical flex-col' : 'animate-marquee flex-row'} ${pauseOnHover ? 'group-hover:[animation-play-state:paused]' : ''} ${reverse ? '[animation-direction:reverse]' : ''}`}
-            style={{ animationPlayState: paused ? 'paused' : 'running' }}
+            style={{ animationPlayState: paused ? 'paused' : undefined }}
           >
             {children}
           </div>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -30,9 +30,10 @@ export default function Header({
     <div className="h-28 md:h-32 border-b border-gray-200/50">
       <header
         className={cn(
-          "fixed top-0 left-0 right-0 z-30 w-full transition duration-300 ease-in-out border-none bg-transparent",
+          "fixed left-0 right-0 z-30 w-full transition duration-300 ease-in-out border-none bg-transparent",
           isBlogReadingPage && "bg-white"
         )}
+        style={{ top: "var(--announcement-h, 0px)" }}
       >
         <FloatingNavbar isBlogReadingPage={isBlogReadingPage} />
         {readProgress && (

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -44,7 +44,7 @@ export default function Layout({
         className="min-h-screen animate-[fadeIn_0.3s_ease-out] motion-reduce:animate-none"
       >
         {/* <Alert preview={preview} /> */}
-        <main className="pt-20 md:pt-24">{children}</main>
+        <main className="layout-content-padded">{children}</main>
       </div>
       <Footer />
       <ScrollToTop />

--- a/components/navbar/FloatingNavbar.tsx
+++ b/components/navbar/FloatingNavbar.tsx
@@ -41,7 +41,7 @@ export default function FloatingNavbar({ isBlogReadingPage }: FloatingNavbarProp
 
   const navPositionClasses = derivedBlogReadingPage
     ? "relative top-0 mx-auto z-40"
-    : "fixed top-6 left-1/2 -translate-x-1/2 z-40";
+    : "fixed left-1/2 -translate-x-1/2 z-40";
   const navWidthClasses = isScrolled
     ? "w-[82%] md:max-w-5xl"
     : "w-[96%] md:max-w-6xl";
@@ -61,7 +61,11 @@ export default function FloatingNavbar({ isBlogReadingPage }: FloatingNavbarProp
       : glassNavDefault;
 
   return (
-    <nav data-testid="navbar" className={`${navPositionClasses} transition-all duration-300 ${navWidthClasses}`}>
+    <nav
+      data-testid="navbar"
+      className={`${navPositionClasses} transition-all duration-300 ${navWidthClasses}`}
+      style={derivedBlogReadingPage ? undefined : { top: "calc(var(--announcement-h, 0px) + 1.5rem)" }}
+    >
         <div
           className={`${glassNavBase} ${navGlassClasses} overflow-visible ${navShadowClasses} ${navPaddingClasses}`}
         >

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,6 +6,7 @@ import Script from 'next/script';
 import { useEffect, useState } from "react";
 import dynamic from 'next/dynamic'
 import { trackAiReferral } from '@/utils/aiReferralTracker';
+import { Announcements } from '../components/Announcements';
 
 const PageLoader = dynamic(() => import('../components/PageLoader'), {
   ssr: false,
@@ -46,6 +47,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         data-source="blog"
         strategy="lazyOnload"
       />
+      <Announcements />
       {loading ? <PageLoader /> : <Component {...pageProps} />}
     </>
   );

--- a/styles/index.css
+++ b/styles/index.css
@@ -5,6 +5,22 @@
 
 /* Write your own custom base styles here */
 
+:root {
+  --announcement-h: 0px;
+}
+
+/* Main content padding that accounts for the fixed header + announcement bar.
+   Replaces the static pt-20 md:pt-24 so it adapts when the bar is visible. */
+.layout-content-padded {
+  padding-top: calc(var(--announcement-h) + 5rem);
+}
+
+@media (min-width: 768px) {
+  .layout-content-padded {
+    padding-top: calc(var(--announcement-h) + 6rem);
+  }
+}
+
 /* Start purging... */
 @tailwind components;
 /* Stop purging. */

--- a/tests/components/Announcements.spec.ts
+++ b/tests/components/Announcements.spec.ts
@@ -1,4 +1,35 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
+
+const announcementRegionSelector = '[role="region"][aria-label="Event announcement"]';
+
+const dispatchSyntheticTouch = async (
+  page: Page,
+  selector: string,
+  type: 'touchstart' | 'touchmove' | 'touchend',
+  touches: Array<{ clientX: number; clientY: number }>
+) => {
+  await page.evaluate(
+    ({ targetSelector, eventType, touchPoints }) => {
+      const el = document.querySelector(targetSelector);
+      if (!el) {
+        throw new Error(`Element not found for selector: ${targetSelector}`);
+      }
+
+      const event = new Event(eventType, { bubbles: true, cancelable: true });
+      Object.defineProperty(event, 'touches', {
+        configurable: true,
+        value: touchPoints,
+      });
+      Object.defineProperty(event, 'changedTouches', {
+        configurable: true,
+        value: touchPoints,
+      });
+
+      el.dispatchEvent(event);
+    },
+    { targetSelector: selector, eventType: type, touchPoints: touches }
+  );
+};
 
 test.describe('Announcements — Desktop', () => {
   test.beforeEach(async ({ page, baseURL }) => {
@@ -7,7 +38,7 @@ test.describe('Announcements — Desktop', () => {
   });
 
   test('should render with correct ARIA role and label', async ({ page }) => {
-    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    const banner = page.locator(announcementRegionSelector);
     await expect(banner).toBeVisible({ timeout: 5000 });
   });
 
@@ -47,7 +78,7 @@ test.describe('Announcements — Desktop', () => {
   });
 
   test('should display marquee event text', async ({ page }) => {
-    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    const banner = page.locator(announcementRegionSelector);
     await expect(banner).toBeVisible({ timeout: 5000 });
     await expect(banner).toContainText('GitTogether SF');
     await expect(banner).toContainText('San Francisco');
@@ -56,7 +87,7 @@ test.describe('Announcements — Desktop', () => {
   test('should set --announcement-h CSS variable to a non-zero value when visible', async ({
     page,
   }) => {
-    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    const banner = page.locator(announcementRegionSelector);
     await expect(banner).toBeVisible({ timeout: 5000 });
 
     const announcementH = await page.evaluate(() =>
@@ -69,7 +100,7 @@ test.describe('Announcements — Desktop', () => {
   });
 
   test('should hide the announcement bar when dismiss button is clicked', async ({ page }) => {
-    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    const banner = page.locator(announcementRegionSelector);
     await expect(banner).toBeVisible({ timeout: 5000 });
 
     const dismissBtn = page.locator('button[aria-label="Dismiss announcement"]');
@@ -81,7 +112,7 @@ test.describe('Announcements — Desktop', () => {
   });
 
   test('should set --announcement-h to 0px after dismiss', async ({ page }) => {
-    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    const banner = page.locator(announcementRegionSelector);
     await expect(banner).toBeVisible({ timeout: 5000 });
 
     const dismissBtn = page.locator('button[aria-label="Dismiss announcement"]');
@@ -95,7 +126,7 @@ test.describe('Announcements — Desktop', () => {
   });
 
   test('should be positioned at the top of the page (fixed)', async ({ page }) => {
-    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    const banner = page.locator(announcementRegionSelector);
     await expect(banner).toBeVisible({ timeout: 5000 });
 
     const box = await banner.boundingBox();
@@ -105,7 +136,7 @@ test.describe('Announcements — Desktop', () => {
   });
 
   test('should remain visible after scrolling the page', async ({ page }) => {
-    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    const banner = page.locator(announcementRegionSelector);
     await expect(banner).toBeVisible({ timeout: 5000 });
 
     await page.evaluate(() => window.scrollTo(0, 500));
@@ -117,7 +148,11 @@ test.describe('Announcements — Desktop', () => {
 });
 
 test.describe('Announcements — Mobile', () => {
-  test.use({ viewport: { width: 375, height: 812 } });
+  test.use({
+    viewport: { width: 375, height: 812 },
+    hasTouch: true,
+    isMobile: true,
+  });
 
   test.beforeEach(async ({ page, baseURL }) => {
     await page.goto(baseURL!);
@@ -125,7 +160,7 @@ test.describe('Announcements — Mobile', () => {
   });
 
   test('should render the announcement bar on mobile', async ({ page }) => {
-    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    const banner = page.locator(announcementRegionSelector);
     await expect(banner).toBeVisible({ timeout: 5000 });
   });
 
@@ -137,7 +172,7 @@ test.describe('Announcements — Mobile', () => {
   });
 
   test('should display the compact mobile CTA button', async ({ page }) => {
-    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    const banner = page.locator(announcementRegionSelector);
     await expect(banner).toBeVisible({ timeout: 5000 });
 
     // The mobile CTA link is inside the mobile-only layout (shown below lg)
@@ -149,13 +184,13 @@ test.describe('Announcements — Mobile', () => {
   });
 
   test('should display marquee event text on mobile', async ({ page }) => {
-    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    const banner = page.locator(announcementRegionSelector);
     await expect(banner).toBeVisible({ timeout: 5000 });
     await expect(banner).toContainText('GitTogether SF');
   });
 
   test('should dismiss when swiped up past the threshold', async ({ page }) => {
-    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    const banner = page.locator(announcementRegionSelector);
     await expect(banner).toBeVisible({ timeout: 5000 });
 
     const box = await banner.boundingBox();
@@ -165,33 +200,20 @@ test.describe('Announcements — Mobile', () => {
     const startY = box!.y + box!.height / 2;
 
     // Simulate a swipe-up gesture: start in the banner, move up > 50px, then release
-    await page.touchscreen.tap(centerX, startY);
-    await page.evaluate(
-      ({ cx, sy }) => {
-        const el = document.querySelector('[role="banner"][aria-label="Event announcement"]')!;
-        el.dispatchEvent(
-          new TouchEvent('touchstart', {
-            bubbles: true,
-            touches: [new Touch({ identifier: 1, target: el, clientX: cx, clientY: sy })],
-          }),
-        );
-        el.dispatchEvent(
-          new TouchEvent('touchmove', {
-            bubbles: true,
-            touches: [new Touch({ identifier: 1, target: el, clientX: cx, clientY: sy - 70 })],
-          }),
-        );
-        el.dispatchEvent(new TouchEvent('touchend', { bubbles: true, touches: [] }));
-      },
-      { cx: centerX, sy: startY },
-    );
+    await dispatchSyntheticTouch(page, announcementRegionSelector, 'touchstart', [
+      { clientX: centerX, clientY: startY },
+    ]);
+    await dispatchSyntheticTouch(page, announcementRegionSelector, 'touchmove', [
+      { clientX: centerX, clientY: startY - 70 },
+    ]);
+    await dispatchSyntheticTouch(page, announcementRegionSelector, 'touchend', []);
 
     // After the swipe-up, the bar should animate out (220ms timeout in the component)
     await expect(banner).not.toBeVisible({ timeout: 2000 });
   });
 
   test('should not dismiss when swiped up below the threshold (< 50px)', async ({ page }) => {
-    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    const banner = page.locator(announcementRegionSelector);
     await expect(banner).toBeVisible({ timeout: 5000 });
 
     const box = await banner.boundingBox();
@@ -201,32 +223,20 @@ test.describe('Announcements — Mobile', () => {
     const startY = box!.y + box!.height / 2;
 
     // Swipe up only 20px — below the 50px dismiss threshold
-    await page.evaluate(
-      ({ cx, sy }) => {
-        const el = document.querySelector('[role="banner"][aria-label="Event announcement"]')!;
-        el.dispatchEvent(
-          new TouchEvent('touchstart', {
-            bubbles: true,
-            touches: [new Touch({ identifier: 1, target: el, clientX: cx, clientY: sy })],
-          }),
-        );
-        el.dispatchEvent(
-          new TouchEvent('touchmove', {
-            bubbles: true,
-            touches: [new Touch({ identifier: 1, target: el, clientX: cx, clientY: sy - 20 })],
-          }),
-        );
-        el.dispatchEvent(new TouchEvent('touchend', { bubbles: true, touches: [] }));
-      },
-      { cx: centerX, sy: startY },
-    );
+    await dispatchSyntheticTouch(page, announcementRegionSelector, 'touchstart', [
+      { clientX: centerX, clientY: startY },
+    ]);
+    await dispatchSyntheticTouch(page, announcementRegionSelector, 'touchmove', [
+      { clientX: centerX, clientY: startY - 20 },
+    ]);
+    await dispatchSyntheticTouch(page, announcementRegionSelector, 'touchend', []);
 
     // Bar should still be visible
     await expect(banner).toBeVisible({ timeout: 1000 });
   });
 
   test('should set --announcement-h CSS variable on mobile', async ({ page }) => {
-    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    const banner = page.locator(announcementRegionSelector);
     await expect(banner).toBeVisible({ timeout: 5000 });
 
     const announcementH = await page.evaluate(() =>

--- a/tests/components/Announcements.spec.ts
+++ b/tests/components/Announcements.spec.ts
@@ -1,0 +1,238 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Announcements — Desktop', () => {
+  test.beforeEach(async ({ page, baseURL }) => {
+    await page.goto(baseURL!);
+    await page.waitForLoadState('domcontentloaded');
+  });
+
+  test('should render with correct ARIA role and label', async ({ page }) => {
+    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    await expect(banner).toBeVisible({ timeout: 5000 });
+  });
+
+  test('should display the "Event LIVE" eyebrow badge on desktop', async ({ page }) => {
+    // The eyebrow badge is only shown in the desktop layout (hidden on < lg)
+    const badge = page
+      .locator('.hidden.lg\\:flex span')
+      .filter({ hasText: 'Event LIVE' })
+      .first();
+    await expect(badge).toBeVisible({ timeout: 5000 });
+  });
+
+  test('should display the dismiss button on desktop', async ({ page }) => {
+    const dismissBtn = page.locator('button[aria-label="Dismiss announcement"]');
+    await expect(dismissBtn).toBeVisible({ timeout: 5000 });
+  });
+
+  test('should display the CTA link with correct href', async ({ page }) => {
+    // Both mobile and desktop CTAs share the same href; grab the desktop one
+    const ctaLinks = page.locator('a[href="https://luma.com/lr79szro"]');
+    await expect(ctaLinks.first()).toBeVisible({ timeout: 5000 });
+    const href = await ctaLinks.first().getAttribute('href');
+    expect(href).toBe('https://luma.com/lr79szro');
+  });
+
+  test('should open CTA link in a new tab', async ({ page }) => {
+    const ctaLinks = page.locator('a[href="https://luma.com/lr79szro"]');
+    await expect(ctaLinks.first()).toBeVisible({ timeout: 5000 });
+    expect(await ctaLinks.first().getAttribute('target')).toBe('_blank');
+    expect(await ctaLinks.first().getAttribute('rel')).toContain('noopener');
+  });
+
+  test('should display "Register NOW" CTA label', async ({ page }) => {
+    const ctaLinks = page.locator('a[href="https://luma.com/lr79szro"]');
+    await expect(ctaLinks.first()).toBeVisible({ timeout: 5000 });
+    await expect(ctaLinks.first()).toContainText('Register NOW');
+  });
+
+  test('should display marquee event text', async ({ page }) => {
+    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    await expect(banner).toBeVisible({ timeout: 5000 });
+    await expect(banner).toContainText('GitTogether SF');
+    await expect(banner).toContainText('San Francisco');
+  });
+
+  test('should set --announcement-h CSS variable to a non-zero value when visible', async ({
+    page,
+  }) => {
+    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    await expect(banner).toBeVisible({ timeout: 5000 });
+
+    const announcementH = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue('--announcement-h').trim(),
+    );
+    expect(announcementH).not.toBe('');
+    expect(announcementH).not.toBe('0px');
+    // Should be a pixel value like "40px"
+    expect(announcementH).toMatch(/^\d+(\.\d+)?px$/);
+  });
+
+  test('should hide the announcement bar when dismiss button is clicked', async ({ page }) => {
+    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    await expect(banner).toBeVisible({ timeout: 5000 });
+
+    const dismissBtn = page.locator('button[aria-label="Dismiss announcement"]');
+    await expect(dismissBtn).toBeVisible();
+    await expect(dismissBtn).toBeEnabled();
+    await dismissBtn.click();
+
+    await expect(banner).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('should set --announcement-h to 0px after dismiss', async ({ page }) => {
+    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    await expect(banner).toBeVisible({ timeout: 5000 });
+
+    const dismissBtn = page.locator('button[aria-label="Dismiss announcement"]');
+    await dismissBtn.click();
+    await expect(banner).not.toBeVisible({ timeout: 5000 });
+
+    const announcementH = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue('--announcement-h').trim(),
+    );
+    expect(announcementH).toBe('0px');
+  });
+
+  test('should be positioned at the top of the page (fixed)', async ({ page }) => {
+    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    await expect(banner).toBeVisible({ timeout: 5000 });
+
+    const box = await banner.boundingBox();
+    expect(box).not.toBeNull();
+    // Fixed at top: y should be at or very near 0
+    expect(box!.y).toBeLessThanOrEqual(2);
+  });
+
+  test('should remain visible after scrolling the page', async ({ page }) => {
+    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    await expect(banner).toBeVisible({ timeout: 5000 });
+
+    await page.evaluate(() => window.scrollTo(0, 500));
+
+    await expect(banner).toBeVisible();
+    const box = await banner.boundingBox();
+    expect(box!.y).toBeLessThanOrEqual(2);
+  });
+});
+
+test.describe('Announcements — Mobile', () => {
+  test.use({ viewport: { width: 375, height: 812 } });
+
+  test.beforeEach(async ({ page, baseURL }) => {
+    await page.goto(baseURL!);
+    await page.waitForLoadState('domcontentloaded');
+  });
+
+  test('should render the announcement bar on mobile', async ({ page }) => {
+    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    await expect(banner).toBeVisible({ timeout: 5000 });
+  });
+
+  test('should show the dismiss button on mobile for accessibility', async ({ page }) => {
+    const dismissBtn = page.locator('button[aria-label="Dismiss announcement"]');
+    // Dismiss button is visible on all viewports so keyboard/screen-reader users
+    // can dismiss without relying solely on the swipe gesture.
+    await expect(dismissBtn).toBeVisible({ timeout: 5000 });
+  });
+
+  test('should display the compact mobile CTA button', async ({ page }) => {
+    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    await expect(banner).toBeVisible({ timeout: 5000 });
+
+    // The mobile CTA link is inside the mobile-only layout (shown below lg)
+    const mobileCta = page
+      .locator('.lg\\:hidden a[href="https://luma.com/lr79szro"]')
+      .first();
+    await expect(mobileCta).toBeVisible({ timeout: 5000 });
+    await expect(mobileCta).toContainText('Register NOW');
+  });
+
+  test('should display marquee event text on mobile', async ({ page }) => {
+    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    await expect(banner).toBeVisible({ timeout: 5000 });
+    await expect(banner).toContainText('GitTogether SF');
+  });
+
+  test('should dismiss when swiped up past the threshold', async ({ page }) => {
+    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    await expect(banner).toBeVisible({ timeout: 5000 });
+
+    const box = await banner.boundingBox();
+    expect(box).not.toBeNull();
+
+    const centerX = box!.x + box!.width / 2;
+    const startY = box!.y + box!.height / 2;
+
+    // Simulate a swipe-up gesture: start in the banner, move up > 50px, then release
+    await page.touchscreen.tap(centerX, startY);
+    await page.evaluate(
+      ({ cx, sy }) => {
+        const el = document.querySelector('[role="banner"][aria-label="Event announcement"]')!;
+        el.dispatchEvent(
+          new TouchEvent('touchstart', {
+            bubbles: true,
+            touches: [new Touch({ identifier: 1, target: el, clientX: cx, clientY: sy })],
+          }),
+        );
+        el.dispatchEvent(
+          new TouchEvent('touchmove', {
+            bubbles: true,
+            touches: [new Touch({ identifier: 1, target: el, clientX: cx, clientY: sy - 70 })],
+          }),
+        );
+        el.dispatchEvent(new TouchEvent('touchend', { bubbles: true, touches: [] }));
+      },
+      { cx: centerX, sy: startY },
+    );
+
+    // After the swipe-up, the bar should animate out (220ms timeout in the component)
+    await expect(banner).not.toBeVisible({ timeout: 2000 });
+  });
+
+  test('should not dismiss when swiped up below the threshold (< 50px)', async ({ page }) => {
+    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    await expect(banner).toBeVisible({ timeout: 5000 });
+
+    const box = await banner.boundingBox();
+    expect(box).not.toBeNull();
+
+    const centerX = box!.x + box!.width / 2;
+    const startY = box!.y + box!.height / 2;
+
+    // Swipe up only 20px — below the 50px dismiss threshold
+    await page.evaluate(
+      ({ cx, sy }) => {
+        const el = document.querySelector('[role="banner"][aria-label="Event announcement"]')!;
+        el.dispatchEvent(
+          new TouchEvent('touchstart', {
+            bubbles: true,
+            touches: [new Touch({ identifier: 1, target: el, clientX: cx, clientY: sy })],
+          }),
+        );
+        el.dispatchEvent(
+          new TouchEvent('touchmove', {
+            bubbles: true,
+            touches: [new Touch({ identifier: 1, target: el, clientX: cx, clientY: sy - 20 })],
+          }),
+        );
+        el.dispatchEvent(new TouchEvent('touchend', { bubbles: true, touches: [] }));
+      },
+      { cx: centerX, sy: startY },
+    );
+
+    // Bar should still be visible
+    await expect(banner).toBeVisible({ timeout: 1000 });
+  });
+
+  test('should set --announcement-h CSS variable on mobile', async ({ page }) => {
+    const banner = page.locator('[role="banner"][aria-label="Event announcement"]');
+    await expect(banner).toBeVisible({ timeout: 5000 });
+
+    const announcementH = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue('--announcement-h').trim(),
+    );
+    expect(announcementH).toMatch(/^\d+(\.\d+)?px$/);
+    expect(announcementH).not.toBe('0px');
+  });
+});

--- a/tests/components/Announcements.spec.ts
+++ b/tests/components/Announcements.spec.ts
@@ -57,24 +57,25 @@ test.describe('Announcements — Desktop', () => {
   });
 
   test('should display the CTA link with correct href', async ({ page }) => {
-    // Both mobile and desktop CTAs share the same href; grab the desktop one
-    const ctaLinks = page.locator('a[href="https://luma.com/lr79szro"]');
-    await expect(ctaLinks.first()).toBeVisible({ timeout: 5000 });
-    const href = await ctaLinks.first().getAttribute('href');
+    // Target the desktop CTA specifically — the mobile one (lg:hidden) is first in the DOM
+    // but hidden at desktop viewport, so we scope to the desktop layout container.
+    const ctaLink = page.locator('.hidden.lg\\:flex a[href="https://luma.com/lr79szro"]');
+    await expect(ctaLink).toBeVisible({ timeout: 5000 });
+    const href = await ctaLink.getAttribute('href');
     expect(href).toBe('https://luma.com/lr79szro');
   });
 
   test('should open CTA link in a new tab', async ({ page }) => {
-    const ctaLinks = page.locator('a[href="https://luma.com/lr79szro"]');
-    await expect(ctaLinks.first()).toBeVisible({ timeout: 5000 });
-    expect(await ctaLinks.first().getAttribute('target')).toBe('_blank');
-    expect(await ctaLinks.first().getAttribute('rel')).toContain('noopener');
+    const ctaLink = page.locator('.hidden.lg\\:flex a[href="https://luma.com/lr79szro"]');
+    await expect(ctaLink).toBeVisible({ timeout: 5000 });
+    expect(await ctaLink.getAttribute('target')).toBe('_blank');
+    expect(await ctaLink.getAttribute('rel')).toContain('noopener');
   });
 
   test('should display "Register NOW" CTA label', async ({ page }) => {
-    const ctaLinks = page.locator('a[href="https://luma.com/lr79szro"]');
-    await expect(ctaLinks.first()).toBeVisible({ timeout: 5000 });
-    await expect(ctaLinks.first()).toContainText('Register NOW');
+    const ctaLink = page.locator('.hidden.lg\\:flex a[href="https://luma.com/lr79szro"]');
+    await expect(ctaLink).toBeVisible({ timeout: 5000 });
+    await expect(ctaLink).toContainText('Register NOW');
   });
 
   test('should display marquee event text', async ({ page }) => {


### PR DESCRIPTION
Adds a reusable fixed announcement bar for the GitTogether SF promotion and wires the site layout offsets so the header and floating navbar stay correctly positioned while the bar is visible.

### What changed

- added the global announcement bar in `components/Announcements.tsx`
- wired it into `pages/_app.tsx` so it appears across the site
- synced header and floating navbar offsets with `--announcement-h`
- added responsive desktop/mobile layouts, swipe-to-dismiss on mobile, and a visible dismiss button on all breakpoints
- fixed marquee pause behavior so explicit pause state does not break existing hover pause behavior elsewhere
- hardened the dismiss flow to avoid stale timers and to collapse the layout offset immediately

### Behavior notes

- dismissal is intentionally session-only in the current implementation; the bar reappears after refresh so event visibility is not lost
- `ResizeObserver` usage is guarded and falls back to resize-driven measurement
- the offset is written before paint when the bar becomes visible to avoid header/navbar overlap flicker

### Testing

- Playwright coverage exists in `tests/components/Announcements.spec.ts` for render, CTA, dismiss, mobile, swipe, and CSS offset behavior
- local Playwright re-run is currently blocked by the existing app build/test environment issues in this workspace
