### PR TITLE
feat: fix sitemap indexing issue due to img tag

### DIFF
--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -234,7 +234,7 @@ function buildEntries(posts, mainSiteUrl) {
 function buildSitemapXml(entries) {
   const namespaces = [
     'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"',
-    'xmlns:image="http://www.google.com/schemas/sitemap-image/0.9"',
+    'xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"',
   ].join("\n        ");
 
   const body = entries


### PR DESCRIPTION
update image sitemap namespace from 0.9 to 1.1

## Problem

After the sitemap automation was merged and the sitemap submitted to Google Search Console, three cascading errors appeared in the GSC coverage report:

| Error | Count |
|---|---|
| Incorrect namespace | 1 |
| Invalid XML tag | 494 |
| Missing XML tag | 988 |

All three trace back to a single root cause: the image sitemap namespace URI in `<urlset>` was declared as version `0.9`:

```xml
xmlns:image="http://www.google.com/schemas/sitemap-image/0.9"
```

**Why it failed:** GSC's validator no longer accepts the `0.9` namespace URI. When it encounters an unrecognized namespace, it cascades:

1. The namespace itself is flagged as incorrect (1 error).
2. Every tag that uses the `image:` prefix - all 494 `<image:loc>` entries - becomes part of an undefined vocabulary and is flagged as invalid (494 errors).
3. The validator then evaluates the entries against the old `0.9` schema rules, which required two now-removed fields per image entry: `family_friendly` and `landing_page_loc`. With 494 image entries and 2 missing fields each, that's exactly 988 missing-tag errors.

The original generator was written following Google's public documentation, which still showed `0.9` in its example code at the time. This was a documentation lag - Google had deprecated `0.9` and moved to `1.1` in their validator, but the docs hadn't been updated. Any hand-written sitemap generator following those docs would have the same issue.

---

## Solution

Change the namespace URI from `0.9` to `1.1` in `scripts/generate-sitemap.mjs`:

```diff
- 'xmlns:image="http://www.google.com/schemas/sitemap-image/0.9"',
+ 'xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"',
```

**How this resolves all three errors:**

- Error 1 (Incorrect namespace): `1.1` is the namespace URI GSC's validator accepts. Once the URI is recognized, the namespace error clears.
- Error 2 (Invalid XML tag): `<image:loc>` and `<image:title>` are both valid elements in the `1.1` schema. Once the namespace is accepted, all 494 tags become valid.
- Error 3 (Missing XML tag): `family_friendly` and `landing_page_loc` were removed from the schema in `1.1`. The validator no longer expects them, so the 988 missing-tag errors disappear.

The element structure of our entries - `<image:image>` containing `<image:loc>` and `<image:title>` - is identical in both versions and requires no changes.

**Verified sources confirming `1.1` is the correct namespace:**

- **Yoast SEO** (the most widely deployed WordPress sitemap plugin, used on 13M+ sites) ships `xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"`. Verifiable live at `https://wp.keploy.io/post-sitemap.xml` - this is keploy's own WordPress backend.
- **TechCrunch** uses `1.1` with `<image:loc>` + `<image:title>` per entry - the identical structure to ours. Verifiable live at `https://techcrunch.com/sitemap-page-1.xml`.
- **Backlinko** uses `1.1` with `xsi:schemaLocation` explicitly pointing to the `1.1` schema document. Verifiable live at `https://backlinko.com/post-sitemap.xml`.
- **HubSpot Blog** declares `xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"`. Verifiable live at `https://blog.hubspot.com/sitemap.xml`.
- Google's official sitemap image extension schema document is hosted at `http://www.google.com/schemas/sitemap-image/1.1/sitemap-image.xsd` - the `1.1` path is the canonical location.

---

## Approach and ideation

The GSC errors weren't immediately obvious. Three separate error types with counts that didn't obviously relate to each other (1, 494, 988) required some investigation before the single root cause became clear.

**First hypothesis - crawlability:** The images in our sitemap point to `wp.keploy.io`, a separate domain from `keploy.io`. The initial concern was that Googlebot might be blocked from crawling `wp.keploy.io` images, which would explain why the image entries were being rejected. This was ruled out by checking `https://wp.keploy.io/robots.txt` - it has no `Disallow` rules and is fully open to all crawlers.

**Second hypothesis - proxy/redirect the image URLs:** If cross-domain was a concern, one option was to rewrite all `<image:loc>` URLs to route through `keploy.io/blog/api/proxy-image` (an existing endpoint that already proxies `wp.keploy.io` images). This would make the image URLs appear to be on the same domain as the sitemap property. However, this was ruled out because the error was a namespace validation error, not a crawl or domain error - a domain change would not affect XML namespace validation at all.

**Third hypothesis - remove image entries entirely:** Stripping `<image:image>` blocks from the sitemap would eliminate all three errors immediately. This was a valid fallback since all blog posts already surface their featured images through `og:image`, `twitter:image`, Schema.org `Article.image`, and standard `<img>` tags - Google can index those images without a sitemap extension. However, removing them entirely means losing the explicit signal to GSC, which has known SEO value for image-heavy content.

**Root cause identified - namespace version:** Comparing our `<urlset>` declaration against live sitemaps from TechCrunch, Backlinko, HubSpot, and the site's own Yoast-generated WordPress sitemap (`wp.keploy.io/post-sitemap.xml`) showed a consistent pattern: every working image sitemap uses `sitemap-image/1.1`. Ours used `sitemap-image/0.9`. Cross-referencing with the GSC error detail - specifically the "Missing XML tag" entries asking for `family_friendly` and `landing_page_loc`, which are fields that exist only in the old `0.9` schema - confirmed that the validator was rejecting `0.9` as an unsupported namespace and then evaluating the entries against the deprecated `0.9` schema rules, producing the cascading errors.

The fix is a one-string change. No structural changes to the sitemap entries are needed.
