### PR TITLE
feat: fix the ga tag data not being logged in due to lazyload

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -52,6 +52,9 @@ export default function Layout({
       {/* ── Analytics & third-party scripts ──
            All non-essential scripts use lazyOnload to keep TBT/TTI low.
            They fire after the page is fully interactive. */}
+      {/* update: changing this to afterInteractive since this is not a non essential script, due to lazyload on this we 
+           are losing on the important data becasue the script for analytics never gets loaded until the page is fully interavtive
+           and if the user navigates before the page is fully interactive, the script is never triggerred and hence we are losing data */}
 
       <Script
         id="gtag-loader"

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -56,11 +56,11 @@ export default function Layout({
       <Script
         id="gtag-loader"
         src="https://www.googletagmanager.com/gtag/js?id=G-GYS09X6KHS"
-        strategy="lazyOnload"
+        strategy="afterInteractive"
       />
       <Script
         id="google-ga"
-        strategy="lazyOnload"
+        strategy="afterInteractive"
         dangerouslySetInnerHTML={{
           __html: `
           window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
Fixes a major drop in recorded blog traffic caused by delayed Google Analytics script execution.

### RCA & Cause
The Next.js script `strategy="lazyOnload"` forced the browser to wait for a completely idle state before loading Google Analytics. If a user navigated before the browser became idle, the script never fired, resulting in dropped sessions.

### Fix
Changed the script strategy to `afterInteractive` in `components/layout.tsx` so the tracking script executes as soon as the page is interactive.



### Source
[Next.js Documentation](https://nextjs.org/docs/pages/api-reference/components/script#afterinteractive) explicitly recommends afterInteractive for Google Analytics to prevent dropped data from early bounces.
<br/>

<img width="722" height="268" alt="Screenshot 2026-05-07 at 1 47 54 PM" src="https://github.com/user-attachments/assets/894f340b-d0b5-4518-b536-5284625cb9fc" />

<br/>

### Verification
- Build: `npm run build` completed successfully.