### PR TITLE
chore: redirect legacy CI/CD blog post to ci-cd-testing-guide

### DIFF
--- a/config/redirect.ts
+++ b/config/redirect.ts
@@ -12,7 +12,8 @@ export const slugRedirects: Record<string, string> = {
     // Example redirects - add your mappings here
     // "old-post-slug": "new-post-slug",
     "everything-you-need-to-know-about-api-testing": "what-is-api-testing",
-    "regression-testing-tools-rankings-2025": "regression-testing-tools"
+    "regression-testing-tools-rankings-2025": "regression-testing-tools",
+    "how-cicd-is-changing-the-future-of-software-development": "ci-cd-testing-guide"
 
     // "deprecated-article": "updated-article",
 };


### PR DESCRIPTION
Added a slug redirect so /blog/community/how-cicd-is-changing-the-future-of-software-development permanently redirects (308) to /blog/community/ci-cd-testing-guide, consolidating outdated content into the current guide.
