### PR TITLE
chore: add redirects for updated blog URLs

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -225,6 +225,21 @@ module.exports = {
         destination: '/community/codium-vs-copilot-which-ai-coding-assistant-is-best-for-you',
         permanent: true,
       },
+      {
+        source: '/community/software-development-tools-in-2025',
+        destination: '/community/software-development-tools',
+        permanent: true,
+      },
+      {
+        source: '/community/guide-to-automated-testing-tools-in-2025',
+        destination: '/community/automated-software-testing-tools',
+        permanent: true,
+      },
+      {
+        source: '/community/top-7-test-automation-tools-boost-your-software-testing-efficiency',
+        destination: '/community/test-automation-tools',
+        permanent: true,
+      },
     ]
   },
 }


### PR DESCRIPTION
chore: Add permanent redirects for updated community blog URLs

## Summary
This PR introduces 3 permanent (308) redirects for updated community blog posts to ensure backwards compatibility and preserve SEO rankings for the new URLs.

## Changes
- Redirected `/community/software-development-tools-in-2025` to `/community/software-development-tools`
- Redirected `/community/guide-to-automated-testing-tools-in-2025` to `/community/automated-software-testing-tools`
- Redirected `/community/top-7-test-automation-tools-boost-your-software-testing-efficiency` to `/community/test-automation-tools`