### PR TITLE
chore: add 301 redirect for essential-free-api-testing-tools blog slug 

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -19,6 +19,11 @@
       "source": "/blog/technology/regression-testing-tools-rankings-2025",
       "destination": "/blog/technology/regression-testing-tools",
       "permanent": true
+    },
+    {
+      "source": "/blog/community/essential-free-api-testing-tools-every-developer-should-know",
+      "destination": "/blog/community/api-testing-tools",
+      "permanent": true
     }
   ],
   "headers": [


### PR DESCRIPTION
## Summary

- Adds a permanent (301) redirect in `vercel.json` from the old verbose slug
  `/blog/community/essential-free-api-testing-tools-every-developer-should-know`
  to the new canonical slug `/blog/community/api-testing-tools`.

- `vercel.json` - one new redirect entry added, no other changes.
