### PR TITLE
feat(seo): enrich blog Organization schema (entity + E-E-A-T signals)

### DIFF
--- a/lib/structured-data.ts
+++ b/lib/structured-data.ts
@@ -11,6 +11,18 @@ export const SOCIAL_LINKS = [
   "https://www.youtube.com/@keploy",
   "https://www.instagram.com/keploy.io/",
   "https://www.github.com/keploy/keploy",
+  // Authority / review profiles — kept in sync with keploy.io Organization
+  // sameAs so AI engines resolve one consistent Keploy entity across
+  // landing, blog, and docs (reduces entity fragmentation).
+  "https://discord.gg/keploy",
+  "https://community.keploy.io",
+  "https://marketplace.visualstudio.com/items?itemName=Keploy.keployio",
+  "https://chromewebstore.google.com/detail/keploy-api-test-recorder/ohcclfkaidblnjnggclkiecgkpgldihe",
+  "https://www.crunchbase.com/organization/hybridk8s",
+  "https://www.gartner.com/reviews/product/keploy-618993540",
+  "https://www.g2.com/products/keploy/reviews",
+  "https://www.capterra.in/software/1070466/Keploy",
+  "https://aws.amazon.com/marketplace/reviews/reviews-list/prodview-xgwmdk4ivjjv4",
 ];
 
 type BreadcrumbItem = {
@@ -72,6 +84,24 @@ export const getOrganizationSchema = () => ({
   name: ORG_NAME,
   url: MAIN_SITE_URL,
   logo: ORG_LOGO_URL,
+  // Entity/E-E-A-T signals kept in sync with the keploy.io landing
+  // Organization node so all three properties resolve to one Keploy entity.
+  foundingDate: "2021-01-01",
+  knowsAbout: [
+    "API Testing",
+    "Test Automation",
+    "eBPF-based Testing",
+    "Dependency Virtualization",
+    "AI-Powered Testing",
+    "Production Behavior Replay",
+    "Unit Test Generation",
+  ],
+  award: [
+    "API World 2023 Award: Best in API Infrastructure",
+    "CNCF Landscape",
+    "Google for Startups Accelerator",
+    "Google Summer of Code Mentoring Organization",
+  ],
   sameAs: SOCIAL_LINKS,
   contactPoint: [
     {


### PR DESCRIPTION
## What & why

Aligns the **blog-website** `Organization` JSON-LD (`lib/structured-data.ts` → `getOrganizationSchema`) with the `keploy.io` landing `Organization` node so all three web properties (landing, blog, docs) resolve to **one consistent Keploy entity** for AI answer engines. Entity fragmentation across properties is a known GEO/AEO weakness; consistent `sameAs` + `knowsAbout` is the primary entity-disambiguation signal LLMs use.

## Changes (all additive, `lib/structured-data.ts`)
- **`sameAs`**: added verified authority/review profiles already live on landing — Discord, community, VS Code + Chrome Web Store, Crunchbase, Gartner, G2, Capterra, AWS Marketplace.
- **`foundingDate`**: `2021-01-01`
- **`knowsAbout`**: core expertise topics (API Testing, Test Automation, eBPF-based Testing, …)
- **`award`**: API World 2023, CNCF Landscape, Google for Startups, GSoC mentoring org

All values are **mirrored verbatim from the live landing Organization node** — no new or unverified claims.

## Scope / safety
- Touches only `getOrganizationSchema` + the `SOCIAL_LINKS` constant. Does **not** overlap the open `seo/audit-fixes` PR (that PR does not touch `lib/structured-data.ts`).
- Typecheck passes (`tsc --noEmit`).

## Audit mapping
GEO/AEO audit — Organization `knowsAbout`/`foundingDate`/`award` (Tasks 43/51) + cross-property entity consistency (Pixis GEO audit, entity/E-E-A-T lever).

🤖 Generated with [Claude Code](https://claude.com/claude-code)