### PR TITLE
feat: capture newsletter leads via /blog-mql with invisible reCAPTCHA

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -4,3 +4,7 @@ WORDPRESS_API_URL=https://wp.keploy.io/graphql
 # Only required if you want to enable preview mode
 # WORDPRESS_AUTH_REFRESH_TOKEN=
 # WORDPRESS_PREVIEW_SECRET=
+# Lead capture (blog-mql). Committed defaults live in next.config.js env —
+# override here only if you need a different telemetry endpoint or key.
+# NEXT_PUBLIC_TELEMETRY_URL=https://telemetry.keploy.io
+# NEXT_PUBLIC_RECAPTCHA_SITE_KEY=<score-based reCAPTCHA Enterprise key>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,58 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      # The reCAPTCHA site key ships as a committed default in next.config.js
+      # (it's a public value). Validate the EFFECTIVE key against Google before
+      # building: a stale or wrong-type key ships a frontend that sends empty
+      # tokens, so the telemetry server silently rejects every newsletter lead.
+      # Two probes, verified empirically: enterprise.js?render=<key> returns
+      # 400 for checkbox-type keys (the invisible flow needs a score-based
+      # key); the invisible anchor endpoint embeds "Invalid site key" /
+      # "Invalid domain for site key" for nonexistent or wrong-domain keys.
+      # Notes from hard-won debugging: curl prints exit-code-000 http_code on
+      # network failure (never rely on `|| echo` markers), and the anchor `co`
+      # param must be base64url WITHOUT padding — Google rejects padded input.
+      - name: Validate reCAPTCHA site key
+        env:
+          # next.config.js refuses to load without a WordPress URL
+          WORDPRESS_API_URL: "https://wp.keploy.io/graphql"
+        run: |
+          key=$(node -e "console.log(require('./next.config.js').env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY || '')")
+          if [ -z "$key" ]; then
+            echo "ERROR: NEXT_PUBLIC_RECAPTCHA_SITE_KEY resolves empty in next.config.js; lead capture would be disabled." >&2
+            exit 1
+          fi
+          type_status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "https://www.google.com/recaptcha/enterprise.js?render=$key" || true)
+          if [ -z "$type_status" ] || [ "$type_status" = "000" ]; then
+            echo "WARNING: could not reach www.google.com to validate the reCAPTCHA site key; continuing." >&2
+            exit 0
+          fi
+          if [ "$type_status" != "200" ]; then
+            echo "ERROR: the reCAPTCHA loader rejected the site key (enterprise.js?render=<key> returned $type_status)." >&2
+            echo "The frontend needs a SCORE-based Enterprise key — checkbox keys return 400 here." >&2
+            exit 1
+          fi
+          ver=$(curl -s --max-time 15 "https://www.google.com/recaptcha/enterprise.js" | grep -oE 'releases/[0-9A-Za-z_-]+' | head -1 | cut -d/ -f2 || true)
+          if [ -z "$ver" ]; then
+            echo "WARNING: could not extract the reCAPTCHA release version; anchor validation skipped." >&2
+            exit 0
+          fi
+          # The blog serves under keploy.io/blog (basePath), so tokens mint on
+          # the keploy.io origin — that is the origin to validate.
+          origin=$(printf 'https://keploy.io:443' | base64 | tr '+/' '-_' | tr -d '=')
+          body=$(curl -s --max-time 15 "https://www.google.com/recaptcha/enterprise/anchor?ar=1&k=$key&co=$origin&hl=en&v=$ver&size=invisible" || true)
+          if [ -z "$body" ]; then
+            echo "WARNING: reCAPTCHA anchor endpoint returned nothing; key validation skipped." >&2
+            exit 0
+          fi
+          if echo "$body" | grep -qE "Invalid site key|Invalid key type|Invalid domain for site key|ERROR for site owner"; then
+            echo "ERROR: Google rejected the reCAPTCHA site key for origin keploy.io." >&2
+            echo "Fix NEXT_PUBLIC_RECAPTCHA_SITE_KEY in next.config.js (reCAPTCHA Enterprise console -> key with keploy.io domain)." >&2
+            exit 1
+          fi
+
       - name: Build Next.js application
-        env: 
+        env:
           WORDPRESS_API_URL: "https://wp.keploy.io/graphql"
           NEXT_PUBLIC_WORDPRESS_API_URL : "https://wp.keploy.io/graphql"
         run: npm run build

--- a/components/BlogSidebar.tsx
+++ b/components/BlogSidebar.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { useRouter } from "next/router";
+import SubscribeNewsletter from "./subscribe-newsletter";
 import {
   FaFacebook,
   FaLinkedin,
@@ -263,6 +264,12 @@ export default function BlogSidebar() {
 
       {/* Ad banner */}
       <SidebarAdBanner />
+
+      {/* Dashed divider */}
+      <hr className="border-0 border-t-2 border-dashed border-gray-300" />
+
+      {/* Newsletter + lead capture */}
+      <SubscribeNewsletter />
     </div>
   );
 }

--- a/components/subscribe-newsletter.tsx
+++ b/components/subscribe-newsletter.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import styles from "./subscribe-newsletter.module.css";
 import { newsLetterSubscriptionUrl } from '../services/constants'
-import newsletterBunny from "../public/images/newsletterBunny.png"
-import Image from "next/image";
-import { gsap } from "gsap";
+import { useInvisibleRecaptcha, RecaptchaAttribution } from "../lib/use-invisible-recaptcha";
+import { sendBlogLead } from "../lib/blog-mql";
 
 export const subscribeMutation = (formData: { fullName: string, email: string, companyName: string, message: string }) => {
 
@@ -39,7 +38,7 @@ export const subscribeMutation = (formData: { fullName: string, email: string, c
 };
 
 
-export default function SubscribeNewsletter(props: { isSmallScreen: Boolean }) {
+export default function SubscribeNewsletter(props: { isSmallScreen?: boolean }) {
   const myComponent = useRef<HTMLDivElement>(null);
   const [isVisible, setVisible] = useState<boolean>(true);
   const [fullName, setFullName] = useState('');
@@ -48,6 +47,10 @@ export default function SubscribeNewsletter(props: { isSmallScreen: Boolean }) {
   const [subscribed, setSubscribed] = useState<boolean>(false);
   const [emailError, setEmailError] = useState('');
   const message = "NEWSLETTER"
+  // Don't load Google's script for every reader — only once someone actually
+  // interacts with the form (filling three fields leaves it ample time to load).
+  const [captchaActive, setCaptchaActive] = useState(false);
+  const { script: recaptchaScript, getToken } = useInvisibleRecaptcha(captchaActive);
   const isValidEmail = (email) => {
     return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
   };
@@ -89,40 +92,30 @@ export default function SubscribeNewsletter(props: { isSmallScreen: Boolean }) {
       message
     };
 
+    // Lead capture rides alongside the newsletter subscription, never gating
+    // it: token minting and the /blog-mql POST are fire-and-forget (fail-open,
+    // verified server-side via reCAPTCHA Enterprise).
+    const page = window.location.href;
+    getToken('submit_lead').then((recaptchaToken) => {
+      sendBlogLead({
+        email: email.trim().toLowerCase(),
+        name: fullName.trim(),
+        company: companyName.trim(),
+        source: 'blog-newsletter',
+        page,
+        assetType: 'newsletter',
+        recaptchaToken,
+      });
+    });
+
     handleSubscribe(payload)
   };
   const isSubscribeDisabled = ()=>{
     return Boolean(!email || !fullName || !companyName)    
   }
-  const bunnyRef = useRef(null);
-
-  useEffect(() => {
-    const currentBunnyRef = bunnyRef.current;
-    
-    const timer = setTimeout(() => {
-      if (!props.isSmallScreen) {
-        gsap.to(currentBunnyRef, { y: -180, duration: 1, yoyo: true, repeat: 1 })
-          .then(() => {
-            gsap.to(currentBunnyRef, { y: 140, duration: 0.4 }); 
-          });
-      } else {
-        gsap.to(currentBunnyRef, { y: 0 });
-      }
-    }, 1000);
-    
-    return () => {
-      clearTimeout(timer);
-      if (currentBunnyRef) {
-        gsap.killTweensOf(currentBunnyRef);
-      }
-    };
-}, [props.isSmallScreen]);
   return (
-    <div className="flex flex-col" ref={bunnyRef}>
-      <div className="hidden lg:block ">
-        <Image src={newsletterBunny} alt="Subscribe to Keploy newsletter" />
-      </div>
-      <div className="overflow-x-hidden mt-2 lg:-mt-7 shadow-md border-b-primary-300 border-b-2 py-6 px-4 sticky ml-0 sm:ml-10 md:ml-0  w-full" ref={myComponent}>
+    <div className="flex flex-col">
+      <div className="overflow-x-hidden mt-2 shadow-md rounded-lg border-b-primary-300 border-b-2 py-6 px-4 sticky ml-0 sm:ml-10 md:ml-0  w-full" ref={myComponent}>
         <div
           className={`${isVisible ? styles["slide-in"] : "translate-x-full opacity-0"
             }`}
@@ -131,7 +124,11 @@ export default function SubscribeNewsletter(props: { isSmallScreen: Boolean }) {
             <p className="text-sm text-black pb-2 text-center">
               To get the latest blogs and updates straight to your inbox.
             </p>
-            <form className="flex flex-col gap-y-4 text-sm" onSubmit={submitHandler}>
+            <form
+              className="flex flex-col gap-y-4 text-sm"
+              onSubmit={submitHandler}
+              onFocusCapture={() => setCaptchaActive(true)}
+            >
               <input
                 type="text"
                 className="rounded px-4 py-2 border border-gray-300 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
@@ -170,7 +167,9 @@ export default function SubscribeNewsletter(props: { isSmallScreen: Boolean }) {
             <span className="text-xs mt-2 border-none mb-2 text-center block">
               *<strong>We won&#39;t spam you</strong> only one Email every month.
             </span>
+            <RecaptchaAttribution />
           </div>
+          {recaptchaScript}
           {emailError && <p className="text-sm text-red-500 text-center font-semibold mt-3">{emailError}</p>}
           {subscribed && <p className="text-sm text-green-800 text-center font-semibold mt-3">Thanks for subscribing!</p>}
         </div>

--- a/lib/blog-mql.ts
+++ b/lib/blog-mql.ts
@@ -1,0 +1,69 @@
+export interface BlogLead {
+  email: string;
+  name?: string;
+  company?: string;
+  designation?: string;
+  source: string;
+  page: string;
+  assetType?: string;
+  assetId?: string;
+  assetTitle?: string;
+  recaptchaToken: string;
+}
+
+/**
+ * Fire-and-forget lead capture to the telemetry service's /blog-mql endpoint
+ * (verified server-side via reCAPTCHA Enterprise assessments). Never blocks
+ * or fails the caller's flow: a lost MQL is preferable to a broken UX.
+ * keepalive lets the request survive navigation.
+ */
+// Server-side field caps (telemetry validateBlogMQLRequest) — an over-limit
+// field rejects the WHOLE lead with a 400, so truncate client-side instead of
+// losing the lead to an oversized page URL or a long company name.
+const FIELD_CAPS: Partial<Record<keyof BlogLead, number>> = {
+  email: 254,
+  name: 120,
+  company: 160,
+  designation: 120,
+  source: 80,
+  page: 500,
+  assetType: 80,
+  assetId: 160,
+  assetTitle: 200,
+};
+
+export function sendBlogLead(lead: BlogLead): void {
+  const base = process.env.NEXT_PUBLIC_TELEMETRY_URL;
+  if (!base) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.debug('[blog-mql] NEXT_PUBLIC_TELEMETRY_URL not set; lead capture is disabled');
+    }
+    return;
+  }
+  const payload: Record<string, string> = {};
+  for (const [field, value] of Object.entries(lead)) {
+    if (value === undefined) continue;
+    const cap = FIELD_CAPS[field as keyof BlogLead];
+    payload[field] = cap ? String(value).slice(0, cap) : String(value);
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 15000);
+  fetch(`${base}/blog-mql`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    signal: controller.signal,
+    keepalive: true,
+    body: JSON.stringify(payload),
+  })
+    .then((res) => {
+      if (!res.ok && process.env.NODE_ENV !== 'production') {
+        console.debug(`[blog-mql] lead capture rejected: ${res.status} ${res.statusText}`);
+      }
+    })
+    .catch((err) => {
+      if (process.env.NODE_ENV !== 'production') {
+        console.debug('[blog-mql] lead capture error:', err);
+      }
+    })
+    .finally(() => clearTimeout(timer));
+}

--- a/lib/use-invisible-recaptcha.tsx
+++ b/lib/use-invisible-recaptcha.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useState } from 'react';
+import Script from 'next/script';
+
+declare global {
+  interface Window {
+    grecaptcha?: {
+      enterprise?: {
+        ready: (cb: () => void) => void;
+        execute: (siteKey: string, opts: { action: string }) => Promise<string>;
+      };
+    };
+  }
+}
+
+/** How long to wait for the reCAPTCHA script before failing open (ms). */
+const CAPTCHA_WATCHDOG_MS = 10000;
+/** Ceiling on a single execute() call — a hung call must not strand the lead (ms). */
+const EXECUTE_TIMEOUT_MS = 5000;
+
+export const RECAPTCHA_SITE_KEY = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
+
+/**
+ * Invisible score-based reCAPTCHA Enterprise, mirroring the landing repo's
+ * ReportGate flow: tokens are minted at submit time via
+ * grecaptcha.enterprise.execute() and verified server-side by the telemetry
+ * service. Everything fails OPEN — a blocked or broken captcha never blocks
+ * the visitor's action; the lead is simply sent with an empty token and
+ * rejected server-side (visible in telemetry logs).
+ *
+ * The badge is hidden globally (styles/index.css), which Google's terms
+ * permit only when the "Protected by reCAPTCHA" attribution is shown next
+ * to the form — render `RecaptchaAttribution` there.
+ *
+ * Render the returned `script` element while the host form is mounted.
+ */
+export function useInvisibleRecaptcha(active: boolean) {
+  const [scriptReady, setScriptReady] = useState(false);
+  const [captchaFailed, setCaptchaFailed] = useState(false);
+
+  // On re-navigation the script may already be in the window before this
+  // hook's Script element mounts (next/script re-fires onReady on remount,
+  // but only after mount) — recover the ready state immediately.
+  useEffect(() => {
+    if (active && !scriptReady && window.grecaptcha?.enterprise) setScriptReady(true);
+  }, [active, scriptReady]);
+
+  // Fail-open watchdog: Script onError only fires for outright load failures.
+  // A stalled request or blocked follow-up resources would otherwise never
+  // resolve. If the script actually arrived but onReady was swallowed,
+  // recover instead of failing.
+  useEffect(() => {
+    if (!active || !RECAPTCHA_SITE_KEY || scriptReady || captchaFailed) return;
+    const timer = setTimeout(() => {
+      if (window.grecaptcha?.enterprise) setScriptReady(true);
+      else setCaptchaFailed(true);
+    }, CAPTCHA_WATCHDOG_MS);
+    return () => clearTimeout(timer);
+  }, [active, scriptReady, captchaFailed]);
+
+  // Mint a token invisibly; resolve '' on any failure or hang (fail open).
+  // Checks the live window rather than captchaFailed: if the script arrived
+  // after the watchdog latched, a real token is still mintable.
+  const getToken = (action: string): Promise<string> => {
+    const enterprise = window.grecaptcha?.enterprise;
+    if (!RECAPTCHA_SITE_KEY || !enterprise) return Promise.resolve('');
+    return new Promise<string>((resolve) => {
+      const timer = setTimeout(() => resolve(''), EXECUTE_TIMEOUT_MS);
+      const settle = (token: string) => {
+        clearTimeout(timer);
+        resolve(token);
+      };
+      try {
+        enterprise.ready(() => {
+          enterprise
+            .execute(RECAPTCHA_SITE_KEY, { action })
+            .then(settle)
+            .catch(() => settle(''));
+        });
+      } catch {
+        settle('');
+      }
+    });
+  };
+
+  const script =
+    active && RECAPTCHA_SITE_KEY ? (
+      <Script
+        src={`https://www.google.com/recaptcha/enterprise.js?render=${RECAPTCHA_SITE_KEY}`}
+        strategy="afterInteractive"
+        onReady={() => setScriptReady(true)}
+        onError={() => setCaptchaFailed(true)}
+      />
+    ) : null;
+
+  return { script, getToken, scriptReady, captchaFailed };
+}
+
+/** Required whenever the badge is hidden (Google's terms). */
+export function RecaptchaAttribution() {
+  if (!RECAPTCHA_SITE_KEY) return null;
+  return (
+    <span className="text-xs text-gray-400 block text-center">
+      Protected by reCAPTCHA &mdash;{' '}
+      <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer" className="underline">
+        Privacy
+      </a>
+      {' & '}
+      <a href="https://policies.google.com/terms" target="_blank" rel="noopener noreferrer" className="underline">
+        Terms
+      </a>
+    </span>
+  );
+}

--- a/next.config.js
+++ b/next.config.js
@@ -10,7 +10,7 @@ const { protocol, hostname, port, pathname } = new URL(
 )
 
 const contentSecurityPolicy = `
-  connect-src 'self' https://px.ads.linkedin.com https://www.google-analytics.com https://analytics.google.com https://region1.google-analytics.com https://stats.g.doubleclick.net https://rp.liadm.com https://idx.liadm.com https://pagead2.googlesyndication.com https://*.clarity.ms https://news.google.com https://assets.apollo.io https://wp.keploy.io https://cdn.hashnode.com https://keploy-websites.vercel.app https://blog-website-phi-eight.vercel.app https://docbot.keploy.io https://www.youtube.com https://youtube.com https://www.youtube-nocookie.com https://*.youtube.com https://*.googlevideo.com https://googleads.g.doubleclick.net https://marketplace.visualstudio.com https://api.github.com https://pro.ip-api.com https://api.vector.co https://aplo-evnt.com https://ep1.adtrafficquality.google https://ppptg.com https://telemetry.keploy.io;
+  connect-src 'self' https://telemetry.keploy.io https://www.google.com https://px.ads.linkedin.com https://www.google-analytics.com https://analytics.google.com https://region1.google-analytics.com https://stats.g.doubleclick.net https://rp.liadm.com https://idx.liadm.com https://pagead2.googlesyndication.com https://*.clarity.ms https://news.google.com https://assets.apollo.io https://wp.keploy.io https://cdn.hashnode.com https://keploy-websites.vercel.app https://blog-website-phi-eight.vercel.app https://docbot.keploy.io https://www.youtube.com https://youtube.com https://www.youtube-nocookie.com https://*.youtube.com https://*.googlevideo.com https://googleads.g.doubleclick.net https://marketplace.visualstudio.com https://api.github.com https://pro.ip-api.com https://api.vector.co https://aplo-evnt.com https://ep1.adtrafficquality.google https://ppptg.com;
   frame-src 'self' https://www.googletagmanager.com https://keploy-websites.vercel.app https://blog-website-phi-eight.vercel.app https://docbot.keploy.io https://www.youtube.com https://youtube.com https://www.youtube-nocookie.com https://*.youtube.com https://news.google.com https://googleads.g.doubleclick.net https://*.google.com https://ppptg.com;
   img-src 'self' data: https://c.bing.com https://ppptg.com https://wp.keploy.io https://keploy.io https://secure.gravatar.com https://pbs.twimg.com https://*.wp.com https://*.wordpress.com *;
 `
@@ -26,6 +26,15 @@ module.exports = {
   // This exposes the server-side variable to the browser
   env: {
     NEXT_PUBLIC_WORDPRESS_API_URL: process.env.WORDPRESS_API_URL,
+    // Lead capture (blog-mql): both values are public (the site key ships in
+    // the JS bundle by design) and committed here as defaults so a clean
+    // checkout can never silently build without them — a missing key sends
+    // empty reCAPTCHA tokens and the telemetry server rejects every lead.
+    NEXT_PUBLIC_TELEMETRY_URL:
+      process.env.NEXT_PUBLIC_TELEMETRY_URL || 'https://telemetry.keploy.io',
+    NEXT_PUBLIC_RECAPTCHA_SITE_KEY:
+      process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY ||
+      '6LcURVUtAAAAAL0lEReXR4kKj_SaLymm_0MQzJHB',
   },
   // ----------------------
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -448,3 +448,11 @@ td {
     --chart-5: 340 75% 55%;
   }
 }
+/* Hide the reCAPTCHA badge site-wide. The enterprise.js script (loaded by
+   the newsletter lead capture) appends the badge to <body> and outlives the
+   component, so a component-scoped style would leak it. Hiding it is allowed
+   by Google's terms only because the form shows the required
+   "Protected by reCAPTCHA" attribution (RecaptchaAttribution). */
+.grecaptcha-badge {
+  visibility: hidden;
+}

--- a/tests/e2e/LeadCapture.spec.ts
+++ b/tests/e2e/LeadCapture.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect, Route } from '@playwright/test';
+
+/**
+ * Newsletter lead capture → telemetry /blog-mql with an invisible reCAPTCHA
+ * Enterprise token. The Google loader is stubbed so the test is deterministic
+ * and offline: window.grecaptcha.enterprise is injected before hydration and
+ * the real enterprise.js request is fulfilled with an empty script.
+ */
+test.describe('Newsletter lead capture (blog-mql + reCAPTCHA)', () => {
+  // The sidebar renders twice (desktop ≥1440px + mobile fallback); use a wide
+  // viewport so the first DOM instance is the visible one.
+  test.use({ viewport: { width: 1600, height: 1000 } });
+
+  let leadRequests: Array<Record<string, unknown>>;
+
+  test.beforeEach(async ({ page, baseURL }) => {
+    leadRequests = [];
+
+    await page.route('https://www.google.com/recaptcha/enterprise.js*', (route: Route) =>
+      route.fulfill({ status: 200, contentType: 'application/javascript', body: '/* stubbed loader */' })
+    );
+
+    await page.addInitScript(() => {
+      (window as any).grecaptcha = {
+        enterprise: {
+          ready: (cb: () => void) => cb(),
+          execute: async () => 'e2e-stub-token',
+        },
+      };
+    });
+
+    // No OPTIONS handling needed: Playwright's interception bypasses CORS
+    // entirely for route.fulfill'd requests — the handler only ever sees POST.
+    await page.route('**/blog-mql', async (route: Route) => {
+      leadRequests.push(route.request().postDataJSON());
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: '{"success":true}',
+      });
+    });
+
+    const targetUrl = baseURL
+      ? `${baseURL}/technology`
+      : 'http://localhost:3000/blog/technology';
+    await page.goto(targetUrl);
+    await page.waitForLoadState('domcontentloaded');
+
+    const firstPost = page.locator('a[href*="/technology/"]').first();
+    await expect(firstPost).toBeVisible({ timeout: 15000 });
+    await firstPost.click();
+    await page.waitForLoadState('domcontentloaded');
+  });
+
+  test('submitting the newsletter form sends a lead with the reCAPTCHA token', async ({ page }) => {
+    const form = page.locator('form', { has: page.getByPlaceholder('Full Name') }).first();
+    await form.scrollIntoViewIfNeeded();
+    await expect(form).toBeVisible({ timeout: 15000 });
+
+    await form.getByPlaceholder('Full Name').fill('E2E Tester');
+    await form.getByPlaceholder('Email').fill('e2e@keploy.io');
+    await form.getByPlaceholder('Company Name').fill('Keploy');
+    await form.locator('button[type="submit"]').click();
+
+    await expect
+      .poll(() => leadRequests.length, { timeout: 10000, message: 'lead POST should fire' })
+      .toBeGreaterThan(0);
+
+    const lead = leadRequests[0];
+    expect(lead.email).toBe('e2e@keploy.io');
+    expect(lead.name).toBe('E2E Tester');
+    expect(lead.company).toBe('Keploy');
+    expect(lead.source).toBe('blog-newsletter');
+    expect(lead.assetType).toBe('newsletter');
+    expect(lead.recaptchaToken).toBe('e2e-stub-token');
+    expect(String(lead.page)).toContain('/blog/');
+  });
+
+  test('shows the reCAPTCHA attribution required for the hidden badge', async ({ page }) => {
+    const attribution = page.getByText('Protected by reCAPTCHA').first();
+    await attribution.scrollIntoViewIfNeeded();
+    await expect(attribution).toBeVisible({ timeout: 15000 });
+  });
+
+  test('lead is still sent with an empty token when reCAPTCHA is unavailable (fail open)', async ({ page }) => {
+    // Remove the stub and make the loader fail — the form must not block.
+    await page.addInitScript(() => {
+      delete (window as any).grecaptcha;
+    });
+    await page.route('https://www.google.com/recaptcha/enterprise.js*', (route: Route) => route.abort());
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+
+    const form = page.locator('form', { has: page.getByPlaceholder('Full Name') }).first();
+    await form.scrollIntoViewIfNeeded();
+    await expect(form).toBeVisible({ timeout: 15000 });
+
+    await form.getByPlaceholder('Full Name').fill('Blocked User');
+    await form.getByPlaceholder('Email').fill('blocked@keploy.io');
+    await form.getByPlaceholder('Company Name').fill('Keploy');
+    await form.locator('button[type="submit"]').click();
+
+    await expect
+      .poll(() => leadRequests.length, { timeout: 10000, message: 'fail-open lead POST should fire' })
+      .toBeGreaterThan(0);
+    expect(leadRequests[0].recaptchaToken).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Extends the reCAPTCHA-protected lead capture (landing#250 / telemetry#40) to the blog. Blog readers never reached the MQL pipeline — the newsletter form has been **orphaned dead code since #46** (waitlist banner replaced it), so nothing on the blog captured emails at all.

- **Revives the newsletter form inside `BlogSidebar`** (every post page, desktop sidebar + mobile fallback), minus its old bunny/gsap weight.
- Submissions still hit the newsletter service unchanged, and now *also* send a fire-and-forget lead to telemetry `/blog-mql` with an invisible **score-based reCAPTCHA Enterprise** token (same key as the report gates — `blog.keploy.io` and `keploy.io` are both registered). Fail-open: a blocked captcha never blocks the subscription; the lead just carries an empty token and is rejected server-side, visibly in telemetry logs.
- Google's script loads only after first interaction with the form — no third-party JS for readers who never touch it.
- **Public config as committed defaults in `next.config.js` env** (telemetry URL + site key): `.env` is gitignored in this repo, so a clean checkout would otherwise build with both values undefined and silently drop every lead — the exact incident class from landing#247/#249.
- CI validates the effective key against Google before building (wrong-type/nonexistent/wrong-domain probes; verified against the real key for the `keploy.io` origin).
- Client-side field truncation to the server's caps, CSP `connect-src` additions, badge hidden + required attribution shown.

## Testing
- New Playwright e2e (3 specs): token-attached lead POST, attribution visibility, fail-open empty-token path — green.
- Full suite: **222/222 passing**.
- Multi-agent adversarial review (18 agents): 13 confirmed findings all fixed, including the gitignored-.env trap and two shell bugs in the CI probe (curl `000` handling, base64 padding rejection by Google's anchor endpoint).

## Note for deploy
If the production Vercel project sets these env vars in its dashboard they win over the committed defaults; nothing else to configure — backend (telemetry v0.6.5) is already live and verifying against this key.