### PR TITLE
fix: prevent desktop navbar from redirecting on touch devices

### DIFF
--- a/components/navbar/FloatingNavbarClient.tsx
+++ b/components/navbar/FloatingNavbarClient.tsx
@@ -225,6 +225,13 @@ export default function FloatingNavbarClient({ techLatest = [], communityLatest 
               href="/technology"
               onMouseEnter={() => { setHoveredNav('tech'); setLinkHoverTech(true); }}
               onMouseLeave={() => { setLinkHoverTech(false); setHoveredNav(null); }}
+              onClick={(e) => {
+                if (typeof window !== 'undefined' && window.matchMedia('(hover: none) and (pointer: coarse)').matches) {
+                  e.preventDefault();
+                  setShowTechDropdown(prev => !prev);
+                  setHoveredNav('tech');
+                }
+              }}
               className={`${(showTechDropdown || showCommunityDropdown || resourcesOpen) && !showTechDropdown ? 'text-black/50' : 'text-foreground'} transition-colors text-[15px] font-medium py-2 px-1 inline-flex items-center gap-1.5 align-middle ${linkHoverTech ? 'underline underline-offset-2 decoration-1 decoration-neutral-400' : ''}`}
             >
               <span>Technology</span>
@@ -295,6 +302,13 @@ export default function FloatingNavbarClient({ techLatest = [], communityLatest 
               href="/community"
               onMouseEnter={() => { setHoveredNav('community'); setLinkHoverCommunity(true); }}
               onMouseLeave={() => { setLinkHoverCommunity(false); setHoveredNav(null); }}
+              onClick={(e) => {
+                if (typeof window !== 'undefined' && window.matchMedia('(hover: none) and (pointer: coarse)').matches) {
+                  e.preventDefault();
+                  setShowCommunityDropdown(prev => !prev);
+                  setHoveredNav('community');
+                }
+              }}
               className={`${(showTechDropdown || showCommunityDropdown || resourcesOpen) && !showCommunityDropdown ? 'text-black/50' : 'text-foreground'} transition-colors text-[15px] font-medium py-2 px-1 inline-flex items-center gap-1.5 align-middle ${linkHoverCommunity ? 'underline underline-offset-2 decoration-1 decoration-neutral-400' : ''}`}
             >
               <span>Community</span>


### PR DESCRIPTION
Fixes: keploy/keploy#3431

The Problem:
Currently, when viewing the Keploy Blog on an iPad or large tablet (devices that render the desktop navigation bar but lack native hover support), interacting with the "Technology" or "Community" dropdowns results in a poor user experience. Because touch devices interpret a tap on a <Link> as an immediate click event, users are instantly redirected to the category pages instead of opening the mega-menu dropdown to view its contents.

The Solution:
This PR resolves the issue by intelligently intercepting the onClick event on these navigation links specifically for touch devices, allowing them to act natively as dropdown toggles.

Key Changes:

Updated the Link components in components/navbar/FloatingNavbarClient.tsx for the "Technology" and "Community" desktop navigation items.
Implemented a precise touch-device check using the modern window.matchMedia('(hover: none) and (pointer: coarse)').matches API.
If a touch device is detected, the click event correctly calls e.preventDefault() to block the hard redirect and dynamically toggles the mega-menu's visibility state (setShowTechDropdown / setShowCommunityDropdown).

Testing Performed
Tablet/Touch Simulation: Verified via Chrome DevTools (Device Toolbar -> iPad) that tapping "Technology" and "Community" smoothly drops down the glassmorphism mega-menu options instead of redirecting the user.
Desktop Functionality: Confirmed that the standard desktop browser hover functionality (onMouseEnter / onMouseLeave) remains completely unaffected for mouse users.

 Type of Change
 Bug fix (non-breaking change which fixes an issue)
 New feature (non-breaking change which adds functionality)
 Breaking change (fix or feature that would cause existing functionality to not work as expected)

Checklist
 My code follows the style guidelines of this project
 I have performed a self-review of my own code
 I have added the standard DCO sign-off (-s) to my commits