### PR TITLE
fix: install libxml2-utils before xmllint in sync-sitemap workflow

### DIFF
--- a/.github/workflows/sync-sitemap.yml
+++ b/.github/workflows/sync-sitemap.yml
@@ -26,7 +26,9 @@ jobs:
         run: node scripts/generate-sitemap.mjs
 
       - name: Validate sitemap XML
-        run: xmllint --noout public/sitemap.xml
+        run: |
+          sudo apt-get install -y libxml2-utils -qq
+          xmllint --noout public/sitemap.xml
 
       - name: Detect sitemap changes
         id: diff


### PR DESCRIPTION


The `Sync Sitemap` cron workflow has been failing every day since June 25 with exit code 127:

```
xmllint: command not found
```

The workflow runs on `ubuntu-latest`, which GitHub recently promoted from `ubuntu-22.04` to `ubuntu-24.04`. On `ubuntu-22.04`, the `libxml2-utils` package (which provides `xmllint`) was pre-installed. On `ubuntu-24.04` it is not.

Because the workflow fails at the XML validation step, it never reaches the commit-and-push step. This means `public/sitemap.xml` has been stale since June 25 - no new posts have been added and the namespace fix from #399 never made it into the committed static file.

## Fix

Explicitly install `libxml2-utils` before calling `xmllint`:

```diff
- run: xmllint --noout public/sitemap.xml
+ run: |
+   sudo apt-get install -y libxml2-utils -qq
+   xmllint --noout public/sitemap.xml
```

The `-qq` flag keeps the apt output quiet so CI logs stay readable. `xmllint` itself is unaffected - it runs identically, just against an explicitly installed binary rather than a pre-installed one.

## Impact

Once merged, the next cron run (or a manual `workflow_dispatch` trigger) will:
1. Generate a fresh `public/sitemap.xml` with the `1.1` image namespace from #399
2. Pass the xmllint validation gate
3. Commit and push the updated sitemap to main
4. Vercel deploys → live site serves the corrected sitemap
---

## Verification

**1. Root cause confirmed from CI logs**
The actual failure log (run ID `28357045666`, June 29) shows `xmllint: command not found` with exit code 127. Exit code 127 is the POSIX standard for "command not found" - this is a missing binary, not an xmllint error.

**2. `libxml2-utils` is absent from the ubuntu-24.04 runner image**
The runner logs identified the exact image: `ubuntu24/20260622.220`. The image README at https://github.com/actions/runner-images/blob/ubuntu24/20260622.220/images/ubuntu/Ubuntu2404-Readme.md`contains zero entries for `libxml2`, `libxml2-utils`, or `xmllint`. Not pre-installed.

**3. `libxml2-utils` is available and installable on Ubuntu 24.04**
Ubuntu's official packages index for Noble (24.04) lists the package: https://packages.ubuntu.com/noble/libxml2-utils. Installing it provides `xmllint`.

**4. Generator produces correct output**
Ran `node scripts/generate-sitemap.mjs` locally against the live WordPress endpoint - succeeds with 512 posts, outputs `xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"`, passes `xmllint --noout` locally.

**5. git diff will trigger the commit step**
The committed `public/sitemap.xml` has `0.9`. The generator now outputs `1.1`. `git diff --quiet` returns non-zero → `changed=true` → commit and push runs.

**6. No branch protection blocks the bot push**
GitHub API confirms no branch protection rules on `main`. The existing `permissions: contents: write` in the workflow is sufficient.

---

## Sources and references

- ubuntu-24.04 runner image software list (exact version used in failing runs):
  https://github.com/actions/runner-images/blob/ubuntu24/20260622.220/images/ubuntu/Ubuntu2404-Readme.md

- Ubuntu Noble (24.04) package detail for `libxml2-utils`:
  https://packages.ubuntu.com/noble/libxml2-utils

- POSIX exit code 127 ("command not found"):
  https://www.gnu.org/software/bash/manual/bash.html#Exit-Status

---
