### PR TITLE
chore: replace the temp slack url to permanent route

### DIFF
--- a/config/nav.ts
+++ b/config/nav.ts
@@ -375,7 +375,7 @@ export const developersNav = {
     links: [
       {
         title: "Slack",
-        href: "https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA",
+        href: "https://keploy.io/slack",
         icon: MessageSquare,
         iconColor: "text-indigo-600",
       },
@@ -597,7 +597,7 @@ export const footerLinks = {
     { title: "Documentation", href: "https://keploy.io/docs" },
     {
       title: "Help Center",
-      href: "https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA",
+      href: "https://keploy.io/slack",
     },
     // { title: "Status", href: "/status" },
     // { title: "Contact", href: "/contact" },


### PR DESCRIPTION
## Summary

- Replaces the temporary Slack invite URL (`join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-...`) with the permanent redirect `https://keploy.io/slack` in two places in `config/nav.ts`
- Covers the nav community links section and the footer "Help Center" support link
- Follows up on #389 which was a temporary fix for the expired invite link

## Files changed

- `config/nav.ts` - 2 URL replacements, no logic changes

