### PR TITLE
seo: blog index H1 + HowTo schema for tutorial posts

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -26,7 +26,10 @@ jobs:
       
       - name: Install dependencies
         run: npm ci
-      
+
+      - name: Run unit tests
+        run: npm run test:unit
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
       

--- a/components/meta.tsx
+++ b/components/meta.tsx
@@ -1,6 +1,7 @@
 import Head from "next/head";
 import { CMS_NAME, HOME_OG_IMAGE_URL } from "../lib/constants";
 import { Post } from "../types/post";
+import { safeJsonLdStringify } from "../utils/seo";
 
 export default function Meta({
   featuredImage,
@@ -94,7 +95,12 @@ export default function Meta({
         <script
           key={`jsonld-${index}`}
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+          // Use safeJsonLdStringify (not raw JSON.stringify) so that field
+          // values containing `<`/`>`/`&`/U+2028/U+2029 (e.g. a WP title
+          // decoded through sanitizeTitle, or an inline-code paragraph in
+          // HowTo step text) can't terminate this <script> tag or trip
+          // JSONP/inline-JS parsers.
+          dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(schema) }}
         />
       ))}
       {/* <link

--- a/components/meta.tsx
+++ b/components/meta.tsx
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import { CMS_NAME, HOME_OG_IMAGE_URL } from "../lib/constants";
+import { HOME_OG_IMAGE_URL } from "../lib/constants";
 import { Post } from "../types/post";
 import { safeJsonLdStringify } from "../utils/seo";
 

--- a/lib/howToSchema.ts
+++ b/lib/howToSchema.ts
@@ -99,16 +99,20 @@ function decodeStepBody(tag: string, inner: string): string {
   return stripHtml(inner);
 }
 
-// Truncate at the last whitespace boundary at-or-before `limit` so a step
-// never ends mid-word. Falls back to a hard slice only if no whitespace
-// exists in the window (extremely rare — would mean a single ~110-char
-// unbroken token, e.g. a URL).
+// Truncate at the last whitespace boundary so a step never ends mid-word,
+// while keeping the FULL result (text + ellipsis) within `limit`. The "..."
+// is 3 chars, so the search window is `limit - 3`; cutting inside it then
+// appending the ellipsis lands the result at <= limit. Falls back to a hard
+// slice at `limit - 3` only if no whitespace exists in the window (extremely
+// rare — a single ~110-char unbroken token, e.g. a URL).
+const ELLIPSIS = "...";
 function truncateAtBoundary(value: string, limit: number): string {
   if (value.length <= limit) return value;
-  const window = value.slice(0, limit);
+  const max = limit - ELLIPSIS.length;
+  const window = value.slice(0, max);
   const boundary = window.lastIndexOf(" ");
-  const cut = boundary > 0 ? boundary : limit - 3;
-  return `${value.slice(0, cut).trimEnd()}...`;
+  const cut = boundary > 0 ? boundary : max;
+  return `${value.slice(0, cut).trimEnd()}${ELLIPSIS}`;
 }
 
 /**

--- a/lib/howToSchema.ts
+++ b/lib/howToSchema.ts
@@ -1,9 +1,11 @@
 /**
  * HowTo JSON-LD builder for tutorial blog posts.
  *
- * A WordPress post is treated as a tutorial when it carries a tag whose name
- * (or slug) matches one of `HOWTO_TAG_NAMES`. Tags ride on the existing
- * GraphQL fragment, so this works without any WordPress-side schema changes.
+ * A WordPress post is treated as a tutorial when it carries a tag whose
+ * name normalizes to one of `HOWTO_TAG_NORMALIZED`. Tags ride on the
+ * existing GraphQL fragment (`tags.edges.node.name`), so this works without
+ * any WordPress-side schema changes. Slugs are not queried — name is the
+ * only signal we have here.
  *
  * Steps are extracted from the rendered post HTML — h2/h3 headings paired
  * with the first <p> that follows. If that yields < 2 usable steps, the
@@ -16,7 +18,6 @@
 type RawTagEdge = {
   node?: {
     name?: string;
-    slug?: string;
   };
 };
 
@@ -45,14 +46,26 @@ export type TutorialPostShape = {
   };
 };
 
-const HOWTO_TAG_NAMES = ["howto", "how-to", "tutorial"];
+// Normalized form used for tag matching. Keeping this kebab-cased+lowercased
+// means a WordPress tag named "How To" (display name with whitespace + caps)
+// matches the same bucket as "howto" / "how-to" / "tutorial".
+const HOWTO_TAG_NORMALIZED = new Set(["howto", "how-to", "tutorial"]);
+
+function normalizeTagName(raw: string): string {
+  return raw
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, "-");
+}
 
 function isTutorial(post: TutorialPostShape): boolean {
-  const tagNames =
-    post?.tags?.edges
-      ?.map((e) => (e?.node?.name || e?.node?.slug || "").toLowerCase())
-      .filter(Boolean) ?? [];
-  return tagNames.some((n) => HOWTO_TAG_NAMES.includes(n));
+  const edges = post?.tags?.edges ?? [];
+  for (const e of edges) {
+    const name = e?.node?.name;
+    if (!name) continue;
+    if (HOWTO_TAG_NORMALIZED.has(normalizeTagName(name))) return true;
+  }
+  return false;
 }
 
 function stripHtml(s: string): string {
@@ -114,12 +127,19 @@ export type HowToJsonLd = Record<string, unknown>;
 /**
  * Returns a HowTo JSON-LD object suitable for injecting via <script type="application/ld+json">,
  * or null if the post is not a tutorial / doesn't yield a valid step array.
+ *
+ * `safeTitle` and `safeDescription` MUST already be passed through
+ * `sanitizeTitle` / `getSafeDescription` (or equivalent) by the caller —
+ * matching the existing BlogPosting schema on these pages so JSON-LD
+ * doesn't ship raw Yoast HTML/entities.
  */
 export function getHowToSchema(
   post: TutorialPostShape | null | undefined,
   pageUrl: string,
+  safeTitle: string,
+  safeDescription: string,
 ): HowToJsonLd | null {
-  if (!post || !post.title) return null;
+  if (!post || !safeTitle) return null;
   if (!isTutorial(post)) return null;
 
   const steps: AuthoredHowToStep[] = post.content
@@ -132,7 +152,7 @@ export function getHowToSchema(
   const schema: HowToJsonLd = {
     "@context": "https://schema.org",
     "@type": "HowTo",
-    name: post.title,
+    name: safeTitle,
     mainEntityOfPage: {
       "@type": "WebPage",
       "@id": pageUrl,
@@ -149,7 +169,7 @@ export function getHowToSchema(
     }),
   };
 
-  if (post.seo?.metaDesc) schema.description = post.seo.metaDesc;
+  if (safeDescription) schema.description = safeDescription;
   if (post.featuredImage?.node?.sourceUrl) {
     schema.image = [post.featuredImage.node.sourceUrl];
   }

--- a/lib/howToSchema.ts
+++ b/lib/howToSchema.ts
@@ -15,6 +15,8 @@
  * cheerio) so it is safe for both server-side and client-side rendering.
  */
 
+import { decodeEntities } from "../utils/seo";
+
 type RawTagEdge = {
   node?: {
     name?: string;
@@ -68,30 +70,12 @@ function isTutorial(post: TutorialPostShape): boolean {
   return false;
 }
 
-// WordPress emits typographic punctuation as numeric HTML entities
-// (`&#8217;` curly apostrophe, `&#8211;` en dash, etc.), so the JSON-LD
-// would otherwise carry literal "It&#8217;s" strings — invalid markup that
-// search engines and the rich-results test treat as broken content.
-// Mirrors the decode list in utils/seo.ts so the HowTo schema and the meta
-// description stay in lockstep.
-function stripHtml(s: string): string {
-  return s
-    .replace(/<[^>]+>/g, "")
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&#8217;/g, "'")
-    .replace(/&#8216;/g, "'")
-    .replace(/&#8220;/g, "“")
-    .replace(/&#8221;/g, "”")
-    .replace(/&#8211;/g, "–")
-    .replace(/&#8212;/g, "—")
-    .replace(/\s+/g, " ")
-    .trim();
-}
+// Reuse the shared sanitizer that powers meta titles/descriptions so the
+// HowTo schema and the rest of the metadata pipeline can't drift on entity
+// handling. utils/seo.ts also carries the script-context safety note about
+// why `&lt;` / `&gt;` are intentionally NOT decoded into raw angle brackets
+// — important context for any future change to that list.
+const stripHtml = decodeEntities;
 
 /**
  * Walks the HTML body and pairs each h2/h3 with the first <p> that follows it,

--- a/lib/howToSchema.ts
+++ b/lib/howToSchema.ts
@@ -68,6 +68,12 @@ function isTutorial(post: TutorialPostShape): boolean {
   return false;
 }
 
+// WordPress emits typographic punctuation as numeric HTML entities
+// (`&#8217;` curly apostrophe, `&#8211;` en dash, etc.), so the JSON-LD
+// would otherwise carry literal "It&#8217;s" strings — invalid markup that
+// search engines and the rich-results test treat as broken content.
+// Mirrors the decode list in utils/seo.ts so the HowTo schema and the meta
+// description stay in lockstep.
 function stripHtml(s: string): string {
   return s
     .replace(/<[^>]+>/g, "")
@@ -77,6 +83,12 @@ function stripHtml(s: string): string {
     .replace(/&gt;/g, ">")
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
+    .replace(/&#8217;/g, "'")
+    .replace(/&#8216;/g, "'")
+    .replace(/&#8220;/g, "“")
+    .replace(/&#8221;/g, "”")
+    .replace(/&#8211;/g, "–")
+    .replace(/&#8212;/g, "—")
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/lib/howToSchema.ts
+++ b/lib/howToSchema.ts
@@ -23,7 +23,7 @@ type RawTagEdge = {
   };
 };
 
-type AuthoredHowToStep = {
+type ExtractedHowToStep = {
   name?: string;
   text?: string;
   image?: string;
@@ -120,9 +120,9 @@ function truncateAtBoundary(value: string, limit: number): string {
  * element (see STEP_BODY_TAGS) that follows it, up to the next heading.
  * Caps step text length so the JSON-LD stays compact.
  */
-function extractStepsFromContent(html: string): AuthoredHowToStep[] {
+function extractStepsFromContent(html: string): ExtractedHowToStep[] {
   if (!html) return [];
-  const steps: AuthoredHowToStep[] = [];
+  const steps: ExtractedHowToStep[] = [];
   // Find every h2/h3, in order, with their text and source index.
   const headingRegex = /<h([23])(?:\s[^>]*)?>([\s\S]*?)<\/h\1>/gi;
   const headings: {
@@ -196,7 +196,7 @@ export function getHowToSchema(
   if (!post || !safeTitle) return null;
   if (!isTutorial(post)) return null;
 
-  const steps: AuthoredHowToStep[] = post.content
+  const steps: ExtractedHowToStep[] = post.content
     ? extractStepsFromContent(post.content)
     : [];
 

--- a/lib/howToSchema.ts
+++ b/lib/howToSchema.ts
@@ -83,6 +83,22 @@ const stripHtml = decodeEntities;
 // is by far the most common body element, then list/code/blockquote.
 const STEP_BODY_TAGS = ["p", "ul", "ol", "blockquote", "pre"] as const;
 
+// Decode a matched body element into plain step text. For list bodies the
+// raw inner HTML is "<li>A</li><li>B</li>" — feeding that straight to
+// `stripHtml` drops the tags with no separator and concatenates the items
+// into a run-on token ("AB"). Split on the list-item boundaries first and
+// join with ". " so each item stays a distinct clause in the JSON-LD.
+function decodeStepBody(tag: string, inner: string): string {
+  if (tag === "ul" || tag === "ol") {
+    return inner
+      .split(/<\/li\s*>/i)
+      .map((item) => stripHtml(item))
+      .filter(Boolean)
+      .join(". ");
+  }
+  return stripHtml(inner);
+}
+
 // Truncate at the last whitespace boundary at-or-before `limit` so a step
 // never ends mid-word. Falls back to a hard slice only if no whitespace
 // exists in the window (extremely rare — would mean a single ~110-char
@@ -139,7 +155,7 @@ function extractStepsFromContent(html: string): AuthoredHowToStep[] {
       const match = slice.match(re);
       if (!match || match.index === undefined) continue;
       if (match.index >= earliestIdx) continue;
-      const decoded = stripHtml(match[1]);
+      const decoded = decodeStepBody(tag, match[1]);
       if (!decoded) continue;
       earliestIdx = match.index;
       text = decoded;

--- a/lib/howToSchema.ts
+++ b/lib/howToSchema.ts
@@ -1,0 +1,187 @@
+/**
+ * HowTo JSON-LD builder for tutorial blog posts.
+ *
+ * A WordPress post is treated as a tutorial when EITHER:
+ *   1. it has a tag named "howto" (case-insensitive), OR
+ *   2. it carries a custom meta field `is_tutorial` set to true, OR
+ *   3. an explicit `howto_steps` field is present in the post payload.
+ *
+ * The `step` array is sourced (in priority order) from:
+ *   1. an explicit `howto_steps` array on the post (preferred — authored), or
+ *   2. h2/h3 headings + their first paragraph extracted from `post.content`.
+ *
+ * If neither source yields >= 2 steps, the helper returns null so the page
+ * does NOT emit an invalid schema.
+ *
+ * The helper is purely string-based (does not touch the DOM, does not import
+ * cheerio) so it is safe for both server-side and client-side rendering.
+ */
+
+type RawTagEdge = {
+  node?: {
+    name?: string;
+    slug?: string;
+  };
+};
+
+type AuthoredHowToStep = {
+  name?: string;
+  text?: string;
+  url?: string;
+  image?: string;
+};
+
+export type TutorialPostShape = {
+  title?: string;
+  slug?: string;
+  content?: string;
+  date?: string;
+  // Optional explicit steps the author can ship from WordPress as a
+  // post-meta JSON array.
+  howto_steps?: AuthoredHowToStep[] | null;
+  // Optional flag the author can set in WordPress as a custom field.
+  is_tutorial?: boolean;
+  // The blog uses WPGraphQL, so tags are nested as edges.
+  tags?: {
+    edges?: RawTagEdge[];
+  };
+  seo?: {
+    metaDesc?: string;
+  };
+  featuredImage?: {
+    node?: {
+      sourceUrl?: string;
+    };
+  };
+};
+
+const HOWTO_TAG_NAMES = ["howto", "how-to", "tutorial"];
+
+function isTutorial(post: TutorialPostShape): boolean {
+  if (post?.is_tutorial === true) return true;
+  if (Array.isArray(post?.howto_steps) && post.howto_steps.length > 0) {
+    return true;
+  }
+  const tagNames =
+    post?.tags?.edges
+      ?.map((e) => (e?.node?.name || e?.node?.slug || "").toLowerCase())
+      .filter(Boolean) ?? [];
+  return tagNames.some((n) => HOWTO_TAG_NAMES.includes(n));
+}
+
+function stripHtml(s: string): string {
+  return s
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Walks the HTML body and pairs each h2/h3 with the first <p> that follows it,
+ * up to the next heading. Caps step text length so the JSON-LD stays compact.
+ */
+function extractStepsFromContent(html: string): AuthoredHowToStep[] {
+  if (!html) return [];
+  const steps: AuthoredHowToStep[] = [];
+  // Find every h2/h3, in order, with their text and source index.
+  const headingRegex = /<h([23])(?:\s[^>]*)?>([\s\S]*?)<\/h\1>/gi;
+  const headings: {start: number; end: number; level: number; name: string}[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = headingRegex.exec(html)) !== null) {
+    const name = stripHtml(m[2]);
+    if (!name) continue;
+    headings.push({
+      start: m.index,
+      end: m.index + m[0].length,
+      level: Number(m[1]),
+      name,
+    });
+  }
+  for (let i = 0; i < headings.length; i += 1) {
+    const h = headings[i];
+    const next = headings[i + 1];
+    const slice = html.slice(h.end, next ? next.start : html.length);
+    const pMatch = slice.match(/<p(?:\s[^>]*)?>([\s\S]*?)<\/p>/i);
+    const text = pMatch ? stripHtml(pMatch[1]) : "";
+    // Skip steps with no usable body — they aren't useful in JSON-LD.
+    if (!text) continue;
+    const slug = h.name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "");
+    steps.push({
+      name: h.name.length > 110 ? `${h.name.slice(0, 107)}...` : h.name,
+      text: text.length > 480 ? `${text.slice(0, 477)}...` : text,
+      url: slug ? `#${slug}` : undefined,
+    });
+  }
+  return steps;
+}
+
+export type HowToJsonLd = Record<string, unknown>;
+
+/**
+ * Returns a HowTo JSON-LD object suitable for injecting via <script type="application/ld+json">,
+ * or null if the post is not a tutorial / doesn't yield a valid step array.
+ */
+export function getHowToSchema(
+  post: TutorialPostShape | null | undefined,
+  pageUrl: string,
+): HowToJsonLd | null {
+  if (!post || !post.title) return null;
+  if (!isTutorial(post)) return null;
+
+  let steps: AuthoredHowToStep[] = [];
+  if (Array.isArray(post.howto_steps) && post.howto_steps.length > 0) {
+    steps = post.howto_steps
+      .map((s) => ({
+        name: (s?.name || "").trim(),
+        text: (s?.text || "").trim(),
+        url: s?.url,
+        image: s?.image,
+      }))
+      .filter((s) => s.name && s.text);
+  } else if (post.content) {
+    steps = extractStepsFromContent(post.content);
+  }
+
+  // Google requires at least 2 steps for HowTo to render rich-result-style.
+  if (steps.length < 2) return null;
+
+  const schema: HowToJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    name: post.title,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": pageUrl,
+    },
+    step: steps.map((s, i) => {
+      const step: Record<string, unknown> = {
+        "@type": "HowToStep",
+        position: i + 1,
+        name: s.name,
+        text: s.text,
+      };
+      if (s.url) {
+        step.url = s.url.startsWith("#") ? `${pageUrl}${s.url}` : s.url;
+      }
+      if (s.image) step.image = s.image;
+      return step;
+    }),
+  };
+
+  if (post.seo?.metaDesc) schema.description = post.seo.metaDesc;
+  if (post.featuredImage?.node?.sourceUrl) {
+    schema.image = [post.featuredImage.node.sourceUrl];
+  }
+  if (post.date) schema.datePublished = post.date;
+
+  return schema;
+}

--- a/lib/howToSchema.ts
+++ b/lib/howToSchema.ts
@@ -1,17 +1,13 @@
 /**
  * HowTo JSON-LD builder for tutorial blog posts.
  *
- * A WordPress post is treated as a tutorial when EITHER:
- *   1. it has a tag named "howto" (case-insensitive), OR
- *   2. it carries a custom meta field `is_tutorial` set to true, OR
- *   3. an explicit `howto_steps` field is present in the post payload.
+ * A WordPress post is treated as a tutorial when it carries a tag whose name
+ * (or slug) matches one of `HOWTO_TAG_NAMES`. Tags ride on the existing
+ * GraphQL fragment, so this works without any WordPress-side schema changes.
  *
- * The `step` array is sourced (in priority order) from:
- *   1. an explicit `howto_steps` array on the post (preferred — authored), or
- *   2. h2/h3 headings + their first paragraph extracted from `post.content`.
- *
- * If neither source yields >= 2 steps, the helper returns null so the page
- * does NOT emit an invalid schema.
+ * Steps are extracted from the rendered post HTML — h2/h3 headings paired
+ * with the first <p> that follows. If that yields < 2 usable steps, the
+ * helper returns null so the page does not emit an invalid schema.
  *
  * The helper is purely string-based (does not touch the DOM, does not import
  * cheerio) so it is safe for both server-side and client-side rendering.
@@ -27,7 +23,6 @@ type RawTagEdge = {
 type AuthoredHowToStep = {
   name?: string;
   text?: string;
-  url?: string;
   image?: string;
 };
 
@@ -36,11 +31,6 @@ export type TutorialPostShape = {
   slug?: string;
   content?: string;
   date?: string;
-  // Optional explicit steps the author can ship from WordPress as a
-  // post-meta JSON array.
-  howto_steps?: AuthoredHowToStep[] | null;
-  // Optional flag the author can set in WordPress as a custom field.
-  is_tutorial?: boolean;
   // The blog uses WPGraphQL, so tags are nested as edges.
   tags?: {
     edges?: RawTagEdge[];
@@ -58,10 +48,6 @@ export type TutorialPostShape = {
 const HOWTO_TAG_NAMES = ["howto", "how-to", "tutorial"];
 
 function isTutorial(post: TutorialPostShape): boolean {
-  if (post?.is_tutorial === true) return true;
-  if (Array.isArray(post?.howto_steps) && post.howto_steps.length > 0) {
-    return true;
-  }
   const tagNames =
     post?.tags?.edges
       ?.map((e) => (e?.node?.name || e?.node?.slug || "").toLowerCase())
@@ -111,14 +97,13 @@ function extractStepsFromContent(html: string): AuthoredHowToStep[] {
     const text = pMatch ? stripHtml(pMatch[1]) : "";
     // Skip steps with no usable body — they aren't useful in JSON-LD.
     if (!text) continue;
-    const slug = h.name
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-|-$/g, "");
+    // Intentionally NOT setting `step.url`: the rendered post doesn't carry
+    // server-side anchor ids on its h2/h3s — `components/post-body.tsx`
+    // attaches them in a client useEffect — so any `#slug` we emit here
+    // would point at a non-existent anchor in the SSR HTML that crawlers see.
     steps.push({
       name: h.name.length > 110 ? `${h.name.slice(0, 107)}...` : h.name,
       text: text.length > 480 ? `${text.slice(0, 477)}...` : text,
-      url: slug ? `#${slug}` : undefined,
     });
   }
   return steps;
@@ -137,19 +122,9 @@ export function getHowToSchema(
   if (!post || !post.title) return null;
   if (!isTutorial(post)) return null;
 
-  let steps: AuthoredHowToStep[] = [];
-  if (Array.isArray(post.howto_steps) && post.howto_steps.length > 0) {
-    steps = post.howto_steps
-      .map((s) => ({
-        name: (s?.name || "").trim(),
-        text: (s?.text || "").trim(),
-        url: s?.url,
-        image: s?.image,
-      }))
-      .filter((s) => s.name && s.text);
-  } else if (post.content) {
-    steps = extractStepsFromContent(post.content);
-  }
+  const steps: AuthoredHowToStep[] = post.content
+    ? extractStepsFromContent(post.content)
+    : [];
 
   // Google requires at least 2 steps for HowTo to render rich-result-style.
   if (steps.length < 2) return null;
@@ -169,9 +144,6 @@ export function getHowToSchema(
         name: s.name,
         text: s.text,
       };
-      if (s.url) {
-        step.url = s.url.startsWith("#") ? `${pageUrl}${s.url}` : s.url;
-      }
       if (s.image) step.image = s.image;
       return step;
     }),

--- a/lib/howToSchema.ts
+++ b/lib/howToSchema.ts
@@ -124,7 +124,6 @@ function extractStepsFromContent(html: string): AuthoredHowToStep[] {
   const headings: {
     start: number;
     end: number;
-    level: number;
     name: string;
   }[] = [];
   let m: RegExpExecArray | null;
@@ -134,7 +133,6 @@ function extractStepsFromContent(html: string): AuthoredHowToStep[] {
     headings.push({
       start: m.index,
       end: m.index + m[0].length,
-      level: Number(m[1]),
       name,
     });
   }

--- a/lib/howToSchema.ts
+++ b/lib/howToSchema.ts
@@ -54,10 +54,7 @@ export type TutorialPostShape = {
 const HOWTO_TAG_NORMALIZED = new Set(["howto", "how-to", "tutorial"]);
 
 function normalizeTagName(raw: string): string {
-  return raw
-    .toLowerCase()
-    .trim()
-    .replace(/\s+/g, "-");
+  return raw.toLowerCase().trim().replace(/\s+/g, "-");
 }
 
 function isTutorial(post: TutorialPostShape): boolean {
@@ -77,16 +74,43 @@ function isTutorial(post: TutorialPostShape): boolean {
 // — important context for any future change to that list.
 const stripHtml = decodeEntities;
 
+// Step text can come from any of these tags after a heading — not just <p>.
+// Authors frequently put a <ul>/<ol> immediately after a step heading
+// (instruction lists), or a <blockquote> / <pre> for callouts and code.
+// Without this fallback set, a tutorial with 4 headings whose bodies use
+// any of those instead of <p> would yield 0 usable steps and emit no
+// schema even though it IS a tutorial. Order matters: <p> first because it
+// is by far the most common body element, then list/code/blockquote.
+const STEP_BODY_TAGS = ["p", "ul", "ol", "blockquote", "pre"] as const;
+
+// Truncate at the last whitespace boundary at-or-before `limit` so a step
+// never ends mid-word. Falls back to a hard slice only if no whitespace
+// exists in the window (extremely rare — would mean a single ~110-char
+// unbroken token, e.g. a URL).
+function truncateAtBoundary(value: string, limit: number): string {
+  if (value.length <= limit) return value;
+  const window = value.slice(0, limit);
+  const boundary = window.lastIndexOf(" ");
+  const cut = boundary > 0 ? boundary : limit - 3;
+  return `${value.slice(0, cut).trimEnd()}...`;
+}
+
 /**
- * Walks the HTML body and pairs each h2/h3 with the first <p> that follows it,
- * up to the next heading. Caps step text length so the JSON-LD stays compact.
+ * Walks the HTML body and pairs each h2/h3 with the first usable body
+ * element (see STEP_BODY_TAGS) that follows it, up to the next heading.
+ * Caps step text length so the JSON-LD stays compact.
  */
 function extractStepsFromContent(html: string): AuthoredHowToStep[] {
   if (!html) return [];
   const steps: AuthoredHowToStep[] = [];
   // Find every h2/h3, in order, with their text and source index.
   const headingRegex = /<h([23])(?:\s[^>]*)?>([\s\S]*?)<\/h\1>/gi;
-  const headings: {start: number; end: number; level: number; name: string}[] = [];
+  const headings: {
+    start: number;
+    end: number;
+    level: number;
+    name: string;
+  }[] = [];
   let m: RegExpExecArray | null;
   while ((m = headingRegex.exec(html)) !== null) {
     const name = stripHtml(m[2]);
@@ -102,8 +126,24 @@ function extractStepsFromContent(html: string): AuthoredHowToStep[] {
     const h = headings[i];
     const next = headings[i + 1];
     const slice = html.slice(h.end, next ? next.start : html.length);
-    const pMatch = slice.match(/<p(?:\s[^>]*)?>([\s\S]*?)<\/p>/i);
-    const text = pMatch ? stripHtml(pMatch[1]) : "";
+    // Try each body tag in priority order; first one that yields decoded
+    // text wins. Pick the EARLIEST occurrence within the slice across all
+    // tags so a <ul> appearing before a later <p> is still preferred.
+    let text = "";
+    let earliestIdx = Infinity;
+    for (const tag of STEP_BODY_TAGS) {
+      const re = new RegExp(
+        `<${tag}(?:\\s[^>]*)?>([\\s\\S]*?)<\\/${tag}>`,
+        "i",
+      );
+      const match = slice.match(re);
+      if (!match || match.index === undefined) continue;
+      if (match.index >= earliestIdx) continue;
+      const decoded = stripHtml(match[1]);
+      if (!decoded) continue;
+      earliestIdx = match.index;
+      text = decoded;
+    }
     // Skip steps with no usable body — they aren't useful in JSON-LD.
     if (!text) continue;
     // Intentionally NOT setting `step.url`: the rendered post doesn't carry
@@ -111,8 +151,8 @@ function extractStepsFromContent(html: string): AuthoredHowToStep[] {
     // attaches them in a client useEffect — so any `#slug` we emit here
     // would point at a non-existent anchor in the SSR HTML that crawlers see.
     steps.push({
-      name: h.name.length > 110 ? `${h.name.slice(0, 107)}...` : h.name,
-      text: text.length > 480 ? `${text.slice(0, 477)}...` : text,
+      name: truncateAtBoundary(h.name, 110),
+      text: truncateAtBoundary(text, 480),
     });
   }
   return steps;
@@ -167,7 +207,17 @@ export function getHowToSchema(
 
   if (safeDescription) schema.description = safeDescription;
   if (post.featuredImage?.node?.sourceUrl) {
-    schema.image = [post.featuredImage.node.sourceUrl];
+    // Google's HowTo rich-result docs use a full ImageObject (with url and,
+    // when known, width/height) rather than a bare URL string. We only know
+    // the source URL at this layer — WPGraphQL's `featuredImage` doesn't
+    // surface intrinsic dimensions here — so emit just `@type` + `url`. A
+    // future enrichment can add height/width by querying `mediaDetails`.
+    schema.image = [
+      {
+        "@type": "ImageObject",
+        url: post.featuredImage.node.sourceUrl,
+      },
+    ];
   }
   if (post.date) schema.datePublished = post.date;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,8 @@
         "eslint": "8.56.0",
         "eslint-config-next": "14.1.0",
         "postcss": "8.4.31",
-        "tailwindcss": "^3.0.24"
+        "tailwindcss": "^3.0.24",
+        "tsx": "^4.21.0"
       },
       "engines": {
         "node": ">=18"
@@ -294,6 +295,448 @@
         "node-bitmap": "0.0.1",
         "omggif": "^1.0.10",
         "pngjs": "^6.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2783,6 +3226,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/escalade": {
@@ -6030,6 +6515,25 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:codegen": "playwright codegen http://localhost:3000/blog",
     "test:e2e:chromium": "playwright test --project=chromium",
-    "test:e2e:report": "playwright show-report"
+    "test:e2e:report": "playwright show-report",
+    "test:unit": "tsx --test tests/lib/*.test.ts"
   },
   "dependencies": {
     "@codemirror/lang-go": "^6.0.1",
@@ -64,6 +65,7 @@
     "eslint": "8.56.0",
     "eslint-config-next": "14.1.0",
     "postcss": "8.4.31",
-    "tailwindcss": "^3.0.24"
+    "tailwindcss": "^3.0.24",
+    "tsx": "^4.21.0"
   }
 }

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -94,7 +94,22 @@ export const getStaticProps: GetStaticProps = async () => {
       revalidate: 60, // Revalidate every minute
     };
   } catch (error) {
-    console.error("Error fetching posts for 404 page:", error);
+    const message = error instanceof Error ? error.message : String(error);
+    // Structured log mirroring pages/sitemap.xml.tsx so on-call can diagnose
+    // from Vercel logs alone. The 404 still renders (with empty post rails)
+    // rather than 500ing — these are supplementary "latest posts" widgets.
+    console.error("[404] degraded: latest-posts rails empty", {
+      endpoint:
+        process.env.WORDPRESS_API_URL ||
+        process.env.NEXT_PUBLIC_WORDPRESS_API_URL,
+      error: message,
+      nextSteps: [
+        "1. Verify WPGraphQL is up: curl -sS -X POST <endpoint> -H 'Content-Type: application/json' -d '{\"query\":\"{ __typename }\"}'",
+        "2. If the curl 5xx's or hangs, check wp.keploy.io host status and the WPGraphQL plugin (WP admin → Plugins)",
+        "3. If the endpoint logged above is unexpected, double-check WORDPRESS_API_URL in Vercel project settings and redeploy",
+        "4. Page is served with revalidate: 60, so the rails self-heal within ~1 min after WP recovers",
+      ],
+    });
     return {
       props: {
         latestPosts: { edges: [] },

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -5,6 +5,7 @@ import NotFoundPage from "../components/NotFoundPage";
 import { getAllPostsForTechnology, getAllPostsForCommunity } from "../lib/api";
 import { GetStaticProps } from "next";
 import { getBreadcrumbListSchema, SITE_URL } from "../lib/structured-data";
+import { safeJsonLdStringify } from "../utils/seo";
 
 interface Custom404Props {
   latestPosts: { edges: Array<{ node: any }> };
@@ -12,7 +13,11 @@ interface Custom404Props {
   technologyPosts: { edges: Array<{ node: any }> };
 }
 
-export default function Custom404({ latestPosts, communityPosts, technologyPosts }: Custom404Props) {
+export default function Custom404({
+  latestPosts,
+  communityPosts,
+  technologyPosts,
+}: Custom404Props) {
   const router = useRouter();
   const asPath = router.asPath;
   const structuredData = getBreadcrumbListSchema([
@@ -38,13 +43,22 @@ export default function Custom404({ latestPosts, communityPosts, technologyPosts
     <>
       <Head>
         <title>404 - Page Not Found | Keploy Blog</title>
-        <meta name="description" content="Oops! The page you're looking for doesn't exist. Explore our latest blog posts and featured articles." />
+        <meta
+          name="description"
+          content="Oops! The page you're looking for doesn't exist. Explore our latest blog posts and featured articles."
+        />
         <script
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+          dangerouslySetInnerHTML={{
+            __html: safeJsonLdStringify(structuredData),
+          }}
         />
       </Head>
-      <NotFoundPage latestPosts={latestPosts} communityPosts={communityPosts} technologyPosts={technologyPosts} />
+      <NotFoundPage
+        latestPosts={latestPosts}
+        communityPosts={communityPosts}
+        technologyPosts={technologyPosts}
+      />
     </>
   );
 }
@@ -54,13 +68,14 @@ export const getStaticProps: GetStaticProps = async () => {
     // Fetch latest posts from both technology and community
     const [techPosts, communityPosts] = await Promise.all([
       getAllPostsForTechnology(false, null),
-      getAllPostsForCommunity(false, null)
+      getAllPostsForCommunity(false, null),
     ]);
 
     // Combine and sort by date to get the latest posts
     const allPosts = [...techPosts.edges, ...communityPosts.edges];
-    const sortedPosts = allPosts.sort((a, b) => 
-      new Date(b.node.date).getTime() - new Date(a.node.date).getTime()
+    const sortedPosts = allPosts.sort(
+      (a, b) =>
+        new Date(b.node.date).getTime() - new Date(a.node.date).getTime(),
     );
 
     // Get latest 6 posts for latest section
@@ -79,7 +94,7 @@ export const getStaticProps: GetStaticProps = async () => {
       revalidate: 60, // Revalidate every minute
     };
   } catch (error) {
-    console.error('Error fetching posts for 404 page:', error);
+    console.error("Error fetching posts for 404 page:", error);
     return {
       props: {
         latestPosts: { edges: [] },

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,5 +1,6 @@
-import { Html, Head, Main, NextScript } from 'next/document';
-import { getOrganizationSchema, getBlogSchema } from '../lib/structured-data';
+import { Html, Head, Main, NextScript } from "next/document";
+import { getOrganizationSchema, getBlogSchema } from "../lib/structured-data";
+import { safeJsonLdStringify } from "../utils/seo";
 
 export default function Document() {
   return (
@@ -7,7 +8,11 @@ export default function Document() {
       <Head>
         {/* Preconnect to Google Fonts for faster font loading */}
         <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
 
         {/* Baloo 2 — preloaded then loaded as stylesheet (font-display:swap in the CSS handles FOUT) */}
         <link
@@ -35,14 +40,14 @@ export default function Document() {
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify(getOrganizationSchema()),
+            __html: safeJsonLdStringify(getOrganizationSchema()),
           }}
         />
         {/* Blog Schema — single source from lib/structured-data */}
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify(getBlogSchema()),
+            __html: safeJsonLdStringify(getBlogSchema()),
           }}
         />
       </Head>

--- a/pages/community/[slug].tsx
+++ b/pages/community/[slug].tsx
@@ -185,7 +185,7 @@ export default function Post({ post, posts, reviewAuthorDetails, preview }) {
         reviewerDescription: reviewAuthorDescription || undefined,
       }),
     );
-    const howTo = getHowToSchema(post, postUrl);
+    const howTo = getHowToSchema(post, postUrl, safeTitle, safeDescription);
     if (howTo) {
       structuredData.push(howTo);
     }

--- a/pages/community/[slug].tsx
+++ b/pages/community/[slug].tsx
@@ -29,6 +29,7 @@ import {
   SITE_URL,
 } from "../../lib/structured-data";
 import { sanitizeTitle, getSafeDescription } from "../../utils/seo";
+import { getHowToSchema } from "../../lib/howToSchema";
 
 const PostBody = dynamic(() => import("../../components/post-body"));
 
@@ -184,6 +185,10 @@ export default function Post({ post, posts, reviewAuthorDetails, preview }) {
         reviewerDescription: reviewAuthorDescription || undefined,
       }),
     );
+    const howTo = getHowToSchema(post, postUrl);
+    if (howTo) {
+      structuredData.push(howTo);
+    }
   } else {
     structuredData.push(
       getBreadcrumbListSchema([

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,6 +15,12 @@ import {
   getWebSiteSchema,
   SITE_URL,
 } from "../lib/structured-data";
+// Canonical /blog title. Shared by Layout's `Title` prop (which Meta.tsx
+// turns into og:title / twitter:title) and the <Head><title>, so the
+// document title and social metadata can't drift apart.
+const BLOG_TITLE =
+  "Keploy Blog — API Testing, Test Automation & eBPF Deep-Dives";
+
 export default function Index({ communityPosts, technologyPosts, preview }) {
   // Organization schema is in _document.tsx (global) — not duplicated here
   const structuredData = [
@@ -27,7 +33,7 @@ export default function Index({ communityPosts, technologyPosts, preview }) {
     <Layout
       preview={preview}
       featuredImage={HOME_OG_IMAGE_URL}
-      Title={`Keploy Blog — API Testing, Test Automation & eBPF Deep-Dives`}
+      Title={BLOG_TITLE}
       Description={"The Keploy Blog offers in-depth articles and expert insights on software testing, automation, and quality assurance, empowering developers to enhance their testing strategies and deliver robust applications."}
       structuredData={structuredData}
       canonicalUrl={SITE_URL}
@@ -38,7 +44,7 @@ export default function Index({ communityPosts, technologyPosts, preview }) {
             prop but does NOT emit a <title> tag (see LIVE-11 note in
             authors/[slug].tsx). Without this <Head><title>, /blog ships
             with no document title — same regression that hit author pages. */}
-        <title>{`Keploy Blog — API Testing, Test Automation & eBPF Deep-Dives`}</title>
+        <title>{BLOG_TITLE}</title>
       </Head>
       <Header />
       <Container>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -34,16 +34,16 @@ export default function Index({ communityPosts, technologyPosts, preview }) {
       ogType="website"
     >
       <Head>
-        <title>{`Engineering | Keploy Blog`}</title>
+        <title>{`Keploy Blog — API Testing, Test Automation & eBPF Deep-Dives`}</title>
       </Head>
       <Header />
       <Container>
         <div className="">
           <div className="home-container md:mb-0 mb-4 flex lg:flex-nowrap flex-wrap-reverse justify-evenly items-center">
             <div className="content">
-              <h2 className="heading1 font-bold 2xl:text-7xl text-6xl text-orange-400">
-                Keploy Blog
-              </h2>
+              <h1 className="heading1 font-bold 2xl:text-7xl text-6xl text-orange-400">
+                Keploy Engineering Blog
+              </h1>
               <p className="content-body body 2xl:text-2xl text-lg mt-6">
                 Empowering your tech journey with expert advice and analysis
               </p>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,3 @@
-import Head from "next/head";
 import { GetStaticProps } from "next";
 import Container from "../components/container";
 import Layout from "../components/layout";
@@ -27,15 +26,12 @@ export default function Index({ communityPosts, technologyPosts, preview }) {
     <Layout
       preview={preview}
       featuredImage={HOME_OG_IMAGE_URL}
-      Title={`Blog - Keploy`}
+      Title={`Keploy Blog — API Testing, Test Automation & eBPF Deep-Dives`}
       Description={"The Keploy Blog offers in-depth articles and expert insights on software testing, automation, and quality assurance, empowering developers to enhance their testing strategies and deliver robust applications."}
       structuredData={structuredData}
       canonicalUrl={SITE_URL}
       ogType="website"
     >
-      <Head>
-        <title>{`Keploy Blog — API Testing, Test Automation & eBPF Deep-Dives`}</title>
-      </Head>
       <Header />
       <Container>
         <div className="">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,3 +1,4 @@
+import Head from "next/head";
 import { GetStaticProps } from "next";
 import Container from "../components/container";
 import Layout from "../components/layout";
@@ -32,6 +33,13 @@ export default function Index({ communityPosts, technologyPosts, preview }) {
       canonicalUrl={SITE_URL}
       ogType="website"
     >
+      <Head>
+        {/* Meta.tsx renders og:title / twitter:title from Layout's `Title`
+            prop but does NOT emit a <title> tag (see LIVE-11 note in
+            authors/[slug].tsx). Without this <Head><title>, /blog ships
+            with no document title — same regression that hit author pages. */}
+        <title>{`Keploy Blog — API Testing, Test Automation & eBPF Deep-Dives`}</title>
+      </Head>
       <Header />
       <Container>
         <div className="">

--- a/pages/technology/[slug].tsx
+++ b/pages/technology/[slug].tsx
@@ -27,6 +27,7 @@ import {
   SITE_URL,
 } from "../../lib/structured-data";
 import { sanitizeTitle, getSafeDescription } from "../../utils/seo";
+import { getHowToSchema } from "../../lib/howToSchema";
 
 const PostBody = dynamic(() => import("../../components/post-body"));
 
@@ -162,6 +163,10 @@ export default function Post({ post, posts, reviewAuthorDetails, preview }) {
         reviewerDescription: reviewAuthorDescription || undefined,
       })
     );
+    const howTo = getHowToSchema(post, postUrl);
+    if (howTo) {
+      structuredData.push(howTo);
+    }
   } else {
     structuredData.push(
       getBreadcrumbListSchema([

--- a/pages/technology/[slug].tsx
+++ b/pages/technology/[slug].tsx
@@ -163,7 +163,7 @@ export default function Post({ post, posts, reviewAuthorDetails, preview }) {
         reviewerDescription: reviewAuthorDescription || undefined,
       })
     );
-    const howTo = getHowToSchema(post, postUrl);
+    const howTo = getHowToSchema(post, postUrl, safeTitle, safeDescription);
     if (howTo) {
       structuredData.push(howTo);
     }

--- a/tests/e2e/SeoMeta.spec.ts
+++ b/tests/e2e/SeoMeta.spec.ts
@@ -8,11 +8,25 @@ test.describe('SEO and Meta Tags Configuration', () => {
         const metaDesc = page.locator('meta[name="description"]');
         await expect(metaDesc).toHaveAttribute('content', /The Keploy Blog offers in-depth articles/);
 
-        // og:title is rendered from Layout's `Title` prop (see components/meta.tsx);
-        // both that prop and <Head><title> on /blog now use the same canonical
-        // SEO string. The new title leads with "Keploy Blog —".
+        // The homepage SEO rewrite is the headline change of this PR, so the
+        // assertions below pin the *exact* values introduced — a prefix-match
+        // ("starts with Keploy Blog") would still pass if the keyword-rich
+        // suffix were dropped or the H1 copy disappeared, which would
+        // silently regress the rewrite. Both `Title` and the <Head><title> on
+        // pages/index.tsx feed this string, so the og:title and the document
+        // title must be identical.
+        const expectedTitle = 'Keploy Blog — API Testing, Test Automation & eBPF Deep-Dives';
+
         const ogTitle = page.locator('meta[property="og:title"]');
-        await expect(ogTitle).toHaveAttribute('content', /^Keploy Blog\b/);
+        await expect(ogTitle).toHaveAttribute('content', expectedTitle);
+
+        await expect(page).toHaveTitle(expectedTitle);
+
+        // The visible H1 was rewritten to "Keploy Engineering Blog" alongside
+        // the title change. Assert the exact H1 text so a future refactor
+        // that drops the H1 (or reverts it to the old copy) trips this test.
+        const h1 = page.locator('h1').first();
+        await expect(h1).toHaveText('Keploy Engineering Blog');
 
         const ogDesc = page.locator('meta[property="og:description"]');
         await expect(ogDesc).toHaveAttribute('content', /The Keploy Blog offers in-depth articles/);

--- a/tests/e2e/SeoMeta.spec.ts
+++ b/tests/e2e/SeoMeta.spec.ts
@@ -8,8 +8,11 @@ test.describe('SEO and Meta Tags Configuration', () => {
         const metaDesc = page.locator('meta[name="description"]');
         await expect(metaDesc).toHaveAttribute('content', /The Keploy Blog offers in-depth articles/);
 
+        // og:title is rendered from Layout's `Title` prop (see components/meta.tsx);
+        // both that prop and <Head><title> on /blog now use the same canonical
+        // SEO string. The new title leads with "Keploy Blog —".
         const ogTitle = page.locator('meta[property="og:title"]');
-        await expect(ogTitle).toHaveAttribute('content', /Blog - Keploy/);
+        await expect(ogTitle).toHaveAttribute('content', /^Keploy Blog\b/);
 
         const ogDesc = page.locator('meta[property="og:description"]');
         await expect(ogDesc).toHaveAttribute('content', /The Keploy Blog offers in-depth articles/);

--- a/tests/lib/howToSchema.test.ts
+++ b/tests/lib/howToSchema.test.ts
@@ -193,8 +193,11 @@ test("extracts step body from <ul>/<ol>/<blockquote> when no <p> follows the hea
   assert.ok(schema, "expected schema even with no <p> bodies");
   const steps = schema!.step as Array<Record<string, unknown>>;
   assert.equal(steps.length, 3);
-  assert.match(steps[0].text as string, /Run npm install/);
-  assert.match(steps[1].text as string, /Copy \.env\.example/);
+  // List items must be joined with a separator — not concatenated into a
+  // run-on token like "Run npm installVerify versions" (Copilot review on
+  // #383). Pin the ". " separator on both <ul> and <ol> bodies.
+  assert.equal(steps[0].text, "Run npm install. Verify versions");
+  assert.equal(steps[1].text, "Copy .env.example. Set DATABASE_URL");
   assert.match(steps[2].text as string, /\/health endpoint/);
 });
 

--- a/tests/lib/howToSchema.test.ts
+++ b/tests/lib/howToSchema.test.ts
@@ -37,7 +37,9 @@ const PAGE_URL = "https://keploy.io/blog/sample-howto-post";
 const SAFE_TITLE = "Sample HowTo Post";
 const SAFE_DESCRIPTION = "Walks through a minimal Keploy capture/replay cycle.";
 
-function makePost(overrides: Partial<TutorialPostShape> = {}): TutorialPostShape {
+function makePost(
+  overrides: Partial<TutorialPostShape> = {},
+): TutorialPostShape {
   return {
     title: "Sample HowTo Post",
     slug: "sample-howto-post",
@@ -49,7 +51,12 @@ function makePost(overrides: Partial<TutorialPostShape> = {}): TutorialPostShape
 }
 
 test("emits HowTo schema for tutorial-tagged posts with >= 2 usable steps", () => {
-  const schema = getHowToSchema(makePost(), PAGE_URL, SAFE_TITLE, SAFE_DESCRIPTION);
+  const schema = getHowToSchema(
+    makePost(),
+    PAGE_URL,
+    SAFE_TITLE,
+    SAFE_DESCRIPTION,
+  );
 
   assert.ok(schema, "expected a schema object");
   assert.equal(schema!["@context"], "https://schema.org");
@@ -137,7 +144,12 @@ test("decodes WordPress numeric entities in step text and headings", () => {
 });
 
 test("schema carries page url via mainEntityOfPage", () => {
-  const schema = getHowToSchema(makePost(), PAGE_URL, SAFE_TITLE, SAFE_DESCRIPTION);
+  const schema = getHowToSchema(
+    makePost(),
+    PAGE_URL,
+    SAFE_TITLE,
+    SAFE_DESCRIPTION,
+  );
   assert.ok(schema);
   const main = schema!.mainEntityOfPage as Record<string, unknown>;
   assert.equal(main["@type"], "WebPage");
@@ -145,7 +157,100 @@ test("schema carries page url via mainEntityOfPage", () => {
 });
 
 test("returns null on missing post or empty title", () => {
-  assert.equal(getHowToSchema(null, PAGE_URL, SAFE_TITLE, SAFE_DESCRIPTION), null);
-  assert.equal(getHowToSchema(undefined, PAGE_URL, SAFE_TITLE, SAFE_DESCRIPTION), null);
-  assert.equal(getHowToSchema(makePost(), PAGE_URL, "", SAFE_DESCRIPTION), null);
+  assert.equal(
+    getHowToSchema(null, PAGE_URL, SAFE_TITLE, SAFE_DESCRIPTION),
+    null,
+  );
+  assert.equal(
+    getHowToSchema(undefined, PAGE_URL, SAFE_TITLE, SAFE_DESCRIPTION),
+    null,
+  );
+  assert.equal(
+    getHowToSchema(makePost(), PAGE_URL, "", SAFE_DESCRIPTION),
+    null,
+  );
+});
+
+test("extracts step body from <ul>/<ol>/<blockquote> when no <p> follows the heading", () => {
+  // Authors often put a list or callout directly after a step heading
+  // instead of a paragraph; without the fallback the step would be
+  // silently dropped (Amaan's review on #383). Pin each tag.
+  const schema = getHowToSchema(
+    makePost({
+      content: `
+        <h2>Install dependencies</h2>
+        <ul><li>Run npm install</li><li>Verify versions</li></ul>
+        <h2>Configure environment</h2>
+        <ol><li>Copy .env.example</li><li>Set DATABASE_URL</li></ol>
+        <h2>Smoke test</h2>
+        <blockquote>Hit the /health endpoint and expect 200.</blockquote>
+      `,
+    }),
+    PAGE_URL,
+    SAFE_TITLE,
+    SAFE_DESCRIPTION,
+  );
+  assert.ok(schema, "expected schema even with no <p> bodies");
+  const steps = schema!.step as Array<Record<string, unknown>>;
+  assert.equal(steps.length, 3);
+  assert.match(steps[0].text as string, /Run npm install/);
+  assert.match(steps[1].text as string, /Copy \.env\.example/);
+  assert.match(steps[2].text as string, /\/health endpoint/);
+});
+
+test("truncates long step name/text at a word boundary, not mid-word", () => {
+  const longHeading =
+    "Configure the production-grade observability stack with Prometheus Grafana Loki Tempo Pyroscope and OpenTelemetry collectors end to end";
+  const longBody = "lorem ipsum ".repeat(60); // > 480 chars, with spaces
+  const schema = getHowToSchema(
+    makePost({
+      content: `<h2>${longHeading}</h2><p>${longBody}</p><h2>Second step</h2><p>OK.</p>`,
+    }),
+    PAGE_URL,
+    SAFE_TITLE,
+    SAFE_DESCRIPTION,
+  );
+  assert.ok(schema);
+  const steps = schema!.step as Array<Record<string, unknown>>;
+  const name = steps[0].name as string;
+  const text = steps[0].text as string;
+  // Both are truncated (...) and end on whitespace+ellipsis, not mid-word.
+  assert.ok(name.endsWith("..."), `name should end with ellipsis: ${name}`);
+  assert.ok(text.endsWith("..."), `text should end with ellipsis: ${text}`);
+  // The character before the "..." must not split a token — i.e. it must
+  // either be the end of a complete word from the source.
+  const namePrefix = name.slice(0, -3);
+  const textPrefix = text.slice(0, -3);
+  assert.ok(
+    longHeading.startsWith(namePrefix),
+    "truncated name must be a prefix of the original",
+  );
+  assert.ok(
+    longBody.trim().startsWith(textPrefix),
+    "truncated text must be a prefix of the original",
+  );
+  // And specifically, the next char in the source past the cut must be
+  // whitespace (proves we cut at a boundary, not mid-word).
+  assert.equal(
+    longHeading[namePrefix.length],
+    " ",
+    "name cut should land on a space",
+  );
+});
+
+test("featuredImage is emitted as an ImageObject, not a bare URL string", () => {
+  const schema = getHowToSchema(
+    makePost({
+      featuredImage: { node: { sourceUrl: "https://cdn.keploy.io/cover.png" } },
+    }),
+    PAGE_URL,
+    SAFE_TITLE,
+    SAFE_DESCRIPTION,
+  );
+  assert.ok(schema);
+  const image = schema!.image as Array<Record<string, unknown>>;
+  assert.equal(Array.isArray(image), true);
+  assert.equal(image.length, 1);
+  assert.equal(image[0]["@type"], "ImageObject");
+  assert.equal(image[0].url, "https://cdn.keploy.io/cover.png");
 });

--- a/tests/lib/howToSchema.test.ts
+++ b/tests/lib/howToSchema.test.ts
@@ -101,9 +101,11 @@ test("returns null when fewer than 2 steps can be extracted", () => {
 
 test("decodes WordPress numeric entities in step text and headings", () => {
   // &#8217; (curly apostrophe), &#8211; (en dash), and the structural
-  // &lt;/&gt; pair WP emits for inline code blocks. Assert the entities
-  // are replaced with proper Unicode and that no `&lt;`/`&gt;` literals
-  // leak into the JSON-LD payload.
+  // &lt;/&gt; pair WP emits for inline code blocks. Assert that the
+  // numeric punctuation entities ARE replaced with proper Unicode while
+  // `&lt;`/`&gt;` are intentionally LEFT as entities — decodeEntities()
+  // in utils/seo.ts deliberately skips them so a literal `</script>` can
+  // never land inside the JSON-LD `<script>` body.
   const schema = getHowToSchema(
     makePost({
       content: `
@@ -127,8 +129,10 @@ test("decodes WordPress numeric entities in step text and headings", () => {
   assert.match(steps[0].text as string, /– then exercise/);
   // `&lt;` / `&gt;` are intentionally left as entities (script-context
   // safety: see utils/seo.ts decodeEntities note) — they must NOT be
-  // decoded into raw `<`/`>` in the JSON-LD body.
+  // decoded into raw `<`/`>` in the JSON-LD body, and the entity form
+  // must survive into the emitted payload.
   assert.doesNotMatch(steps[0].text as string, /<keploy record>/);
+  assert.match(steps[0].text as string, /&lt;keploy record&gt;/);
   assert.equal(steps[1].text, "Run “keploy test” to replay.");
 });
 

--- a/tests/lib/howToSchema.test.ts
+++ b/tests/lib/howToSchema.test.ts
@@ -220,6 +220,10 @@ test("truncates long step name/text at a word boundary, not mid-word", () => {
   // Both are truncated (...) and end on whitespace+ellipsis, not mid-word.
   assert.ok(name.endsWith("..."), `name should end with ellipsis: ${name}`);
   assert.ok(text.endsWith("..."), `text should end with ellipsis: ${text}`);
+  // The full result (text + ellipsis) must stay within the documented caps
+  // (110 for name, 480 for text) — the ellipsis must not push it over.
+  assert.ok(name.length <= 110, `name length ${name.length} exceeds 110`);
+  assert.ok(text.length <= 480, `text length ${text.length} exceeds 480`);
   // The character before the "..." must not split a token — i.e. it must
   // either be the end of a complete word from the source.
   const namePrefix = name.slice(0, -3);

--- a/tests/lib/howToSchema.test.ts
+++ b/tests/lib/howToSchema.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Unit tests for getHowToSchema.
+ *
+ * Run via: `npm run test:unit`
+ *
+ * Covers the HowTo JSON-LD path that the e2e suite can't reach today —
+ * there are no tutorial-tagged posts in WP yet, so an end-to-end test
+ * would silently pass even if the helper stopped emitting (or started
+ * emitting on every post). These cases pin the contract to controlled
+ * fixtures so a regression in tag detection, step extraction, or entity
+ * decoding fails CI immediately.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { getHowToSchema, type TutorialPostShape } from "../../lib/howToSchema";
+
+const TUTORIAL_TAGS = {
+  edges: [{ node: { name: "tutorial" } }],
+};
+
+const NON_TUTORIAL_TAGS = {
+  edges: [{ node: { name: "engineering" } }, { node: { name: "case-study" } }],
+};
+
+const SAMPLE_TUTORIAL_BODY = `
+<p>Intro paragraph.</p>
+<h2>Install Keploy</h2>
+<p>Run the install script and verify the binary.</p>
+<h2>Capture API traffic</h2>
+<p>Start the app under <code>keploy record</code>.</p>
+<h3>Tip</h3>
+<p>Pipe traffic through curl to seed test cases.</p>
+`;
+
+const PAGE_URL = "https://keploy.io/blog/sample-howto-post";
+const SAFE_TITLE = "Sample HowTo Post";
+const SAFE_DESCRIPTION = "Walks through a minimal Keploy capture/replay cycle.";
+
+function makePost(overrides: Partial<TutorialPostShape> = {}): TutorialPostShape {
+  return {
+    title: "Sample HowTo Post",
+    slug: "sample-howto-post",
+    content: SAMPLE_TUTORIAL_BODY,
+    date: "2026-04-01T00:00:00Z",
+    tags: TUTORIAL_TAGS,
+    ...overrides,
+  };
+}
+
+test("emits HowTo schema for tutorial-tagged posts with >= 2 usable steps", () => {
+  const schema = getHowToSchema(makePost(), PAGE_URL, SAFE_TITLE, SAFE_DESCRIPTION);
+
+  assert.ok(schema, "expected a schema object");
+  assert.equal(schema!["@context"], "https://schema.org");
+  assert.equal(schema!["@type"], "HowTo");
+  assert.equal(schema!.name, SAFE_TITLE);
+  assert.equal(schema!.description, SAFE_DESCRIPTION);
+
+  const steps = schema!.step as Array<Record<string, unknown>>;
+  assert.equal(steps.length, 3);
+  assert.equal(steps[0].name, "Install Keploy");
+  assert.equal(steps[0].position, 1);
+  assert.match(steps[0].text as string, /install script/);
+  assert.equal(steps[2].name, "Tip");
+});
+
+test("returns null for posts not tagged tutorial / how-to / howto", () => {
+  const schema = getHowToSchema(
+    makePost({ tags: NON_TUTORIAL_TAGS }),
+    PAGE_URL,
+    SAFE_TITLE,
+    SAFE_DESCRIPTION,
+  );
+  assert.equal(schema, null);
+});
+
+test("matches tag names case-insensitively and across whitespace variants", () => {
+  for (const variant of ["How To", "HOWTO", "how-to", "Tutorial"]) {
+    const schema = getHowToSchema(
+      makePost({ tags: { edges: [{ node: { name: variant } }] } }),
+      PAGE_URL,
+      SAFE_TITLE,
+      SAFE_DESCRIPTION,
+    );
+    assert.ok(schema, `expected emission for tag "${variant}"`);
+  }
+});
+
+test("returns null when fewer than 2 steps can be extracted", () => {
+  const schema = getHowToSchema(
+    makePost({
+      content: "<h2>Only one step</h2><p>This is the only step.</p>",
+    }),
+    PAGE_URL,
+    SAFE_TITLE,
+    SAFE_DESCRIPTION,
+  );
+  assert.equal(schema, null);
+});
+
+test("decodes WordPress numeric entities in step text and headings", () => {
+  // &#8217; (curly apostrophe), &#8211; (en dash), and the structural
+  // &lt;/&gt; pair WP emits for inline code blocks. Assert the entities
+  // are replaced with proper Unicode and that no `&lt;`/`&gt;` literals
+  // leak into the JSON-LD payload.
+  const schema = getHowToSchema(
+    makePost({
+      content: `
+        <h2>It&#8217;s easy &#8211; really</h2>
+        <p>Use &lt;keploy record&gt; to start &#8211; then exercise the API.</p>
+        <h2>Replay</h2>
+        <p>Run &#8220;keploy test&#8221; to replay.</p>
+      `,
+    }),
+    PAGE_URL,
+    SAFE_TITLE,
+    SAFE_DESCRIPTION,
+  );
+
+  assert.ok(schema);
+  const steps = schema!.step as Array<Record<string, unknown>>;
+  // utils/seo.ts decodes &#8217; → ASCII apostrophe and &#8211; →
+  // U+2013 en dash; pin those exact substitutions so a future change to
+  // the decode table can't quietly flip what crawlers see.
+  assert.equal(steps[0].name, "It's easy – really");
+  assert.match(steps[0].text as string, /– then exercise/);
+  // `&lt;` / `&gt;` are intentionally left as entities (script-context
+  // safety: see utils/seo.ts decodeEntities note) — they must NOT be
+  // decoded into raw `<`/`>` in the JSON-LD body.
+  assert.doesNotMatch(steps[0].text as string, /<keploy record>/);
+  assert.equal(steps[1].text, "Run “keploy test” to replay.");
+});
+
+test("schema carries page url via mainEntityOfPage", () => {
+  const schema = getHowToSchema(makePost(), PAGE_URL, SAFE_TITLE, SAFE_DESCRIPTION);
+  assert.ok(schema);
+  const main = schema!.mainEntityOfPage as Record<string, unknown>;
+  assert.equal(main["@type"], "WebPage");
+  assert.equal(main["@id"], PAGE_URL);
+});
+
+test("returns null on missing post or empty title", () => {
+  assert.equal(getHowToSchema(null, PAGE_URL, SAFE_TITLE, SAFE_DESCRIPTION), null);
+  assert.equal(getHowToSchema(undefined, PAGE_URL, SAFE_TITLE, SAFE_DESCRIPTION), null);
+  assert.equal(getHowToSchema(makePost(), PAGE_URL, "", SAFE_DESCRIPTION), null);
+});

--- a/tests/lib/safeJsonLdStringify.test.ts
+++ b/tests/lib/safeJsonLdStringify.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for safeJsonLdStringify (utils/seo.ts).
+ *
+ * Pin the script-injection safety guarantees so a future change to the
+ * escape list can't quietly re-open the </script> termination hole.
+ * Specifically: now that `sanitizeTitle` / `getSafeDescription` decode
+ * `&lt;`/`&gt;` for the meta/title attribute path, those raw `<`/`>` can
+ * legitimately flow into JSON-LD field values on post pages — so the
+ * safety guarantee MUST live at the JSON-LD serialization boundary.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { safeJsonLdStringify } from "../../utils/seo";
+
+test("escapes < and > so a value can't terminate the enclosing <script>", () => {
+  const payload = { headline: "Use </script><img src=x onerror=alert(1)>" };
+  const out = safeJsonLdStringify(payload);
+  // No literal </script> anywhere in the serialized string — the unicode
+  // escapes round-trip back to the original chars when JSON.parse runs.
+  assert.doesNotMatch(out, /<\/script>/i);
+  assert.doesNotMatch(out, /<img/i);
+  assert.match(out, /\\u003c\\u002fscript\\u003e|\\u003c\/script\\u003e/);
+  // And the value still parses back to the original characters (so
+  // schema consumers see the intended string, just safely encoded in
+  // the script body).
+  assert.equal(
+    (JSON.parse(out) as { headline: string }).headline,
+    payload.headline,
+  );
+});
+
+test("escapes & so script-context values can't introduce HTML entities", () => {
+  const out = safeJsonLdStringify({ a: "Tom & Jerry" });
+  assert.doesNotMatch(out, /Tom & Jerry/);
+  assert.match(out, /Tom \\u0026 Jerry/);
+  assert.equal((JSON.parse(out) as { a: string }).a, "Tom & Jerry");
+});
+
+test("escapes U+2028 / U+2029 so JS parsers don't break on line separators", () => {
+  const out = safeJsonLdStringify({ a: "line1\u2028line2\u2029line3" });
+  assert.doesNotMatch(out, /[\u2028\u2029]/);
+  assert.match(out, /line1\\u2028line2\\u2029line3/);
+  assert.equal(
+    (JSON.parse(out) as { a: string }).a,
+    "line1\u2028line2\u2029line3",
+  );
+});
+
+test("leaves normal JSON characters intact (round-trips)", () => {
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    name: "Sample tutorial",
+    step: [
+      { "@type": "HowToStep", position: 1, name: "First", text: "Do this." },
+      { "@type": "HowToStep", position: 2, name: "Second", text: "Then that." },
+    ],
+  };
+  const out = safeJsonLdStringify(schema);
+  assert.deepEqual(JSON.parse(out), schema);
+});

--- a/tests/lib/safeJsonLdStringify.test.ts
+++ b/tests/lib/safeJsonLdStringify.test.ts
@@ -47,6 +47,20 @@ test("escapes U+2028 / U+2029 so JS parsers don't break on line separators", () 
   );
 });
 
+test('returns the JSON literal "null" when the value is unserializable', () => {
+  // `JSON.stringify` returns `undefined` (not a string) for `undefined`,
+  // bare function values, and bare symbols. The old implementation called
+  // `.replace` on that and threw TypeError at SSR. Pin the safe coercion.
+  assert.equal(safeJsonLdStringify(undefined), "null");
+  assert.equal(
+    safeJsonLdStringify(() => 42),
+    "null",
+  );
+  assert.equal(safeJsonLdStringify(Symbol("x")), "null");
+  // And the result still parses back to a valid JSON value (`null`).
+  assert.equal(JSON.parse(safeJsonLdStringify(undefined)), null);
+});
+
 test("leaves normal JSON characters intact (round-trips)", () => {
   const schema = {
     "@context": "https://schema.org",

--- a/utils/seo.ts
+++ b/utils/seo.ts
@@ -1,51 +1,75 @@
 /**
- * Strip HTML tags, decode common WordPress HTML entities, and normalize whitespace.
- * Used for meta descriptions and JSON-LD where raw HTML/entities hurt SEO quality.
+ * WordPress-entity decoders — two variants depending on output context.
  *
- * Exported so JSON-LD builders (e.g. lib/howToSchema.ts) can reuse the same
- * decode list \u2014 keeping a second copy in those files lets entity handling
- * drift the next time WordPress surfaces a new typographic entity.
+ * Both share the same numeric/typographic decode list so callers cannot drift
+ * the next time WordPress surfaces a new entity. Where they diverge is on
+ * `&lt;` / `&gt;`:
  *
- * Note: this function intentionally does NOT decode `&lt;` / `&gt;` to raw
- * angle brackets. Callers fall into two buckets:
- *   1. `<meta name="description" content="...">` / `<title>...</title>` \u2014
- *      the output lands inside an HTML attribute or text node where React
- *      escapes `<`/`>` for us, so leaving entities here is purely a
- *      readability choice (no security impact).
- *   2. JSON-LD payloads injected via
- *      `<script type="application/ld+json" dangerouslySetInnerHTML={{
- *        __html: JSON.stringify(schema) }} />` \u2014 this is the load-bearing
- *      case. `JSON.stringify` does not escape `<` or `>`, so once raw `<`
- *      enters the schema value a tutorial paragraph containing
- *      `</script>` (or any markup) would terminate the surrounding
- *      `<script>` element and break the page. Leaving angle brackets as
- *      `&lt;` / `&gt;` makes that injection impossible.
+ * `decodeEntities` (script-safe — leaves `&lt;` / `&gt;` as entities) is
+ * used by JSON-LD builders (e.g. `lib/howToSchema.ts`). Those payloads ship
+ * inside `<script type="application/ld+json" dangerouslySetInnerHTML={{
+ * __html: JSON.stringify(schema) }} />`. `JSON.stringify` does not escape
+ * `<` or `>`, so a tutorial paragraph containing `</script>` would terminate
+ * the surrounding `<script>` element if we ever decoded entity brackets to
+ * raw ones. Keeping them as entities makes that injection impossible.
  *
- * The regex above strips tag wrappers, so the only `<`/`>` that ever reach
- * the JSON-LD body are ones the WordPress author entity-encoded on purpose
- * (e.g. inline code like `&lt;keploy record&gt;`) \u2014 those were never
- * structural markup and are safe to leave as text.
+ * `decodeEntitiesForAttribute` (full decode — converts `&lt;` / `&gt;` to
+ * `<` / `>`) is used by `sanitizeTitle` / `getSafeDescription`. Those values
+ * land in JSX attribute/text positions (`<meta content={safeDescription}>`,
+ * `<title>{safeTitle}</title>`) where React HTML-encodes `<` / `>` for us
+ * on render. Leaving them as `&lt;` here would cause React to encode the
+ * leading `&` and ship `&amp;lt;` in the final HTML source — wrong in SERP
+ * snippets and social previews. Restoring the decode on this path matches
+ * the pre-#383 behaviour from `3c89e73`.
+ *
+ * The leading `replace(/<[^>]*>/g, '')` in both strips structural tag
+ * wrappers, so the only `<` / `>` that ever reach either output are ones the
+ * WordPress author entity-encoded on purpose (e.g. inline code like
+ * `&lt;keploy record&gt;`).
  */
+const SHARED_DECODES: ReadonlyArray<[RegExp, string]> = [
+  [/&amp;/g, "&"],
+  [/&quot;/g, '"'],
+  [/&#8217;/g, "'"],
+  [/&#8216;/g, "'"],
+  [/&#8220;/g, "“"],
+  [/&#8221;/g, "”"],
+  [/&#8211;/g, "–"],
+  [/&#8212;/g, "—"],
+  [/&#39;/g, "'"],
+  [/&nbsp;/g, " "],
+];
+
+function applyDecodes(
+  text: string,
+  extra: ReadonlyArray<[RegExp, string]> = [],
+): string {
+  let out = text.replace(/<[^>]*>/g, "");
+  for (const [re, sub] of SHARED_DECODES) out = out.replace(re, sub);
+  for (const [re, sub] of extra) out = out.replace(re, sub);
+  return out.replace(/\s+/g, " ").trim();
+}
+
+/** Script-safe decoder. Use for JSON-LD payloads. Leaves `&lt;`/`&gt;` as entities. */
 export function decodeEntities(text: string): string {
-  return text
-    .replace(/<[^>]*>/g, '')
-    .replace(/&amp;/g, '&')
-    .replace(/&quot;/g, '"')
-    .replace(/&#8217;/g, "'")
-    .replace(/&#8216;/g, "'")
-    .replace(/&#8220;/g, '\u201c')
-    .replace(/&#8221;/g, '\u201d')
-    .replace(/&#8211;/g, '\u2013')
-    .replace(/&#8212;/g, '\u2014')
-    .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
+  return applyDecodes(text);
+}
+
+/**
+ * Attribute/text-context decoder. Use for `<meta>` / `<title>` values fed
+ * through JSX, where React re-escapes `<`/`>` for safe output. Decodes the
+ * full WP entity set including `&lt;`/`&gt;`.
+ */
+export function decodeEntitiesForAttribute(text: string): string {
+  return applyDecodes(text, [
+    [/&lt;/g, "<"],
+    [/&gt;/g, ">"],
+  ]);
 }
 
 export function sanitizeTitle(rawTitle: string | undefined | null): string {
-  if (!rawTitle) return '';
-  return decodeEntities(rawTitle);
+  if (!rawTitle) return "";
+  return decodeEntitiesForAttribute(rawTitle);
 }
 
 /**
@@ -55,19 +79,19 @@ export function sanitizeTitle(rawTitle: string | undefined | null): string {
 export function getSafeDescription(
   isFallback: boolean,
   metaDesc: string | undefined | null,
-  safeTitle: string
+  safeTitle: string,
 ): string {
   if (isFallback) {
-    return 'Keploy engineering blog — practical guides, tutorials, and best practices for developers and QA engineers.';
+    return "Keploy engineering blog — practical guides, tutorials, and best practices for developers and QA engineers.";
   }
   if (metaDesc) {
-    const clean = decodeEntities(metaDesc);
+    const clean = decodeEntitiesForAttribute(metaDesc);
     if (clean.length >= 60) {
       return clean;
     }
   }
   if (!safeTitle) {
-    return 'Keploy engineering blog — practical guides, tutorials, and best practices for developers and QA engineers.';
+    return "Keploy engineering blog — practical guides, tutorials, and best practices for developers and QA engineers.";
   }
   return `Learn about ${safeTitle} — practical guide with examples and best practices from the Keploy engineering blog.`;
 }

--- a/utils/seo.ts
+++ b/utils/seo.ts
@@ -1,13 +1,26 @@
 /**
  * Strip HTML tags, decode common WordPress HTML entities, and normalize whitespace.
  * Used for meta descriptions and JSON-LD where raw HTML/entities hurt SEO quality.
+ *
+ * Exported so JSON-LD builders (e.g. lib/howToSchema.ts) can reuse the same
+ * decode list \u2014 keeping a second copy in those files lets entity handling
+ * drift the next time WordPress surfaces a new typographic entity.
+ *
+ * Note: this function intentionally does NOT decode `&lt;` / `&gt;` to raw
+ * angle brackets. The output is consumed inside <script> tags (meta tags,
+ * JSON-LD payloads), where a literal `</script>` inside a string body would
+ * terminate the script element and break the page. JSON.stringify does not
+ * escape `<` or `>`, so once we let raw `<` into the value, downstream
+ * `dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}` callers
+ * have no defence. We strip tags via the regex above instead \u2014 angle
+ * brackets that were entity-encoded in the source were never structural
+ * markup, so leaving them as `&lt;` text in the script payload is safer
+ * than decoding them.
  */
-function decodeEntities(text: string): string {
+export function decodeEntities(text: string): string {
   return text
     .replace(/<[^>]*>/g, '')
     .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#8217;/g, "'")
     .replace(/&#8216;/g, "'")
@@ -15,6 +28,8 @@ function decodeEntities(text: string): string {
     .replace(/&#8221;/g, '\u201d')
     .replace(/&#8211;/g, '\u2013')
     .replace(/&#8212;/g, '\u2014')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/utils/seo.ts
+++ b/utils/seo.ts
@@ -6,12 +6,15 @@
  * `&lt;` / `&gt;`:
  *
  * `decodeEntities` (script-safe — leaves `&lt;` / `&gt;` as entities) is
- * used by JSON-LD builders (e.g. `lib/howToSchema.ts`). Those payloads ship
- * inside `<script type="application/ld+json" dangerouslySetInnerHTML={{
- * __html: JSON.stringify(schema) }} />`. `JSON.stringify` does not escape
- * `<` or `>`, so a tutorial paragraph containing `</script>` would terminate
- * the surrounding `<script>` element if we ever decoded entity brackets to
- * raw ones. Keeping them as entities makes that injection impossible.
+ * used by JSON-LD builders (e.g. `lib/howToSchema.ts`). Those payloads
+ * ultimately ship inside
+ * `<script type="application/ld+json" dangerouslySetInnerHTML={{__html: ...}} />`.
+ * The hard XSS guarantee against `</script>` termination lives in
+ * `safeJsonLdStringify` below — every injection site goes through it — so
+ * this decoder leaving entity brackets alone is now a *defence-in-depth*
+ * layer rather than the sole protection: even if a future caller forgets
+ * the script-safe stringify, the schema fields still don't carry raw `<` /
+ * `>` from this decoder's output.
  *
  * `decodeEntitiesForAttribute` (full decode — converts `&lt;` / `&gt;` to
  * `<` / `>`) is used by `sanitizeTitle` / `getSafeDescription`. Those values
@@ -84,9 +87,18 @@ export function decodeEntitiesForAttribute(text: string): string {
  * decode back to the original characters in JS) but cannot terminate the
  * enclosing `<script>` tag, start an HTML comment, or trip JSONP / inline
  * JS parsers on U+2028/U+2029.
+ *
+ * Edge case: `JSON.stringify` returns `undefined` (not a string) for
+ * `undefined`, function values, and bare symbols. Coerce that to the JSON
+ * literal `"null"` so the helper still returns a valid JSON payload (an
+ * empty schema slot is preferable to an SSR crash from `.replace` on
+ * `undefined`). Calling sites can also choose not to render the
+ * `<script>` tag when the value is missing.
  */
 export function safeJsonLdStringify(value: unknown): string {
-  return JSON.stringify(value)
+  const serialized = JSON.stringify(value);
+  if (typeof serialized !== "string") return "null";
+  return serialized
     .replace(/</g, "\\u003c")
     .replace(/>/g, "\\u003e")
     .replace(/&/g, "\\u0026")

--- a/utils/seo.ts
+++ b/utils/seo.ts
@@ -67,6 +67,33 @@ export function decodeEntitiesForAttribute(text: string): string {
   ]);
 }
 
+/**
+ * Defensively serialize a value for injection inside
+ * `<script type="application/ld+json" dangerouslySetInnerHTML={{__html: ...}} />`.
+ *
+ * `JSON.stringify` does not escape `<`, `>`, `&`, or the JS-only line
+ * separators U+2028 / U+2029, so a field value containing `</script>` would
+ * close the surrounding script element. Now that `sanitizeTitle` /
+ * `getSafeDescription` legitimately decode `&lt;`/`&gt;` for the
+ * `<meta>` / `<title>` attribute path, those same strings can flow into
+ * JSON-LD on the post pages — so the safety guarantee has to live at the
+ * script boundary instead of relying on every upstream sanitizer to keep
+ * angle brackets encoded.
+ *
+ * The five replacements below produce JSON that is still valid (the escapes
+ * decode back to the original characters in JS) but cannot terminate the
+ * enclosing `<script>` tag, start an HTML comment, or trip JSONP / inline
+ * JS parsers on U+2028/U+2029.
+ */
+export function safeJsonLdStringify(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
 export function sanitizeTitle(rawTitle: string | undefined | null): string {
   if (!rawTitle) return "";
   return decodeEntitiesForAttribute(rawTitle);

--- a/utils/seo.ts
+++ b/utils/seo.ts
@@ -7,15 +7,24 @@
  * drift the next time WordPress surfaces a new typographic entity.
  *
  * Note: this function intentionally does NOT decode `&lt;` / `&gt;` to raw
- * angle brackets. The output is consumed inside <script> tags (meta tags,
- * JSON-LD payloads), where a literal `</script>` inside a string body would
- * terminate the script element and break the page. JSON.stringify does not
- * escape `<` or `>`, so once we let raw `<` into the value, downstream
- * `dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}` callers
- * have no defence. We strip tags via the regex above instead \u2014 angle
- * brackets that were entity-encoded in the source were never structural
- * markup, so leaving them as `&lt;` text in the script payload is safer
- * than decoding them.
+ * angle brackets. Callers fall into two buckets:
+ *   1. `<meta name="description" content="...">` / `<title>...</title>` \u2014
+ *      the output lands inside an HTML attribute or text node where React
+ *      escapes `<`/`>` for us, so leaving entities here is purely a
+ *      readability choice (no security impact).
+ *   2. JSON-LD payloads injected via
+ *      `<script type="application/ld+json" dangerouslySetInnerHTML={{
+ *        __html: JSON.stringify(schema) }} />` \u2014 this is the load-bearing
+ *      case. `JSON.stringify` does not escape `<` or `>`, so once raw `<`
+ *      enters the schema value a tutorial paragraph containing
+ *      `</script>` (or any markup) would terminate the surrounding
+ *      `<script>` element and break the page. Leaving angle brackets as
+ *      `&lt;` / `&gt;` makes that injection impossible.
+ *
+ * The regex above strips tag wrappers, so the only `<`/`>` that ever reach
+ * the JSON-LD body are ones the WordPress author entity-encoded on purpose
+ * (e.g. inline code like `&lt;keploy record&gt;`) \u2014 those were never
+ * structural markup and are safe to leave as text.
  */
 export function decodeEntities(text: string): string {
   return text


### PR DESCRIPTION
## Summary

Two fixes from the SEO/GEO/AEO audit on `keploy.io/blog`.

**Blog index H1 + title rewrite**
- `/blog` was rendering zero H1 (only H2/H3 cards). Title ran 25 characters: `Engineering | Keploy Blog` — too short, missing primary keywords like "API testing" or "test automation".
- New H1: `Keploy Engineering Blog`. New title: `Keploy Blog — API Testing, Test Automation & eBPF Deep-Dives` (57c).
- Both the rendered `<title>` (in `<Head>` on `pages/index.tsx`) and Layout's `Title` prop — which `components/meta.tsx` uses to build `og:title`/`twitter:title` — now use this same canonical string, so social/SEO metadata and the document title agree.

**HowTo schema for tutorial posts**
- New `lib/howToSchema.ts` builds a `HowTo` JSON-LD object from a post when one of its tags normalizes to `howto` / `how-to` / `tutorial` (the normalize step lowercases + replaces whitespace with `-` so a WordPress display tag like "How To" matches).
- Steps are extracted from the post body — h2/h3 headings paired with the first `<p>` that follows. Capped at 110 chars for `name`, 480 for `text`.
- The helper takes pre-sanitized `safeTitle`/`safeDescription` from the caller (the same values used for `BlogPosting`), so encoded WordPress entities and inline markup never end up in the JSON-LD.
- Returns `null` for non-tutorial posts (and for posts where fewer than 2 steps could be derived) — no invalid schema is emitted.
- Wired into `pages/community/[slug].tsx` and `pages/technology/[slug].tsx`: appended to the existing `structuredData[]` array.

**Note:** the helper does not consume custom WordPress meta (`howto_steps` / `is_tutorial`). Exposing those over WPGraphQL would need a server-side `register_graphql_field` registration that doesn't exist on this site today; if/when WP adds it, the helper can be extended in a follow-up to read authored steps.

## Test plan
- [ ] `npx tsc --noEmit` reports no new errors — verified (1 pre-existing PNG-import error unchanged)
- [ ] `tests/e2e/SeoMeta.spec.ts` — `og:title` regex updated to match the new title; suite still passes
- [ ] Tag the 5 candidate WordPress posts with the `howto` (or "How To") tag (their slugs):
  - `community/how-to-do-java-unit-testing-effectively`
  - `community/how-to-generate-test-cases-with-automation-tools`
  - `community/how-to-mock-backend-of-selenium-tests-using-keploy`
  - `community/getting-started-with-keploy`
  - `community/how-to-do-frontend-test-automation-using-selenium`
- [ ] Spot-check rendered HTML of one tagged post for `"@type":"HowTo"` JSON-LD
- [ ] Google Rich Results test passes for one tagged post (HowTo)
- [ ] `/blog` page source shows `<h1>Keploy Engineering Blog</h1>` and `<title>Keploy Blog — API Testing, Test Automation & eBPF Deep-Dives</title>`
- [ ] Companion PRs in keploy/landing (#207) and keploy/docs (#857)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
