### PR TITLE
feat: updated ui for the 5 year cta banner

### DIFF
--- a/components/InlinePromoCard.module.css
+++ b/components/InlinePromoCard.module.css
@@ -50,6 +50,13 @@
   -webkit-text-fill-color: transparent;
   color: transparent;
 }
+@media (forced-colors: active) {
+  .k5y-accent-gradient {
+    background: none;
+    -webkit-text-fill-color: currentColor;
+    color: currentColor;
+  }
+}
 .k5y-heading-mobile { display: none; }
 
 .k5y-cta-btn {

--- a/components/InlinePromoCard.module.css
+++ b/components/InlinePromoCard.module.css
@@ -1,0 +1,100 @@
+.k5y-card {
+  position: relative;
+  overflow: hidden;
+  background: #ffffff;
+  border-radius: 0;
+}
+.k5y-ellipse {
+  position: absolute;
+  pointer-events: none;
+  z-index: 0;
+  display: block;
+}
+.k5y-ellipse-tr { top: 0; right: 0; width: 42px; height: 86px; }
+.k5y-ellipse-left { left: 0; top: 50%; width: 33px; height: 123px; transform: translateY(-50%); }
+.k5y-ellipse-bottom { right: 14px; bottom: 0; width: 286px; height: 82px; }
+.k5y-ellipse-tl-m,
+.k5y-ellipse-top-m,
+.k5y-ellipse-right-m,
+.k5y-ellipse-bottom-m {
+  display: none;
+}
+
+.k5y-inner {
+  position: relative;
+  z-index: 1;
+  padding: 44px 349px 44px 56px;
+}
+.k5y-badge-img {
+  position: absolute;
+  z-index: 1;
+  top: -21px;
+  right: -12px;
+  width: 337px;
+  height: 337px;
+}
+.k5y-badge-img-mobile { display: none; }
+
+.k5y-heading {
+  font-family: "Lexend", sans-serif;
+  font-weight: 700;
+  font-size: 28px;
+  line-height: 1.28;
+  color: #000000;
+  margin: 0 0 26px;
+}
+.k5y-accent-gradient {
+  background: linear-gradient(90deg, #ff9d2e, #f76b1c);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+.k5y-heading-mobile { display: none; }
+
+.k5y-cta-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 18px;
+  background: #f76b1c;
+  color: #ffffff;
+  border-radius: 9999px;
+  border: none;
+  font-family: "Lexend", sans-serif;
+  font-weight: 500;
+  font-size: 20px;
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: filter 200ms ease, transform 200ms ease;
+}
+.k5y-cta-btn:hover { filter: brightness(1.06); transform: translateY(-1px); }
+.k5y-cta-btn:active { transform: translateY(1px); }
+.k5y-cta-btn:focus-visible { outline: 3px solid #f76b1c; outline-offset: 2px; }
+.k5y-cta-icon { width: 18px; height: 18px; flex-shrink: 0; }
+
+@media (max-width: 850px) {
+  .k5y-ellipse-tr, .k5y-ellipse-left, .k5y-ellipse-bottom { display: none; }
+  .k5y-ellipse-tl-m { display: block; top: 0; left: 0; width: 54px; height: 96px; }
+  .k5y-ellipse-top-m { display: block; top: 0; right: 46px; width: 61px; height: 28px; }
+  .k5y-ellipse-right-m { display: block; top: 35px; right: 0; width: 41px; height: 166px; }
+  .k5y-ellipse-bottom-m { display: block; left: 23px; bottom: 0; width: 53px; height: 33px; }
+
+  .k5y-inner { text-align: center; padding: 0 16px 44px; }
+  .k5y-badge-img { display: none; }
+  .k5y-badge-img-mobile {
+    display: block;
+    position: static;
+    width: 190px;
+    height: auto;
+    margin: 32px auto 16px;
+  }
+
+  .k5y-heading { font-size: 14px; font-weight: 800; line-height: 1.35; margin: 0 0 22px; }
+  .k5y-heading-desktop { display: none; }
+  .k5y-heading-mobile { display: block; }
+
+  .k5y-cta-btn { padding: 5px 9px; font-size: 10px; gap: 3px; }
+  .k5y-cta-icon { width: 10px; height: 10px; }
+}

--- a/components/InlinePromoCard.tsx
+++ b/components/InlinePromoCard.tsx
@@ -78,7 +78,7 @@ function Keploy5YearsBanner() {
           display: inline-flex;
           align-items: center;
           gap: 6px;
-          padding: 9.6px 18px;
+          padding: 10px 18px;
           background: #f76b1c;
           color: #ffffff;
           border-radius: 9999px;
@@ -96,29 +96,27 @@ function Keploy5YearsBanner() {
         .k5y-cta-btn:focus-visible { outline: 3px solid #f59e0b; outline-offset: 2px; }
         .k5y-cta-icon { width: 18px; height: 18px; flex-shrink: 0; }
 
-        @media (max-width: 600px) {
+        @media (max-width: 850px) {
           .k5y-ellipse-tr, .k5y-ellipse-left, .k5y-ellipse-bottom { display: none; }
           .k5y-ellipse-tl-m { display: block; top: 0; left: 0; width: 54px; height: 96px; }
           .k5y-ellipse-top-m { display: block; top: 0; right: 46px; width: 61px; height: 28px; }
           .k5y-ellipse-right-m { display: block; top: 35px; right: 0; width: 41px; height: 166px; }
           .k5y-ellipse-bottom-m { display: block; left: 23px; bottom: 0; width: 53px; height: 33px; }
 
-          .k5y-inner { text-align: center; padding: 250px 16px 44px; }
+          .k5y-inner { text-align: center; padding: 0 16px 44px; }
           .k5y-badge-img { display: none; }
           .k5y-badge-img-mobile {
             display: block;
-            position: absolute;
-            top: 32px;
-            left: 50%;
+            position: static;
             width: 190px;
             height: auto;
-            transform: translateX(-50%);
+            margin: 32px auto 16px;
           }
 
-          .k5y-heading { font-size: 12.5px; font-weight: 800; line-height: 1.35; margin: 0 0 22px; }
+          .k5y-heading { font-size: 12px; font-weight: 800; line-height: 1.35; margin: 0 0 22px; }
           .k5y-lb2 { display: none; }
 
-          .k5y-cta-btn { padding: 4.8px 8.8px; font-size: 10px; gap: 3px; }
+          .k5y-cta-btn { padding: 5px 9px; font-size: 10px; gap: 3px; }
           .k5y-cta-icon { width: 10px; height: 10px; }
         }
       `}</style>
@@ -126,24 +124,28 @@ function Keploy5YearsBanner() {
       <div className="k5y-card">
         {/* Decorative blobs — desktop */}
         {/* eslint-disable @next/next/no-img-element */}
-        <img className="k5y-ellipse k5y-ellipse-tr" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-top-right.svg" alt="" aria-hidden="true" />
-        <img className="k5y-ellipse k5y-ellipse-left" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-left-side.svg" alt="" aria-hidden="true" />
-        <img className="k5y-ellipse k5y-ellipse-bottom" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-bottom.svg" alt="" aria-hidden="true" />
+        <img className="k5y-ellipse k5y-ellipse-tr" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-top-right.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" />
+        <img className="k5y-ellipse k5y-ellipse-left" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-left-side.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" />
+        <img className="k5y-ellipse k5y-ellipse-bottom" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-bottom.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" />
         {/* Decorative blobs — mobile */}
-        <img className="k5y-ellipse k5y-ellipse-tl-m" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-top-left-mobile.svg" alt="" aria-hidden="true" />
-        <img className="k5y-ellipse k5y-ellipse-top-m" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-mobile-top.svg" alt="" aria-hidden="true" />
-        <img className="k5y-ellipse k5y-ellipse-right-m" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-right-mobile.svg" alt="" aria-hidden="true" />
-        <img className="k5y-ellipse k5y-ellipse-bottom-m" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-bottom-mobile.svg" alt="" aria-hidden="true" />
+        <img className="k5y-ellipse k5y-ellipse-tl-m" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-top-left-mobile.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" />
+        <img className="k5y-ellipse k5y-ellipse-top-m" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-mobile-top.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" />
+        <img className="k5y-ellipse k5y-ellipse-right-m" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-right-mobile.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" />
+        <img className="k5y-ellipse k5y-ellipse-bottom-m" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-bottom-mobile.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" />
 
         <img
           className="k5y-badge-img"
           src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/badge.png"
           alt="Keploy 5 years anniversary badge"
+          loading="lazy"
+          decoding="async"
         />
         <img
           className="k5y-badge-img-mobile"
           src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/badge-tight.png"
           alt="Keploy 5 years anniversary badge"
+          loading="lazy"
+          decoding="async"
         />
 
         <div className="k5y-inner">

--- a/components/InlinePromoCard.tsx
+++ b/components/InlinePromoCard.tsx
@@ -15,50 +15,52 @@ function Keploy5YearsBanner() {
           0%        { transform: translateX(-120%) skewX(-12deg); }
           65%, 100% { transform: translateX(600%) skewX(-12deg); }
         }
-        .k5y-body { display: flex; align-items: center; gap: 20px; }
-        .k5y-card { padding: 22px 28px; }
+        /* Desktop: bigger centered card, single vertical column (same shape as mobile, scaled up) */
+        .k5y-body { display: flex; flex-direction: column; align-items: center; text-align: center; gap: 20px; }
+        .k5y-card { max-width: 460px; margin: 0 auto; padding: 44px 40px; border-radius: 24px; }
         .k5y-badge-wrap {
           position: relative;
-          width: 84px;
-          height: 85px;
+          width: 190px;
+          height: 196px;
           flex-shrink: 0;
           overflow: hidden;
-          transform: translateY(-7px);
+          margin: 0 auto;
         }
         .k5y-badge-img {
           position: absolute;
           top: 50%;
           left: 50%;
-          height: 124px;
+          height: 282px;
           width: auto;
           max-width: none;
           transform: translate(-50%, -50%);
         }
-        .k5y-divider { display: block; }
+        .k5y-content { text-align: center; }
         .k5y-heading {
           color: #171412;
-          font-size: 16px;
+          font-size: 24px;
           font-weight: 700;
-          margin: 0 0 2px;
+          margin: 0 0 10px;
           line-height: 1.35;
         }
         .k5y-desc {
           color: #92400e;
-          font-size: 13.5px;
+          font-size: 15.5px;
           margin: 0;
-          line-height: 1.65;
+          line-height: 1.6;
         }
         .k5y-cta-btn {
           flex-shrink: 0;
           display: inline-flex;
           align-items: center;
           justify-content: center;
-          padding: 12px 12px;
+          margin-top: 24px;
+          padding: 14px 28px;
           background: linear-gradient(180deg, #ff9d2e 0%, #ff6b00 100%);
           color: white;
           border: none;
-          border-radius: 10px;
-          font-size: 13.5px;
+          border-radius: 12px;
+          font-size: 15px;
           font-weight: 700;
           text-decoration: none;
           box-shadow: 0 5px 14px rgba(255,107,0,0.14);
@@ -80,18 +82,18 @@ function Keploy5YearsBanner() {
           outline: 3px solid #f59e0b;
           outline-offset: 2px;
         }
+        /* Mobile: same vertical shape, scaled back down, full-width thumb-friendly button */
         @media (max-width: 600px) {
-          .k5y-body { flex-direction: column; align-items: center; text-align: center; gap: 14px; }
-          .k5y-badge-wrap { width: 150px; height: 155px; transform: none; margin: 0 auto; }
+          .k5y-body { gap: 14px; }
+          .k5y-card { max-width: 100%; padding: 20px 18px; border-radius: 16px; }
+          .k5y-badge-wrap { width: 150px; height: 155px; }
           .k5y-badge-img { height: 224px; }
-          .k5y-divider { display: none; }
-          .k5y-content { text-align: center; }
           .k5y-heading { font-size: 21px; margin: 0 0 8px; }
           .k5y-desc { font-size: 14px; line-height: 1.5; }
-          .k5y-card { padding: 20px 18px; }
           .k5y-cta-btn {
             width: 100%;
             white-space: normal;
+            margin-top: 14px;
             padding: 15px 20px;
             border-radius: 16px;
             font-size: 15.5px;
@@ -122,7 +124,7 @@ function Keploy5YearsBanner() {
             height: "100%",
             background:
               "linear-gradient(105deg, transparent 30%, rgba(251,191,36,0.10) 50%, transparent 70%)",
-            animation: "k5y-sweep 4.5s ease-in-out infinite",
+            animation: "k5y-sweep 3s ease-in-out infinite",
             pointerEvents: "none",
           }}
         />
@@ -137,40 +139,25 @@ function Keploy5YearsBanner() {
           />
         </div>
 
-        {/* Vertical divider */}
-        <div
-          className="k5y-divider"
-          style={{
-            width: 1.5,
-            alignSelf: "stretch",
-            flexShrink: 0,
-            opacity: 0.35,
-            background:
-              "linear-gradient(to bottom, transparent, #fdba74 15%, #f97316 50%, #fdba74 85%, transparent)",
-          }}
-        />
-
-        {/* Text */}
-        <div className="k5y-content" style={{ flex: 1, minWidth: 0 }}>
+        {/* Text + CTA, grouped together as one section */}
+        <div className="k5y-content" style={{ minWidth: 0 }}>
           <p className="k5y-heading">Keploy Turns 5 This Month!</p>
           <p id={`${bannerId}-desc`} className="k5y-desc">
             To celebrate our 5 years, we&apos;re giving away
             <br />
             one month of Keploy credits for free.
           </p>
+          <a
+            href="https://keploy.io/credits-form"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="k5y-cta-btn"
+            aria-label="Claim 1 month of free Keploy credits"
+            aria-describedby={`${bannerId}-desc`}
+          >
+            Claim 1 Month of Free Credits
+          </a>
         </div>
-
-        {/* CTA */}
-        <a
-          href="https://keploy.io/credits-form"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="k5y-cta-btn"
-          aria-label="Claim 1 month of free Keploy credits"
-          aria-describedby={`${bannerId}-desc`}
-        >
-          Claim 1 Month of Free Credits
-        </a>
       </div>
     </div>
   );

--- a/components/InlinePromoCard.tsx
+++ b/components/InlinePromoCard.tsx
@@ -15,24 +15,39 @@ function Keploy5YearsBanner() {
           0%        { transform: translateX(-120%) skewX(-12deg); }
           65%, 100% { transform: translateX(600%) skewX(-12deg); }
         }
-        .k5y-body { display: flex; align-items: center; gap: 26px; }
+        .k5y-body { display: flex; align-items: center; gap: 20px; }
+        .k5y-card { padding: 22px 28px; }
         .k5y-badge-wrap {
           position: relative;
-          width: 88px;
-          height: 90px;
+          width: 84px;
+          height: 85px;
           flex-shrink: 0;
           overflow: hidden;
+          transform: translateY(-7px);
         }
         .k5y-badge-img {
           position: absolute;
           top: 50%;
           left: 50%;
-          height: 130px;
+          height: 124px;
           width: auto;
           max-width: none;
           transform: translate(-50%, -50%);
         }
         .k5y-divider { display: block; }
+        .k5y-heading {
+          color: #171412;
+          font-size: 16px;
+          font-weight: 700;
+          margin: 0 0 2px;
+          line-height: 1.35;
+        }
+        .k5y-desc {
+          color: #92400e;
+          font-size: 13.5px;
+          margin: 0;
+          line-height: 1.65;
+        }
         .k5y-cta-btn {
           flex-shrink: 0;
           display: inline-flex;
@@ -46,7 +61,7 @@ function Keploy5YearsBanner() {
           font-size: 13.5px;
           font-weight: 700;
           text-decoration: none;
-          box-shadow: 0 5px 14px rgba(255,107,0,0.16);
+          box-shadow: 0 5px 14px rgba(255,107,0,0.14);
           letter-spacing: 0.01em;
           cursor: pointer;
           white-space: nowrap;
@@ -54,7 +69,7 @@ function Keploy5YearsBanner() {
           font-family: inherit;
         }
         .k5y-cta-btn:hover {
-          box-shadow: 0 6px 16px rgba(255,107,0,0.20);
+          box-shadow: 0 6px 16px rgba(255,107,0,0.18);
           transform: translateY(-1px);
           filter: brightness(1.05);
         }
@@ -66,24 +81,33 @@ function Keploy5YearsBanner() {
           outline-offset: 2px;
         }
         @media (max-width: 600px) {
-          .k5y-body { flex-direction: column; align-items: flex-start; gap: 16px; }
-          .k5y-badge-wrap { width: 70px; height: 72px; }
-          .k5y-badge-img { height: 104px; }
+          .k5y-body { flex-direction: column; align-items: center; text-align: center; gap: 14px; }
+          .k5y-badge-wrap { width: 150px; height: 155px; transform: none; margin: 0 auto; }
+          .k5y-badge-img { height: 224px; }
           .k5y-divider { display: none; }
-          .k5y-cta-btn { width: 100%; text-align: center; white-space: normal; }
+          .k5y-content { text-align: center; }
+          .k5y-heading { font-size: 21px; margin: 0 0 8px; }
+          .k5y-desc { font-size: 14px; line-height: 1.5; }
+          .k5y-card { padding: 20px 18px; }
+          .k5y-cta-btn {
+            width: 100%;
+            white-space: normal;
+            padding: 15px 20px;
+            border-radius: 16px;
+            font-size: 15.5px;
+          }
         }
       `}</style>
 
       {/* Card body */}
       <div
-        className="k5y-body"
+        className="k5y-body k5y-card"
         style={{
           background:
-            "radial-gradient(65% 110% at 0% 45%, rgba(255,140,32,0.12) 0%, rgba(255,157,46,0.06) 24%, rgba(255,255,255,0) 46%), #ffffff",
+            "radial-gradient(85% 140% at 0% 45%, rgba(255,140,32,0.10) 0%, rgba(255,150,40,0.06) 20%, rgba(255,160,50,0.025) 38%, rgba(255,255,255,0) 64%), #ffffff",
           borderRadius: 16,
           border: "1px solid #e5e7eb",
           boxShadow: "0 4px 24px rgba(0,0,0,0.08)",
-          padding: "22px 28px",
           position: "relative",
           overflow: "hidden",
         }}
@@ -120,35 +144,19 @@ function Keploy5YearsBanner() {
             width: 1.5,
             alignSelf: "stretch",
             flexShrink: 0,
-            opacity: 0.7,
+            opacity: 0.35,
             background:
               "linear-gradient(to bottom, transparent, #fdba74 15%, #f97316 50%, #fdba74 85%, transparent)",
           }}
         />
 
         {/* Text */}
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <p
-            style={{
-              color: "#171412",
-              fontSize: 16,
-              fontWeight: 700,
-              margin: "0 0 6px",
-              lineHeight: 1.35,
-            }}
-          >
-            Keploy turned 5 this month!
-          </p>
-          <p
-            id={`${bannerId}-desc`}
-            style={{
-              color: "#92400e",
-              fontSize: 13.5,
-              margin: 0,
-              lineHeight: 1.65,
-            }}
-          >
-            To celebrate our 5 years, we are giving away one month of Keploy credits for free!
+        <div className="k5y-content" style={{ flex: 1, minWidth: 0 }}>
+          <p className="k5y-heading">Keploy Turns 5 This Month!</p>
+          <p id={`${bannerId}-desc`} className="k5y-desc">
+            To celebrate our 5 years, we&apos;re giving away
+            <br />
+            one month of Keploy credits for free.
           </p>
         </div>
 

--- a/components/InlinePromoCard.tsx
+++ b/components/InlinePromoCard.tsx
@@ -17,42 +17,38 @@ function Keploy5YearsBanner() {
           100% { background-position: 0% 50%; }
         }
         @keyframes k5y-glow {
-          0%, 100% { box-shadow: 0 2px 16px rgba(0,0,0,0.06), 0 0 0 0 rgba(251,176,45,0); }
-          50%       { box-shadow: 0 2px 20px rgba(0,0,0,0.07), 0 0 20px 4px rgba(251,176,45,0.16); }
+          0%, 100% { box-shadow: 0 2px 16px rgba(0,0,0,0.05), 0 0 0 0 rgba(251,146,60,0); }
+          50%       { box-shadow: 0 2px 20px rgba(0,0,0,0.06), 0 0 18px 3px rgba(251,146,60,0.14); }
         }
         @keyframes k5y-sweep {
           0%        { transform: translateX(-120%) skewX(-12deg); }
           65%, 100% { transform: translateX(600%) skewX(-12deg); }
         }
-        @keyframes k5y-sparkle {
-          0%, 100% { opacity: 0.55; transform: scale(1) rotate(0deg); }
-          50%       { opacity: 1;    transform: scale(1.25) rotate(18deg); }
-        }
-        .k5y-body { display: flex; align-items: center; gap: 24px; }
-        .k5y-badge { display: flex; flex-direction: column; align-items: center; gap: 7px; }
+        .k5y-body { display: flex; align-items: center; gap: 26px; }
+        .k5y-badge-img { display: block; height: 76px; width: auto; flex-shrink: 0; }
         .k5y-divider { display: block; }
         .k5y-cta-btn {
           flex-shrink: 0;
           display: inline-flex;
           align-items: center;
           justify-content: center;
-          padding: 10px 20px;
-          background: linear-gradient(90deg, #f59e0b, #f97316);
+          padding: 12px 22px;
+          background: linear-gradient(135deg, #fb923c, #f97316);
           color: white;
           border: none;
           border-radius: 10px;
-          font-size: 13px;
+          font-size: 13.5px;
           font-weight: 700;
           text-decoration: none;
-          box-shadow: 0 3px 14px rgba(249,115,22,0.32);
-          letter-spacing: 0.02em;
+          box-shadow: 0 4px 12px rgba(249,115,22,0.28);
+          letter-spacing: 0.01em;
           cursor: pointer;
           white-space: nowrap;
-          transition: opacity 0.15s ease, transform 0.15s ease;
+          transition: box-shadow 0.15s ease, transform 0.15s ease;
           font-family: inherit;
         }
         .k5y-cta-btn:hover {
-          opacity: 0.9;
+          box-shadow: 0 6px 16px rgba(249,115,22,0.36);
           transform: translateY(-1px);
         }
         .k5y-cta-btn:focus-visible {
@@ -60,8 +56,8 @@ function Keploy5YearsBanner() {
           outline-offset: 2px;
         }
         @media (max-width: 600px) {
-          .k5y-body { flex-direction: column; align-items: flex-start; gap: 14px; }
-          .k5y-badge { flex-direction: row; align-items: center; gap: 8px; }
+          .k5y-body { flex-direction: column; align-items: flex-start; gap: 16px; }
+          .k5y-badge-img { height: 64px; }
           .k5y-divider { display: none; }
           .k5y-cta-btn { width: 100%; text-align: center; white-space: normal; }
         }
@@ -82,7 +78,9 @@ function Keploy5YearsBanner() {
         <div
           className="k5y-body"
           style={{
-            background: "#fffcf7",
+            background:
+              "radial-gradient(55% 100% at 0% 50%, rgba(251,146,60,0.16) 0%, rgba(253,186,116,0.07) 22%, rgba(255,255,255,0) 42%), " +
+              "#ffffff",
             borderRadius: "calc(16px - 1.5px)",
             padding: "22px 28px",
             position: "relative",
@@ -98,51 +96,29 @@ function Keploy5YearsBanner() {
               width: "25%",
               height: "100%",
               background:
-                "linear-gradient(105deg, transparent 30%, rgba(251,191,36,0.06) 50%, transparent 70%)",
+                "linear-gradient(105deg, transparent 30%, rgba(251,191,36,0.10) 50%, transparent 70%)",
               animation: "k5y-sweep 4.5s ease-in-out infinite",
               pointerEvents: "none",
             }}
           />
 
-          {/* Left: sparkle + badge */}
-          <div className="k5y-badge" style={{ flexShrink: 0 }}>
-            <span
-              style={{
-                fontSize: 22,
-                color: "#f59e0b",
-                display: "inline-block",
-                animation: "k5y-sparkle 2.5s ease-in-out infinite",
-                lineHeight: 1,
-              }}
-            >
-              ✦
-            </span>
-            <span
-              style={{
-                background: "linear-gradient(90deg, #f59e0b, #f97316)",
-                borderRadius: 20,
-                padding: "3px 10px",
-                fontSize: 10,
-                fontWeight: 700,
-                color: "white",
-                letterSpacing: "0.09em",
-                textTransform: "uppercase" as const,
-                whiteSpace: "nowrap" as const,
-              }}
-            >
-              5 Years ✨
-            </span>
-          </div>
+          {/* Left: badge */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/keploy5years.png"
+            alt="5 years of Keploy badge"
+            className="k5y-badge-img"
+          />
 
           {/* Vertical divider */}
           <div
             className="k5y-divider"
             style={{
-              width: 1,
+              width: 1.5,
               alignSelf: "stretch",
               flexShrink: 0,
               background:
-                "linear-gradient(to bottom, transparent, #fde68a 30%, #fed7aa 70%, transparent)",
+                "linear-gradient(to bottom, transparent, #fdba74 15%, #f97316 50%, #fdba74 85%, transparent)",
             }}
           />
 
@@ -150,14 +126,14 @@ function Keploy5YearsBanner() {
           <div style={{ flex: 1, minWidth: 0 }}>
             <p
               style={{
-                color: "#1c0f00",
+                color: "#171412",
                 fontSize: 16,
                 fontWeight: 700,
                 margin: "0 0 6px",
                 lineHeight: 1.35,
               }}
             >
-              Keploy has completed its 5 years this month!
+              keploy turned 5 this month!
             </p>
             <p
               id={`${bannerId}-desc`}
@@ -178,10 +154,10 @@ function Keploy5YearsBanner() {
             target="_blank"
             rel="noopener noreferrer"
             className="k5y-cta-btn"
-            aria-label="Get 1 month of Keploy credits free"
+            aria-label="Claim your free 1 month of Keploy credits"
             aria-describedby={`${bannerId}-desc`}
           >
-            Get 1 Month Free
+            claim free 1 month credits
           </a>
         </div>
       </div>

--- a/components/InlinePromoCard.tsx
+++ b/components/InlinePromoCard.tsx
@@ -80,7 +80,6 @@ function Keploy5YearsBanner() {
             target="_blank"
             rel="noopener noreferrer"
             className={styles["k5y-cta-btn"]}
-            aria-label="Claim 1 month of free Keploy credits"
             aria-describedby={descId}
           >
             Claim 1 Month of Free Credits

--- a/components/InlinePromoCard.tsx
+++ b/components/InlinePromoCard.tsx
@@ -15,22 +15,36 @@ function Keploy5YearsBanner() {
           0%        { transform: translateX(-120%) skewX(-12deg); }
           65%, 100% { transform: translateX(600%) skewX(-12deg); }
         }
-        /* Desktop: bigger centered card, single vertical column (same shape as mobile, scaled up) */
-        .k5y-body { display: flex; flex-direction: column; align-items: center; text-align: center; gap: 20px; }
-        .k5y-card { max-width: 460px; margin: 0 auto; padding: 44px 40px; border-radius: 24px; }
+        /* Desktop: compact centered card, single vertical column (same shape as mobile, scaled up) */
+        .k5y-body { display: flex; flex-direction: column; align-items: center; text-align: center; gap: 12px; }
+        .k5y-card { max-width: 460px; margin: 0 auto; padding: 14px 36px; border-radius: 20px; }
+        .k5y-badge-stage {
+          position: relative;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          flex-shrink: 0;
+        }
+        .k5y-badge-glow {
+          position: absolute;
+          width: 190px;
+          height: 190px;
+          border-radius: 50%;
+          background: radial-gradient(circle, rgba(255,157,46,0.32) 0%, rgba(255,157,46,0) 70%);
+          filter: blur(2px);
+          pointer-events: none;
+        }
         .k5y-badge-wrap {
           position: relative;
-          width: 190px;
-          height: 196px;
-          flex-shrink: 0;
+          width: 142px;
+          height: 147px;
           overflow: hidden;
-          margin: 0 auto;
         }
         .k5y-badge-img {
           position: absolute;
           top: 50%;
           left: 50%;
-          height: 282px;
+          height: 211px;
           width: auto;
           max-width: none;
           transform: translate(-50%, -50%);
@@ -38,30 +52,31 @@ function Keploy5YearsBanner() {
         .k5y-content { text-align: center; }
         .k5y-heading {
           color: #171412;
-          font-size: 24px;
-          font-weight: 700;
-          margin: 0 0 10px;
-          line-height: 1.35;
+          font-size: 23px;
+          font-weight: 800;
+          letter-spacing: -0.015em;
+          margin: 0 0 8px;
+          line-height: 1.2;
         }
         .k5y-desc {
-          color: #92400e;
-          font-size: 15.5px;
+          color: #7a3d0f;
+          font-size: 14.5px;
           margin: 0;
-          line-height: 1.6;
+          line-height: 1.4;
         }
         .k5y-cta-btn {
           flex-shrink: 0;
           display: inline-flex;
           align-items: center;
           justify-content: center;
-          margin-top: 24px;
-          padding: 14px 28px;
+          margin-top: 20px;
+          padding: 14px 32px;
           background: linear-gradient(180deg, #ff9d2e 0%, #ff6b00 100%);
           color: white;
           border: none;
           border-radius: 12px;
           font-size: 15px;
-          font-weight: 700;
+          font-weight: 800;
           text-decoration: none;
           box-shadow: 0 5px 14px rgba(255,107,0,0.14);
           letter-spacing: 0.01em;
@@ -82,19 +97,37 @@ function Keploy5YearsBanner() {
           outline: 3px solid #f59e0b;
           outline-offset: 2px;
         }
+        /* Extremely subtle celebratory accents — tiny, low-opacity, corner-only */
+        .k5y-sparkle {
+          position: absolute;
+          color: #fdba74;
+          pointer-events: none;
+          line-height: 1;
+        }
+        .k5y-sparkle-1 { top: 16px; right: 20px; font-size: 12px; opacity: 0.55; }
+        .k5y-sparkle-2 { bottom: 18px; left: 18px; font-size: 9px; opacity: 0.4; }
+        .k5y-confetti {
+          position: absolute;
+          border-radius: 50%;
+          background: #fb923c;
+          pointer-events: none;
+        }
+        .k5y-confetti-1 { top: 28px; left: 26px; width: 5px; height: 5px; opacity: 0.35; }
+        .k5y-confetti-2 { bottom: 32px; right: 28px; width: 4px; height: 4px; opacity: 0.3; }
         /* Mobile: same vertical shape, scaled back down, full-width thumb-friendly button */
         @media (max-width: 600px) {
-          .k5y-body { gap: 14px; }
-          .k5y-card { max-width: 100%; padding: 20px 18px; border-radius: 16px; }
-          .k5y-badge-wrap { width: 150px; height: 155px; }
-          .k5y-badge-img { height: 224px; }
-          .k5y-heading { font-size: 21px; margin: 0 0 8px; }
-          .k5y-desc { font-size: 14px; line-height: 1.5; }
+          .k5y-body { gap: 10px; }
+          .k5y-card { max-width: 100%; padding: 16px; border-radius: 16px; }
+          .k5y-badge-glow { width: 150px; height: 150px; }
+          .k5y-badge-wrap { width: 115px; height: 118px; }
+          .k5y-badge-img { height: 171px; }
+          .k5y-heading { font-size: 20px; margin: 0 0 6px; }
+          .k5y-desc { font-size: 13.5px; line-height: 1.4; }
           .k5y-cta-btn {
             width: 100%;
             white-space: normal;
             margin-top: 14px;
-            padding: 15px 20px;
+            padding: 14px 18px;
             border-radius: 16px;
             font-size: 15.5px;
           }
@@ -107,13 +140,18 @@ function Keploy5YearsBanner() {
         style={{
           background:
             "radial-gradient(85% 140% at 0% 45%, rgba(255,140,32,0.10) 0%, rgba(255,150,40,0.06) 20%, rgba(255,160,50,0.025) 38%, rgba(255,255,255,0) 64%), #ffffff",
-          borderRadius: 16,
           border: "1px solid #e5e7eb",
-          boxShadow: "0 4px 24px rgba(0,0,0,0.08)",
+          boxShadow: "0 1px 2px rgba(16,24,40,0.04), 0 8px 20px rgba(16,24,40,0.06)",
           position: "relative",
           overflow: "hidden",
         }}
       >
+        {/* Celebratory accents — tiny, subtle, corner-only */}
+        <span className="k5y-sparkle k5y-sparkle-1" aria-hidden="true">✦</span>
+        <span className="k5y-sparkle k5y-sparkle-2" aria-hidden="true">✦</span>
+        <span className="k5y-confetti k5y-confetti-1" aria-hidden="true" />
+        <span className="k5y-confetti k5y-confetti-2" aria-hidden="true" />
+
         {/* Shine sweep */}
         <div
           style={{
@@ -129,14 +167,17 @@ function Keploy5YearsBanner() {
           }}
         />
 
-        {/* Left: badge */}
-        <div className="k5y-badge-wrap">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/keploy5years.png"
-            alt="5 years of Keploy badge"
-            className="k5y-badge-img"
-          />
+        {/* Badge, with a soft warm glow behind it */}
+        <div className="k5y-badge-stage">
+          <div className="k5y-badge-glow" aria-hidden="true" />
+          <div className="k5y-badge-wrap">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/keploy5years.png"
+              alt="5 years of Keploy badge"
+              className="k5y-badge-img"
+            />
+          </div>
         </div>
 
         {/* Text + CTA, grouped together as one section */}

--- a/components/InlinePromoCard.tsx
+++ b/components/InlinePromoCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useId } from "react";
 import type { InlinePromoId } from "../config/inline-promos";
 
 // ─── Inline banner ─────────────────────────────────────────────────────────────
@@ -24,6 +25,7 @@ function ArrowIcon() {
 }
 
 function Keploy5YearsBanner() {
+  const descId = useId();
   return (
     <div className="my-8" style={{ width: "100%" }}>
       <style>{`
@@ -73,6 +75,7 @@ function Keploy5YearsBanner() {
           margin: 0 0 26px;
         }
         .k5y-accent { color: #f76b1c; }
+        .k5y-heading-mobile { display: none; }
 
         .k5y-cta-btn {
           display: inline-flex;
@@ -93,7 +96,7 @@ function Keploy5YearsBanner() {
         }
         .k5y-cta-btn:hover { filter: brightness(1.06); transform: translateY(-1px); }
         .k5y-cta-btn:active { transform: translateY(1px); }
-        .k5y-cta-btn:focus-visible { outline: 3px solid #f59e0b; outline-offset: 2px; }
+        .k5y-cta-btn:focus-visible { outline: 3px solid #f76b1c; outline-offset: 2px; }
         .k5y-cta-icon { width: 18px; height: 18px; flex-shrink: 0; }
 
         @media (max-width: 850px) {
@@ -113,8 +116,9 @@ function Keploy5YearsBanner() {
             margin: 32px auto 16px;
           }
 
-          .k5y-heading { font-size: 12px; font-weight: 800; line-height: 1.35; margin: 0 0 22px; }
-          .k5y-lb2 { display: none; }
+          .k5y-heading { font-size: 14px; font-weight: 800; line-height: 1.35; margin: 0 0 22px; }
+          .k5y-heading-desktop { display: none; }
+          .k5y-heading-mobile { display: block; }
 
           .k5y-cta-btn { padding: 5px 9px; font-size: 10px; gap: 3px; }
           .k5y-cta-icon { width: 10px; height: 10px; }
@@ -124,14 +128,14 @@ function Keploy5YearsBanner() {
       <div className="k5y-card">
         {/* Decorative blobs — desktop */}
         {/* eslint-disable @next/next/no-img-element */}
-        <img className="k5y-ellipse k5y-ellipse-tr" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-top-right.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" />
-        <img className="k5y-ellipse k5y-ellipse-left" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-left-side.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" />
-        <img className="k5y-ellipse k5y-ellipse-bottom" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-bottom.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" />
+        <img className="k5y-ellipse k5y-ellipse-tr" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-top-right.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" width={42} height={86} />
+        <img className="k5y-ellipse k5y-ellipse-left" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-left-side.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" width={33} height={123} />
+        <img className="k5y-ellipse k5y-ellipse-bottom" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-bottom.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" width={286} height={82} />
         {/* Decorative blobs — mobile */}
-        <img className="k5y-ellipse k5y-ellipse-tl-m" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-top-left-mobile.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" />
-        <img className="k5y-ellipse k5y-ellipse-top-m" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-mobile-top.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" />
-        <img className="k5y-ellipse k5y-ellipse-right-m" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-right-mobile.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" />
-        <img className="k5y-ellipse k5y-ellipse-bottom-m" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-bottom-mobile.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" />
+        <img className="k5y-ellipse k5y-ellipse-tl-m" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-top-left-mobile.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" width={54} height={96} />
+        <img className="k5y-ellipse k5y-ellipse-top-m" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-mobile-top.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" width={61} height={28} />
+        <img className="k5y-ellipse k5y-ellipse-right-m" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-right-mobile.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" width={41} height={166} />
+        <img className="k5y-ellipse k5y-ellipse-bottom-m" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-bottom-mobile.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" width={53} height={33} />
 
         <img
           className="k5y-badge-img"
@@ -139,6 +143,8 @@ function Keploy5YearsBanner() {
           alt="Keploy 5 years anniversary badge"
           loading="lazy"
           decoding="async"
+          width={337}
+          height={337}
         />
         <img
           className="k5y-badge-img-mobile"
@@ -146,16 +152,25 @@ function Keploy5YearsBanner() {
           alt="Keploy 5 years anniversary badge"
           loading="lazy"
           decoding="async"
+          width={190}
+          height={180}
         />
 
         <div className="k5y-inner">
-          <p className="k5y-heading">
+          <p className="k5y-heading k5y-heading-desktop">
             Celebrate with us
             <br />
             Get <span className="k5y-accent">1 Month</span> of FREE
-            <br className="k5y-lb2" />
-            {" "}
+            <br />
             <span className="k5y-accent">Keploy</span> Credits
+          </p>
+          <p className="k5y-heading k5y-heading-mobile">
+            Celebrate with us
+            <br />
+            Get <span className="k5y-accent">1 Month</span> of FREE <span className="k5y-accent">Keploy</span> Credits
+          </p>
+          <p id={descId} className="sr-only">
+            Celebrating 5 years of Keploy — claim one month of free credits.
           </p>
 
           <a
@@ -164,6 +179,7 @@ function Keploy5YearsBanner() {
             rel="noopener noreferrer"
             className="k5y-cta-btn"
             aria-label="Claim 1 month of free Keploy credits"
+            aria-describedby={descId}
           >
             Claim 1 Month of Free Credits
             <ArrowIcon />

--- a/components/InlinePromoCard.tsx
+++ b/components/InlinePromoCard.tsx
@@ -1,14 +1,13 @@
-"use client";
-
 import { useId } from "react";
 import type { InlinePromoId } from "../config/inline-promos";
+import styles from "./InlinePromoCard.module.css";
 
 // ─── Inline banner ─────────────────────────────────────────────────────────────
 
 function ArrowIcon() {
   return (
     <svg
-      className="k5y-cta-icon"
+      className={styles["k5y-cta-icon"]}
       viewBox="0 0 24 24"
       fill="none"
       aria-hidden="true"
@@ -28,156 +27,59 @@ function Keploy5YearsBanner() {
   const descId = useId();
   return (
     <div className="my-8" style={{ width: "100%" }}>
-      <style>{`
-        .k5y-card {
-          position: relative;
-          overflow: hidden;
-          background: #ffffff;
-          border-radius: 0;
-        }
-        .k5y-ellipse {
-          position: absolute;
-          pointer-events: none;
-          z-index: 0;
-          display: block;
-        }
-        .k5y-ellipse-tr { top: 0; right: 0; width: 42px; height: 86px; }
-        .k5y-ellipse-left { left: 0; top: 50%; width: 33px; height: 123px; transform: translateY(-50%); }
-        .k5y-ellipse-bottom { right: 14px; bottom: 0; width: 286px; height: 82px; }
-        .k5y-ellipse-tl-m,
-        .k5y-ellipse-top-m,
-        .k5y-ellipse-right-m,
-        .k5y-ellipse-bottom-m {
-          display: none;
-        }
-
-        .k5y-inner {
-          position: relative;
-          z-index: 1;
-          padding: 44px 349px 44px 56px;
-        }
-        .k5y-badge-img {
-          position: absolute;
-          z-index: 1;
-          top: -21px;
-          right: -12px;
-          width: 337px;
-          height: 337px;
-        }
-        .k5y-badge-img-mobile { display: none; }
-
-        .k5y-heading {
-          font-family: "Lexend", sans-serif;
-          font-weight: 700;
-          font-size: 28px;
-          line-height: 1.28;
-          color: #000000;
-          margin: 0 0 26px;
-        }
-        .k5y-accent { color: #f76b1c; }
-        .k5y-heading-mobile { display: none; }
-
-        .k5y-cta-btn {
-          display: inline-flex;
-          align-items: center;
-          gap: 6px;
-          padding: 10px 18px;
-          background: #f76b1c;
-          color: #ffffff;
-          border-radius: 9999px;
-          border: none;
-          font-family: "Lexend", sans-serif;
-          font-weight: 500;
-          font-size: 20px;
-          text-decoration: none;
-          white-space: nowrap;
-          cursor: pointer;
-          transition: filter 200ms ease, transform 200ms ease;
-        }
-        .k5y-cta-btn:hover { filter: brightness(1.06); transform: translateY(-1px); }
-        .k5y-cta-btn:active { transform: translateY(1px); }
-        .k5y-cta-btn:focus-visible { outline: 3px solid #f76b1c; outline-offset: 2px; }
-        .k5y-cta-icon { width: 18px; height: 18px; flex-shrink: 0; }
-
-        @media (max-width: 850px) {
-          .k5y-ellipse-tr, .k5y-ellipse-left, .k5y-ellipse-bottom { display: none; }
-          .k5y-ellipse-tl-m { display: block; top: 0; left: 0; width: 54px; height: 96px; }
-          .k5y-ellipse-top-m { display: block; top: 0; right: 46px; width: 61px; height: 28px; }
-          .k5y-ellipse-right-m { display: block; top: 35px; right: 0; width: 41px; height: 166px; }
-          .k5y-ellipse-bottom-m { display: block; left: 23px; bottom: 0; width: 53px; height: 33px; }
-
-          .k5y-inner { text-align: center; padding: 0 16px 44px; }
-          .k5y-badge-img { display: none; }
-          .k5y-badge-img-mobile {
-            display: block;
-            position: static;
-            width: 190px;
-            height: auto;
-            margin: 32px auto 16px;
-          }
-
-          .k5y-heading { font-size: 14px; font-weight: 800; line-height: 1.35; margin: 0 0 22px; }
-          .k5y-heading-desktop { display: none; }
-          .k5y-heading-mobile { display: block; }
-
-          .k5y-cta-btn { padding: 5px 9px; font-size: 10px; gap: 3px; }
-          .k5y-cta-icon { width: 10px; height: 10px; }
-        }
-      `}</style>
-
-      <div className="k5y-card">
+      <div className={styles["k5y-card"]}>
         {/* Decorative blobs — desktop */}
         {/* eslint-disable @next/next/no-img-element */}
-        <img className="k5y-ellipse k5y-ellipse-tr" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-top-right.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" width={42} height={86} />
-        <img className="k5y-ellipse k5y-ellipse-left" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-left-side.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" width={33} height={123} />
-        <img className="k5y-ellipse k5y-ellipse-bottom" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-bottom.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" width={286} height={82} />
+        <img className={`${styles["k5y-ellipse"]} ${styles["k5y-ellipse-tr"]}`} src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-top-right.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" width={42} height={86} />
+        <img className={`${styles["k5y-ellipse"]} ${styles["k5y-ellipse-left"]}`} src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-left-side.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" width={33} height={123} />
+        <img className={`${styles["k5y-ellipse"]} ${styles["k5y-ellipse-bottom"]}`} src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-bottom.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" width={286} height={82} />
         {/* Decorative blobs — mobile */}
-        <img className="k5y-ellipse k5y-ellipse-tl-m" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-top-left-mobile.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" width={54} height={96} />
-        <img className="k5y-ellipse k5y-ellipse-top-m" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-mobile-top.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" width={61} height={28} />
-        <img className="k5y-ellipse k5y-ellipse-right-m" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-right-mobile.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" width={41} height={166} />
-        <img className="k5y-ellipse k5y-ellipse-bottom-m" src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-bottom-mobile.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" width={53} height={33} />
+        <img className={`${styles["k5y-ellipse"]} ${styles["k5y-ellipse-tl-m"]}`} src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-top-left-mobile.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" width={54} height={96} />
+        <img className={`${styles["k5y-ellipse"]} ${styles["k5y-ellipse-top-m"]}`} src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-mobile-top.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" width={61} height={28} />
+        <img className={`${styles["k5y-ellipse"]} ${styles["k5y-ellipse-right-m"]}`} src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-right-mobile.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" width={41} height={166} />
+        <img className={`${styles["k5y-ellipse"]} ${styles["k5y-ellipse-bottom-m"]}`} src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/ellipse-bottom-mobile.svg" alt="" aria-hidden="true" loading="lazy" decoding="async" width={53} height={33} />
 
         <img
-          className="k5y-badge-img"
+          className={styles["k5y-badge-img"]}
           src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/badge.png"
           alt="Keploy 5 years anniversary badge"
-          loading="lazy"
+          loading="eager"
           decoding="async"
           width={337}
           height={337}
         />
         <img
-          className="k5y-badge-img-mobile"
+          className={styles["k5y-badge-img-mobile"]}
           src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/badge-tight.png"
           alt="Keploy 5 years anniversary badge"
-          loading="lazy"
+          loading="eager"
           decoding="async"
           width={190}
           height={180}
         />
 
-        <div className="k5y-inner">
-          <p className="k5y-heading k5y-heading-desktop">
+        <div className={styles["k5y-inner"]}>
+          <p className={`${styles["k5y-heading"]} ${styles["k5y-heading-desktop"]}`}>
             Celebrate with us
             <br />
-            Get <span className="k5y-accent">1 Month</span> of FREE
+            Get <span className={styles["k5y-accent-gradient"]}>1 Month of FREE</span>
             <br />
-            <span className="k5y-accent">Keploy</span> Credits
+            Keploy Credits
           </p>
-          <p className="k5y-heading k5y-heading-mobile">
+          <p className={`${styles["k5y-heading"]} ${styles["k5y-heading-mobile"]}`}>
             Celebrate with us
             <br />
-            Get <span className="k5y-accent">1 Month</span> of FREE <span className="k5y-accent">Keploy</span> Credits
+            Get <span className={styles["k5y-accent-gradient"]}>1 Month of FREE</span> Keploy Credits
           </p>
           <p id={descId} className="sr-only">
-            Celebrating 5 years of Keploy — claim one month of free credits.
+            Celebrating 5 years of Keploy - claim one month of free credits.
           </p>
 
           <a
             href="https://keploy.io/credits-form"
             target="_blank"
             rel="noopener noreferrer"
-            className="k5y-cta-btn"
+            className={styles["k5y-cta-btn"]}
             aria-label="Claim 1 month of free Keploy credits"
             aria-describedby={descId}
           >

--- a/components/InlinePromoCard.tsx
+++ b/components/InlinePromoCard.tsx
@@ -115,7 +115,7 @@ function Keploy5YearsBanner() {
             transform: translateX(-50%);
           }
 
-          .k5y-heading { font-size: 15px; font-weight: 800; line-height: 1.35; margin: 0 0 22px; }
+          .k5y-heading { font-size: 12.5px; font-weight: 800; line-height: 1.35; margin: 0 0 22px; }
           .k5y-lb2 { display: none; }
 
           .k5y-cta-btn { padding: 4.8px 8.8px; font-size: 10px; gap: 3px; }

--- a/components/InlinePromoCard.tsx
+++ b/components/InlinePromoCard.tsx
@@ -118,8 +118,8 @@ function Keploy5YearsBanner() {
           .k5y-heading { font-size: 15px; font-weight: 800; line-height: 1.35; margin: 0 0 22px; }
           .k5y-lb2 { display: none; }
 
-          .k5y-cta-btn { padding: 14px 30px; font-size: 16px; gap: 8px; }
-          .k5y-cta-icon { width: 16px; height: 16px; }
+          .k5y-cta-btn { padding: 4.8px 8.8px; font-size: 10px; gap: 3px; }
+          .k5y-cta-icon { width: 10px; height: 10px; }
         }
       `}</style>
 

--- a/components/InlinePromoCard.tsx
+++ b/components/InlinePromoCard.tsx
@@ -11,21 +11,27 @@ function Keploy5YearsBanner() {
   return (
     <div className="my-8" style={{ width: "100%" }}>
       <style>{`
-        @keyframes k5y-border {
-          0%   { background-position: 0% 50%; }
-          50%  { background-position: 100% 50%; }
-          100% { background-position: 0% 50%; }
-        }
-        @keyframes k5y-glow {
-          0%, 100% { box-shadow: 0 2px 16px rgba(0,0,0,0.05), 0 0 0 0 rgba(251,146,60,0); }
-          50%       { box-shadow: 0 2px 20px rgba(0,0,0,0.06), 0 0 18px 3px rgba(251,146,60,0.14); }
-        }
         @keyframes k5y-sweep {
           0%        { transform: translateX(-120%) skewX(-12deg); }
           65%, 100% { transform: translateX(600%) skewX(-12deg); }
         }
         .k5y-body { display: flex; align-items: center; gap: 26px; }
-        .k5y-badge-img { display: block; height: 76px; width: auto; flex-shrink: 0; }
+        .k5y-badge-wrap {
+          position: relative;
+          width: 88px;
+          height: 90px;
+          flex-shrink: 0;
+          overflow: hidden;
+        }
+        .k5y-badge-img {
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          height: 130px;
+          width: auto;
+          max-width: none;
+          transform: translate(-50%, -50%);
+        }
         .k5y-divider { display: block; }
         .k5y-cta-btn {
           flex-shrink: 0;
@@ -57,109 +63,100 @@ function Keploy5YearsBanner() {
         }
         @media (max-width: 600px) {
           .k5y-body { flex-direction: column; align-items: flex-start; gap: 16px; }
-          .k5y-badge-img { height: 64px; }
+          .k5y-badge-wrap { width: 70px; height: 72px; }
+          .k5y-badge-img { height: 104px; }
           .k5y-divider { display: none; }
           .k5y-cta-btn { width: 100%; text-align: center; white-space: normal; }
         }
       `}</style>
 
-      {/* Animated gradient border */}
+      {/* Card body */}
       <div
+        className="k5y-body"
         style={{
-          background:
-            "linear-gradient(135deg, #fbbf24, #f97316, #f59e0b, #fb923c, #fde68a, #f97316, #fbbf24)",
-          backgroundSize: "400% 400%",
-          animation: "k5y-border 4.5s ease infinite, k5y-glow 3s ease-in-out infinite",
-          padding: "1.5px",
+          background: "#ffffff",
           borderRadius: 16,
+          border: "1px solid #e5e7eb",
+          boxShadow: "0 4px 24px rgba(0,0,0,0.08)",
+          padding: "22px 28px",
+          position: "relative",
+          overflow: "hidden",
         }}
       >
-        {/* Card body */}
+        {/* Shine sweep */}
         <div
-          className="k5y-body"
           style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: "25%",
+            height: "100%",
             background:
-              "radial-gradient(55% 100% at 0% 50%, rgba(251,146,60,0.16) 0%, rgba(253,186,116,0.07) 22%, rgba(255,255,255,0) 42%), " +
-              "#ffffff",
-            borderRadius: "calc(16px - 1.5px)",
-            padding: "22px 28px",
-            position: "relative",
-            overflow: "hidden",
+              "linear-gradient(105deg, transparent 30%, rgba(251,191,36,0.10) 50%, transparent 70%)",
+            animation: "k5y-sweep 4.5s ease-in-out infinite",
+            pointerEvents: "none",
           }}
-        >
-          {/* Shine sweep */}
-          <div
-            style={{
-              position: "absolute",
-              top: 0,
-              left: 0,
-              width: "25%",
-              height: "100%",
-              background:
-                "linear-gradient(105deg, transparent 30%, rgba(251,191,36,0.10) 50%, transparent 70%)",
-              animation: "k5y-sweep 4.5s ease-in-out infinite",
-              pointerEvents: "none",
-            }}
-          />
+        />
 
-          {/* Left: badge */}
+        {/* Left: badge */}
+        <div className="k5y-badge-wrap">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src="https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/keploy5years.png"
             alt="5 years of Keploy badge"
             className="k5y-badge-img"
           />
-
-          {/* Vertical divider */}
-          <div
-            className="k5y-divider"
-            style={{
-              width: 1.5,
-              alignSelf: "stretch",
-              flexShrink: 0,
-              background:
-                "linear-gradient(to bottom, transparent, #fdba74 15%, #f97316 50%, #fdba74 85%, transparent)",
-            }}
-          />
-
-          {/* Text */}
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <p
-              style={{
-                color: "#171412",
-                fontSize: 16,
-                fontWeight: 700,
-                margin: "0 0 6px",
-                lineHeight: 1.35,
-              }}
-            >
-              keploy turned 5 this month!
-            </p>
-            <p
-              id={`${bannerId}-desc`}
-              style={{
-                color: "#92400e",
-                fontSize: 13.5,
-                margin: 0,
-                lineHeight: 1.65,
-              }}
-            >
-              To celebrate our 5 years, we are giving away one month of Keploy credits for free!
-            </p>
-          </div>
-
-          {/* CTA */}
-          <a
-            href="https://keploy.io/credits-form"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="k5y-cta-btn"
-            aria-label="Claim your free 1 month of Keploy credits"
-            aria-describedby={`${bannerId}-desc`}
-          >
-            claim free 1 month credits
-          </a>
         </div>
+
+        {/* Vertical divider */}
+        <div
+          className="k5y-divider"
+          style={{
+            width: 1.5,
+            alignSelf: "stretch",
+            flexShrink: 0,
+            background:
+              "linear-gradient(to bottom, transparent, #fdba74 15%, #f97316 50%, #fdba74 85%, transparent)",
+          }}
+        />
+
+        {/* Text */}
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <p
+            style={{
+              color: "#171412",
+              fontSize: 16,
+              fontWeight: 700,
+              margin: "0 0 6px",
+              lineHeight: 1.35,
+            }}
+          >
+            Keploy turned 5 this month!
+          </p>
+          <p
+            id={`${bannerId}-desc`}
+            style={{
+              color: "#92400e",
+              fontSize: 13.5,
+              margin: 0,
+              lineHeight: 1.65,
+            }}
+          >
+            To celebrate our 5 years, we are giving away one month of Keploy credits for free!
+          </p>
+        </div>
+
+        {/* CTA */}
+        <a
+          href="https://keploy.io/credits-form"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="k5y-cta-btn"
+          aria-label="Claim your free 1 month of Keploy credits"
+          aria-describedby={`${bannerId}-desc`}
+        >
+          claim free 1 month credits
+        </a>
       </div>
     </div>
   );

--- a/components/InlinePromoCard.tsx
+++ b/components/InlinePromoCard.tsx
@@ -38,24 +38,28 @@ function Keploy5YearsBanner() {
           display: inline-flex;
           align-items: center;
           justify-content: center;
-          padding: 12px 22px;
-          background: linear-gradient(135deg, #fb923c, #f97316);
+          padding: 12px 12px;
+          background: linear-gradient(180deg, #ff9d2e 0%, #ff6b00 100%);
           color: white;
           border: none;
           border-radius: 10px;
           font-size: 13.5px;
           font-weight: 700;
           text-decoration: none;
-          box-shadow: 0 4px 12px rgba(249,115,22,0.28);
+          box-shadow: 0 5px 14px rgba(255,107,0,0.16);
           letter-spacing: 0.01em;
           cursor: pointer;
           white-space: nowrap;
-          transition: box-shadow 0.15s ease, transform 0.15s ease;
+          transition: box-shadow 200ms ease, transform 200ms ease, filter 200ms ease;
           font-family: inherit;
         }
         .k5y-cta-btn:hover {
-          box-shadow: 0 6px 16px rgba(249,115,22,0.36);
+          box-shadow: 0 6px 16px rgba(255,107,0,0.20);
           transform: translateY(-1px);
+          filter: brightness(1.05);
+        }
+        .k5y-cta-btn:active {
+          transform: translateY(1px);
         }
         .k5y-cta-btn:focus-visible {
           outline: 3px solid #f59e0b;
@@ -74,7 +78,8 @@ function Keploy5YearsBanner() {
       <div
         className="k5y-body"
         style={{
-          background: "#ffffff",
+          background:
+            "radial-gradient(65% 110% at 0% 45%, rgba(255,140,32,0.12) 0%, rgba(255,157,46,0.06) 24%, rgba(255,255,255,0) 46%), #ffffff",
           borderRadius: 16,
           border: "1px solid #e5e7eb",
           boxShadow: "0 4px 24px rgba(0,0,0,0.08)",
@@ -115,6 +120,7 @@ function Keploy5YearsBanner() {
             width: 1.5,
             alignSelf: "stretch",
             flexShrink: 0,
+            opacity: 0.7,
             background:
               "linear-gradient(to bottom, transparent, #fdba74 15%, #f97316 50%, #fdba74 85%, transparent)",
           }}
@@ -152,10 +158,10 @@ function Keploy5YearsBanner() {
           target="_blank"
           rel="noopener noreferrer"
           className="k5y-cta-btn"
-          aria-label="Claim your free 1 month of Keploy credits"
+          aria-label="Claim 1 month of free Keploy credits"
           aria-describedby={`${bannerId}-desc`}
         >
-          claim free 1 month credits
+          Claim 1 Month of Free Credits
         </a>
       </div>
     </div>

--- a/components/post-body.tsx
+++ b/components/post-body.tsx
@@ -11,7 +11,9 @@ import KeywordTooltipLayer from "./KeywordTooltipLayer";
 import { getTooltipsForSlug } from "../config/keyword-tooltips";
 
 /* ── Heavy components: lazy-loaded to reduce initial JS bundle ── */
-const InlinePromoCard = dynamic(() => import("./InlinePromoCard"));
+const InlinePromoCard = dynamic(() => import("./InlinePromoCard"), {
+  loading: () => <div className="my-8 w-full min-h-[300px]" />,
+});
 const CodeMirror = dynamic(() => import("@uiw/react-codemirror"), {
   ssr: false,
   loading: () => <div className="bg-[#1e1e2e] rounded-lg p-4 mb-6 min-h-[60px]" />,
@@ -349,6 +351,10 @@ export default function PostBody({
     };
 
     const inlinePromoConfigs = blogSlug ? getInlinePromosForSlug(blogSlug) : [];
+    // Tracks which promoIds actually found their anchor somewhere in the post.
+    // If a promoId's anchor text never matches (e.g. the CMS copy changed), it would
+    // otherwise silently vanish from the page — appendMissedPromos below covers that case.
+    const promoIdInjected = new Set<string>();
     const buildPromoSplitRegex = (afterText: string): RegExp => {
       const escaped = afterText.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       return new RegExp(`(${escaped}[\\s\\S]*?<\\/(?:p|blockquote|li|div|h[1-6])>)`, "i");
@@ -361,6 +367,7 @@ export default function PostBody({
         const splitRegex = buildPromoSplitRegex(config.afterText);
         const parts = html.split(splitRegex);
         if (parts.length > 1) {
+          promoIdInjected.add(config.promoId);
           const beforeAndBlock = injectTooltipSpans(parts[0] + (parts[1] || ""));
           const after = parts.slice(2).join("");
           return (
@@ -384,6 +391,21 @@ export default function PostBody({
           suppressHydrationWarning
         />
       );
+    };
+    // If a configured promo's anchor never matched anywhere in the post, render it once
+    // at the end instead of dropping it silently — a missing/changed anchor sentence
+    // should degrade to "shows at the bottom", not "never shows at all".
+    const appendMissedPromos = (parts: ParsedPart[]): ParsedPart[] => {
+      const uniquePromoIds = Array.from(new Set(inlinePromoConfigs.map((c) => c.promoId)));
+      const missed = uniquePromoIds.filter((id) => !promoIdInjected.has(id));
+      if (!missed.length) return parts;
+      return [
+        ...parts,
+        ...missed.map((promoId, i) => ({
+          type: "text" as const,
+          node: <InlinePromoCard key={`promo-fallback-${i}`} promoId={promoId} />,
+        })),
+      ];
     };
 
     const gatedConfig = blogSlug ? getGatedReportConfig(blogSlug) : null;
@@ -423,7 +445,7 @@ export default function PostBody({
     const codeBlocks = safeContent.match(/<pre[\s\S]*?<\/pre>/gm);
 
     if (!codeBlocks) {
-      return [{ type: "text", node: processHtmlPart(safeContent, 0, 0) }];
+      return appendMissedPromos([{ type: "text", node: processHtmlPart(safeContent, 0, 0) }]);
     }
 
     const decodeHtmlEntities = (str: string): string => {
@@ -450,7 +472,7 @@ export default function PostBody({
 
     let nextIsContinuation = false;
 
-    return safeContent
+    const mappedParts = safeContent
       .split(/(<pre[\s\S]*?<\/pre>)/gm)
       .map((part, index): ParsedPart => {
         if (/<pre[\s\S]*?<\/pre>/.test(part)) {
@@ -487,6 +509,8 @@ export default function PostBody({
         });
         return { type: "text", node: processHtmlPart(part, index, 0, isContinuation) };
       });
+
+    return appendMissedPromos(mappedParts);
   }, [replacedContent, blogSlug, tooltipConfigs]);
 
   // Cheap: renders code blocks with current copy state \u2014 no HTML parsing

--- a/config/inline-promos.ts
+++ b/config/inline-promos.ts
@@ -22,13 +22,13 @@ export const inlinePromos: InlinePromoConfig[] = [
   {
     // https://keploy.io/blog/community/software-testing-strategies
     blogSlug: "software-testing-strategies",
-    afterText: "Automation is typically used for repetitive tasks such as regression testing and CI/CD validation.",
+    afterText: "An automation strategy defines which test cases should be automated and how automation fits into the development pipeline.",
     promoId: "keploy-5years",
   },
   {
     // https://keploy.io/blog/community/software-testing-strategies
     blogSlug: "software-testing-strategies",
-    afterText: "I usually run these at defined milestones using tools like JMeter or k6 instead of on every build.",
+    afterText: "I usually run these at defined milestones using tools like JMeter or k6 instead of on every build, since they are expensive to execute and their results only change when architecture or traffic patterns change.",
     promoId: "keploy-5years",
   },
 ];

--- a/config/inline-promos.ts
+++ b/config/inline-promos.ts
@@ -10,7 +10,7 @@ export const inlinePromos: InlinePromoConfig[] = [
   {
     // https://keploy.io/blog/community/software-testing-basics
     blogSlug: "software-testing-basics",
-    afterText: "Software testing is the process of evaluating a software",
+    afterText: "There is no doubt that having a strong foundation",
     promoId: "keploy-5years",
   },
   {

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -29,10 +29,10 @@ export default function Document() {
         <link
           rel="preload"
           as="style"
-          href="https://fonts.googleapis.com/css2?family=Lexend:wght@500;600;700;800&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Lexend:wght@500;700;800&display=swap"
         />
         <link
-          href="https://fonts.googleapis.com/css2?family=Lexend:wght@500;600;700;800&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Lexend:wght@500;700;800&display=swap"
           rel="stylesheet"
         />
 


### PR DESCRIPTION
Rebuilt the inline "5 Years of Keploy" promo CTA banner (`components/InlinePromoCard.tsx`) from scratch against the design team's final Figma file. Placement of the banner within each blog post is unchanged — only the card itself changed, and this replaces the previous gradient/animated-border version entirely rather than iterating on it.

**Desktop**
- Full-width card matching the blog's content column 
- 3 decorative orange ellipse "blobs" (top-right, left-side, bottom) clipped by the card edges, matched to the Figma reference by cross-checking pixel positions against the exported design frames.
- Badge (5-years anniversary ribbon) is absolutely positioned so its `top`/`right` offsets sit outside the card's normal content box, then gets partially clipped by the card's `overflow: hidden` — matching the same clip-content behavior the badge has inside its own Figma frame. This is what lets the card's height be driven purely by the text/button content rather than by the badge's own size.
- Heading wraps to 3 lines per spec: "Celebrate with us / Get **1 Month of FREE** / Keploy Credits" (Lexend Bold). "1 Month of FREE" is one gradient-coloured phrase (`#FF9D2E → #F76B1C`), rest of the heading is plain black - rendered as its own dedicated heading variant (see Mobile below)
- CTA changed from an animated gradient pill to a solid `#F76B1C` pill with a diagonal arrow icon - "Claim 1 Month of Free Credits". Focus ring updated to `#F76B1C` (was a leftover `#F59E0B` from the old palette).
- Dropped the old animated rainbow border, shine-sweep animation, and gradient watercolor wash

**Mobile (≤850px)**
- Centered, stacked layout: badge → heading (2-line variant, since the vertical stack has more relative width to work with) → CTA
- Badge swapped to a separately-cropped asset (`badge-tight.png`) instead of the desktop one - the desktop asset's large transparent canvas padding was creating an oversized gap between badge and heading once stacked vertically. It sits in normal document flow (not absolutely positioned) so its layout doesn't depend on the image's exact intrinsic height.
- Breakpoint widened from 600px to 850px after review caught the 601–850px range (tablets, small laptops) crushing the heading into 6-7 lines against the fixed-width badge. Verified the blog's content column locks to a fixed 732px width from 850px through 1920px, so the desktop layout never gets squeezed above that point.
- Heading at 14px / weight 800 (up from 700) - tested up to 16px, but 15px already wraps to 3 lines on an actual 375px-wide iPhone SE, so 14px is the real ceiling that holds 2 lines on both SE and iPhone 14 widths
- CTA at a compact ~10px/5px-9px padding - kept close to the original Figma spec after a larger version (16px font / 30px padding) was overflowing the card frame on real iPhone SE and iPhone 14 widths
- Desktop and mobile now render as two independent heading elements toggled by CSS (`k5y-heading-desktop` / `k5y-heading-mobile`) instead of hiding a `<br>` via `display: none`, which was inconsistent across renderers and broke if the copy ever changed

**Accessibility**
- Restored a screen-reader-only description ("Celebrating 5 years of Keploy — claim one month of free credits.") linked to the CTA via `aria-describedby`, matching what the previous version had
- All 9 images now carry explicit `width`/`height` attributes (previously missing, a layout-shift risk). The 7 decorative ellipses load `loading="lazy"` + `decoding="async"`; the two badge images (the visual centerpiece of the card) load `eager` instead, since lazy-loading the largest, most prominent image in the component was causing a visible pop-in

**Code health**
- Moved all component CSS out of an inline `<style>` template string into `components/InlinePromoCard.module.css`, matching how the rest of this repo already scopes component styles (`subscribe-newsletter.module.css`, `post-body.module.css`, etc.) - now it's scoped, goes through the normal lint/build pipeline, and doesn't re-inject a global `<style>` tag on every render
- Removed the `"use client"` directive - this repo is Pages Router only (no `app/` directory), so it was inert

**Assets**
- All 9 images (badge, cropped mobile badge, 7 ellipse SVGs) now load from `keploy-devrel.s3.us-west-2.amazonaws.com/landing/5years/` - nothing for this component is bundled in `public/` anymore
- Added the `Lexend` Google Font (weights 500/700/800 - only what's actually used) to `pages/_document.tsx`, following the same preload+stylesheet pattern already used there for Baloo 2 / DM Sans

**Known open items** (see PR conversation)
- `config/inline-promos.ts` anchor text change predates this redesign and moves the CTA from the top to the bottom of the `software-testing-basics` post - still needs an explicit call on whether to revert or keep
- Mobile CTA is intentionally compact to avoid the SE/14 overflow described above, but is under the ~44px touch-target guideline - open to a follow-up if that needs addressing before merge
- The CTA button and heading accent colour (`#F76B1C`) measure below WCAG AA contrast on white (2.97:1, needs 4.5:1) - this was raised in review, but the colour is part of the signed-off Figma design, so it's being kept as-is rather than adjusted unilaterally

## Ui Screenshots:

### Desktop:
<img width="1393" height="671" alt="Screenshot 2026-07-31 at 9 42 20 PM" src="https://github.com/user-attachments/assets/a2e2f3c4-afcc-43e0-8e00-b365b07e8315" />


### Mobile:
<img width="202" height="418" alt="Screenshot 2026-07-31 at 9 44 50 PM" src="https://github.com/user-attachments/assets/5e4902dc-4204-4b07-a95f-201e18b5de04" />



### Have also created a figma design for the same earlier:
- Iterations: https://www.figma.com/design/6Xw3GmXqvWvj52o1wJ45i3/Keploy---New-file--Copy-?node-id=2248-1094&t=m8fQ0MNRN1MswCuJ-1
- Final ui: https://www.figma.com/design/6Xw3GmXqvWvj52o1wJ45i3/Keploy---New-file--Copy-?node-id=2248-1093&m=dev

- Ran `npm run build`, nothing breaks:
<img width="567" height="327" alt="Screenshot 2026-07-28 at 3 06 12 PM" src="https://github.com/user-attachments/assets/fcd739dc-be44-43fe-a9a6-fe8bc6b462c7" />

