### PR TITLE
temp: replace expired slack urls with new slack cahnnel invite

### DIFF
--- a/config/nav.ts
+++ b/config/nav.ts
@@ -375,7 +375,7 @@ export const developersNav = {
     links: [
       {
         title: "Slack",
-        href: "https://join.slack.com/t/keploy/shared_invite/zt-357qqm9b5-PbZRVu3Yt2rJIa6ofrwWNg",
+        href: "https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA",
         icon: MessageSquare,
         iconColor: "text-indigo-600",
       },
@@ -597,7 +597,7 @@ export const footerLinks = {
     { title: "Documentation", href: "https://keploy.io/docs" },
     {
       title: "Help Center",
-      href: "https://join.slack.com/t/keploy/shared_invite/zt-357qqm9b5-PbZRVu3Yt2rJIa6ofrwWNg",
+      href: "https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA",
     },
     // { title: "Status", href: "/status" },
     // { title: "Contact", href: "/contact" },


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change along with the relevant motivation and context. -->
- Change the expired slack url to a newer slack channel invite.
- This is a brute force solution, there would be an optimised one in future so that the urls is changed only once or fetched from either a variable or smth, so that we dont have to change the urls in the entire codebase.


### Changes
<!-- Provide a concise bullet-point list of key modifications. -->
- Mentioned in the description itself

## Type of Change
<!--  Select the most appropriate option(s) -->
- [x] Chore (maintenance, refactoring, tooling updates)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (change that adds functionality)
- [ ] Breaking Change (may require updates in existing code)
- [ ] UI improvement (visual or design changes)
- [ ] Performance improvement (optimization or efficiency enhancements)
- [ ] Documentation update (changes to README, guides, etc.)
- [ ] CI (updates to continuous integration workflows)
- [ ] Revert (undo a previous commit or merge)

## Testing
<!-- Please describe how these changes were tested, specify any test cases or list any relevant details. -->
- Checked locally, redirecting to the right url


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added corresponding tests
- [x] I have run the build command to ensure there are no build errors
- [x] My changes have been tested across relevant browsers/devices
- [x] For UI changes, I've included visual evidence of my changes

<!--- Thanks for contributing to our blog website! If the tests fail or you have questions, please leave a comment below and our team will be happy to assist you. --->