### PR TITLE
fix: deflake author Person JSON-LD spec and serve complete HTML for cold author slugs

### DIFF
--- a/pages/authors/[slug].tsx
+++ b/pages/authors/[slug].tsx
@@ -104,13 +104,13 @@ export const getStaticPaths: GetStaticPaths = async ({ }) => {
 
     return {
       paths,
-      fallback: true,
+      fallback: "blocking",
     };
   } catch (error) {
     console.error("authors/[slug] getStaticPaths error:", error);
     return {
       paths: [],
-      fallback: true,
+      fallback: "blocking",
     };
   }
 };

--- a/tests/pages/AuthorDetailPage.spec.ts
+++ b/tests/pages/AuthorDetailPage.spec.ts
@@ -26,11 +26,24 @@ test.describe('Author Detail Page - Component Availability', () => {
     expect(title).not.toMatch(/^undefined/i);
   });
 
-  test('should emit Person JSON-LD for E-E-A-T author credibility', async ({ page }) => {
+  test('should emit Person JSON-LD for E-E-A-T author credibility', async ({ page, baseURL }) => {
     // LIVE-11: author pages now include Person schema so AI models can
     // resolve the author entity and weight the authority of the posts
     // they cite. This test asserts the schema is present in the HTML
     // payload so it reaches AI crawlers before any hydration.
+    //
+    // Do NOT rely on the beforeEach click: it is a client-side SPA
+    // transition that intermittently fails to navigate (hydration race
+    // on the Link), and crawlers do full loads anyway — the surface this
+    // assertion documents. Resolve the first author URL from the list
+    // and load it directly so the count runs against the
+    // server-rendered payload.
+    await page.goto(`${baseURL!}/authors`, { waitUntil: 'domcontentloaded' });
+    const authorLink = page.locator('a[href*="/authors/"]:not([href$="/authors"])').first();
+    await expect(authorLink).toBeVisible({ timeout: 15000 });
+    const href = await authorLink.getAttribute('href');
+    expect(href).toBeTruthy();
+    await page.goto(href!, { waitUntil: 'domcontentloaded' });
     const personSchemaCount = await page
       .locator('script[type="application/ld+json"]')
       .evaluateAll((els) =>


### PR DESCRIPTION
## Root cause

`AuthorDetailPage.spec.ts`'s Person JSON-LD test fails locally (~2 in 3 runs) but passes in CI — because CI runs with `retries: 1`, which masks it. Failure snapshots show the test asserting against the **authors list page**: the `beforeEach` click is a client-side SPA transition that intermittently never navigates (hydration race on the `Link`), and `waitForLoadState('domcontentloaded')` resolves instantly on SPA transitions, so nothing catches the missed navigation.

## Fix

- The Person JSON-LD test now resolves the first author's URL from the list and **loads it directly** — a full server load, which is exactly the surface the test's own comment documents ("schema present in the HTML payload so it reaches AI crawlers before any hydration"). A clicked SPA transition never tested that.
- `pages/authors/[slug].tsx` switches `getStaticPaths` to `fallback: 'blocking'`: with `fallback: true`, a cold slug served a shell page — no `<title>`, no Person schema (the exact LIVE-11 regression class) — until generation finished. Blocking serves the complete document on first request.

## Verification

3/3 clean-server local runs green (previously 1/3). Found while validating keploy/blog-website#403's rebase — this failure predates that branch (reproduced on clean main at 2fc3d49).