### PR TITLE
chore: turn off gitttogether announcement

### DIFF
--- a/components/Announcements.tsx
+++ b/components/Announcements.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { ArrowRight, X } from "lucide-react";
 import { Marquee } from "./Marquee";
 
-const ANNOUNCEMENT_ENABLED = true;
+const ANNOUNCEMENT_ENABLED = false;
 
 const ANNOUNCEMENT = {
   enabled: ANNOUNCEMENT_ENABLED,

--- a/tests/components/Announcements.spec.ts
+++ b/tests/components/Announcements.spec.ts
@@ -31,7 +31,7 @@ const dispatchSyntheticTouch = async (
   );
 };
 
-test.describe('Announcements — Desktop', () => {
+test.describe.skip('Announcements — Desktop', () => {
   test.beforeEach(async ({ page, baseURL }) => {
     await page.goto(baseURL!);
     await page.waitForLoadState('domcontentloaded');
@@ -148,7 +148,7 @@ test.describe('Announcements — Desktop', () => {
   });
 });
 
-test.describe('Announcements — Mobile', () => {
+test.describe.skip('Announcements — Mobile', () => {
   test.use({
     viewport: { width: 375, height: 812 },
     hasTouch: true,


### PR DESCRIPTION
- disabled announcement bar (`ANNOUNCEMENT_ENABLED = false`) 
- we can merge once the event is over
- since announcements are a component now, we can just simply turn them off, and turn on again 
- when we have an update or announcement, we can turn it on again and edit the content in the same file (`Announcements.tsx`)
- playwright suite skipped in lockstep, both can be re-enabled and updated for the next event
