### PR TITLE
perf: replace time-based ISR with on-demand revalidation

### DIFF
--- a/components/navbar/FloatingNavbarClient.tsx
+++ b/components/navbar/FloatingNavbarClient.tsx
@@ -161,7 +161,7 @@ export default function FloatingNavbarClient({ techLatest = [], communityLatest 
         if (techState.length === 0 || communityState.length === 0) {
           const endpoint = process.env.NEXT_PUBLIC_WORDPRESS_API_URL as string | undefined;
           if (!endpoint) {
-            const res = await fetch(`${router.basePath || ''}/api/nav-latest`, { cache: "no-store" });
+            const res = await fetch(`${router.basePath || ''}/api/nav-latest`);
             if (!res.ok) throw new Error("Failed to fetch latest posts (no env, API 404)");
             const data = await res.json();
             if (!mounted) return;
@@ -771,7 +771,10 @@ function SearchBox({ onClose, techLatest = [], communityLatest = [] as any[] }: 
     (async () => {
       try {
         const base = (router?.basePath as string) || "";
-        const res = await fetch(`${base}/api/search-all`, { cache: "no-store" });
+        // No `cache: "no-store"` — the post list is public and identical for
+        // everyone, so let the browser and edge cache serve it. Opening the
+        // search box previously forced a fresh serverless invocation each time.
+        const res = await fetch(`${base}/api/search-all`);
         if (!res.ok) throw new Error("Failed to load posts");
         const data = await res.json();
         if (!mounted) return;

--- a/config/redirect.ts
+++ b/config/redirect.ts
@@ -23,6 +23,10 @@ export const slugRedirects: Record<string, string> = {
  * @returns The new slug if a redirect exists, otherwise null
  */
 export function getRedirectSlug(slug: string): string | null {
+    // Guard the prototype chain: a bare `slugRedirects[slug]` lookup returns
+    // Object.prototype's method for a slug like "toString", and that function
+    // is truthy — which would send a real post into a bogus redirect.
+    if (!hasRedirect(slug)) return null;
     return slugRedirects[slug] || null;
 }
 
@@ -32,5 +36,8 @@ export function getRedirectSlug(slug: string): string | null {
  * @returns true if the slug should be redirected
  */
 export function hasRedirect(slug: string): boolean {
-    return slug in slugRedirects;
+    // hasOwnProperty, not `in`: `in` walks the prototype chain, so a post
+    // legitimately slugged "constructor" or "toString" would report as having
+    // a redirect and get silently dropped from getStaticPaths.
+    return Object.prototype.hasOwnProperty.call(slugRedirects, slug);
 }

--- a/docs/on-demand-revalidation.md
+++ b/docs/on-demand-revalidation.md
@@ -1,0 +1,232 @@
+# On-demand revalidation
+
+## Why this exists
+
+Every page in this app is statically generated (ISR). Freshness used to come
+from *time-based* revalidation — `revalidate: 10` on technology posts and the
+listing pages, `revalidate: 60` on community posts.
+
+That is the wrong mechanism for a blog. Each time a page's window expired, the
+next request served a stale copy and fired a background regeneration, and each
+regeneration is a full serverless invocation costing ~3.5s of WordPress
+round-trips:
+
+| Query | Time |
+| --- | ---: |
+| `getPostAndMorePosts` | 1488 ms |
+| `getMoreStoriesForSlugs` | 1083 ms |
+| `getReviewAuthorDetails("neha")` | 383 ms |
+| `getReviewAuthorDetails("Jain")` | 889 ms |
+| **total** | **~3.5 s** |
+
+Across ~520 posts under crawler traffic that was roughly 1.2M renders and
+**2,224 GB-Hrs** of Vercel function duration per billing period — almost all of
+it re-fetching content that had not changed.
+
+WordPress content changes a few times a week, not every 10 seconds. So
+regeneration is now driven by *events*, not by a timer: WordPress calls
+`/blog/api/revalidate` when a post actually changes, and the ISR TTLs in
+`lib/isr.ts` are just a 24h safety net.
+
+## Setup
+
+### 1. Vercel
+
+Add a project environment variable:
+
+```
+REVALIDATE_SECRET=<a long random string>
+```
+
+Generate one with `openssl rand -hex 32`. The endpoint fails closed — if this
+is unset it returns 500 rather than allowing unauthenticated regeneration.
+
+### 2. WordPress
+
+Save the file below as
+`wp-content/mu-plugins/keploy-revalidate.php` on `wp.keploy.io`. `mu-plugins`
+(must-use) load automatically and cannot be deactivated from the admin UI by
+accident.
+
+Then add the matching secret to `wp-config.php`:
+
+```php
+define('KEPLOY_REVALIDATE_SECRET', '<the same value as REVALIDATE_SECRET>');
+define('KEPLOY_REVALIDATE_ENDPOINT', 'https://keploy.io/blog/api/revalidate');
+```
+
+```php
+<?php
+/**
+ * Plugin Name: Keploy Blog On-Demand Revalidation
+ * Description: Pings the Next.js blog so it regenerates pages the moment
+ *              content changes, instead of polling on a timer.
+ */
+
+defined('ABSPATH') || exit;
+
+/**
+ * Ping the blog for a single post.
+ *
+ * Sent non-blocking so saving a post in the editor is never slowed down by
+ * page regeneration (which can take a few seconds per page). Delivery failures
+ * are therefore not visible here — they surface in the Vercel function logs,
+ * and the 24h ISR safety net in lib/isr.ts backstops anything genuinely lost.
+ */
+function keploy_ping_revalidate($post) {
+    if (!($post instanceof WP_Post) || $post->post_type !== 'post') {
+        return;
+    }
+
+    if (!defined('KEPLOY_REVALIDATE_SECRET') || !defined('KEPLOY_REVALIDATE_ENDPOINT')) {
+        error_log('[keploy-revalidate] KEPLOY_REVALIDATE_SECRET / _ENDPOINT not defined in wp-config.php');
+        return;
+    }
+
+    // WordPress appends "__trashed" to post_name when a post is trashed. The
+    // blog still knows the page by its original slug, so strip the suffix.
+    $slug = preg_replace('/__trashed$/', '', $post->post_name);
+    if ($slug === '') {
+        return;
+    }
+
+    $body = array('slug' => $slug);
+
+    // Only the two categories the blog actually routes on. If the post is in
+    // neither (or is moving between them), omit `category` and the endpoint
+    // will revalidate both URLs — which is what makes a category change work.
+    $slugs = wp_get_post_categories($post->ID, array('fields' => 'slugs'));
+    foreach (array('community', 'technology') as $category) {
+        if (in_array($category, $slugs, true)) {
+            $body['category'] = $category;
+            break;
+        }
+    }
+
+    // Tag and author pages are ALSO behind the 24h safety net, so a publish
+    // that doesn't refresh them leaves the new post missing from those
+    // listings for a full day. Send them so the endpoint can target them.
+    $tags = wp_get_post_tags($post->ID, array('fields' => 'names'));
+    if (!is_wp_error($tags) && !empty($tags)) {
+        $body['tags'] = array_slice($tags, 0, 20);
+    }
+
+    // PublishPress Multiple Authors (ppmaAuthorName) is the display author the
+    // blog routes on; fall back to the WP account only if it isn't available.
+    $author = '';
+    if (function_exists('get_multiple_authors')) {
+        $authors = get_multiple_authors($post->ID);
+        if (!empty($authors) && !empty($authors[0]->display_name)) {
+            $author = $authors[0]->display_name;
+        }
+    }
+    if ($author === '') {
+        $author = get_the_author_meta('display_name', $post->post_author);
+    }
+    if ($author !== '') {
+        $body['author'] = $author;
+    }
+
+    wp_remote_post(KEPLOY_REVALIDATE_ENDPOINT, array(
+        'timeout'  => 5,
+        'blocking' => false,
+        'headers'  => array(
+            'Content-Type'        => 'application/json',
+            'x-revalidate-secret' => KEPLOY_REVALIDATE_SECRET,
+        ),
+        'body'     => wp_json_encode($body),
+    ));
+}
+
+/**
+ * Fires on publish, update, unpublish and trash.
+ *
+ * transition_post_status covers every status change in one hook, so an
+ * unpublish correctly turns the live page into a 404 instead of leaving the
+ * last good render cached for 24h.
+ */
+function keploy_revalidate_on_transition($new_status, $old_status, $post) {
+    // Ignore autosaves/revisions and no-op transitions.
+    if (wp_is_post_revision($post->ID) || wp_is_post_autosave($post->ID)) {
+        return;
+    }
+    if ($new_status === $old_status && $new_status !== 'publish') {
+        return;
+    }
+    // Only care if the post is, or just stopped being, publicly visible.
+    if ($new_status !== 'publish' && $old_status !== 'publish') {
+        return;
+    }
+
+    keploy_ping_revalidate($post);
+}
+add_action('transition_post_status', 'keploy_revalidate_on_transition', 10, 3);
+
+/** Permanent deletion doesn't go through transition_post_status. */
+function keploy_revalidate_on_delete($post_id) {
+    $post = get_post($post_id);
+    if ($post) {
+        keploy_ping_revalidate($post);
+    }
+}
+add_action('before_delete_post', 'keploy_revalidate_on_delete');
+```
+
+## Verifying
+
+Trigger a revalidation by hand:
+
+```bash
+curl -X POST https://keploy.io/blog/api/revalidate \
+  -H 'content-type: application/json' \
+  -H "x-revalidate-secret: $REVALIDATE_SECRET" \
+  -d '{"slug":"what-is-api-testing","category":"community"}'
+```
+
+A success returns `{"revalidated": true, "results": [...]}` with one entry per
+regenerated path — the post itself plus `/blog`, both category listings, both
+search pages, the tag and author indexes, and any tag/author pages named in the
+request.
+
+Individual paths can report `revalidated: false` without the request failing —
+that is expected when a slug legitimately doesn't exist in one of the two
+categories. Only an all-paths failure returns a 500.
+
+Then confirm the page actually re-rendered:
+
+```bash
+curl -sI https://keploy.io/blog/community/what-is-api-testing | grep -i x-vercel-cache
+# x-vercel-cache: HIT   (age resets to ~0 right after a revalidation)
+```
+
+### Verify the API cache headers on the preview deployment
+
+`vercel.json` previously forced `no-store` on all of `/blog/api/(.*)`; it is now
+scoped to `preview|exit-preview|revalidate` so the read-only data routes can be
+served from the edge. Those routes set their own `Cache-Control` in the handler
+(and `no-store` on their error paths).
+
+What is NOT established from the repo alone is which value wins when a
+`vercel.json` header rule and a handler's `res.setHeader` set the same key —
+`/blog/api/search-all` also matches the blanket `/blog/(.*)` rule. Check it on
+the preview URL before merging:
+
+```bash
+curl -sI https://<preview>.vercel.app/blog/api/search-all | grep -i cache-control
+# want: public, s-maxage=3600, stale-while-revalidate=86400
+```
+
+If the blanket rule wins instead, add an explicit `/blog/api/(search-all|nav-latest|proxy-image)`
+entry to `vercel.json` with those values.
+
+## Gotchas
+
+- **Paths must include the `/blog` basePath.** `res.revalidate()` is not a
+  route lookup; on Vercel it performs a real `fetch('https://' + host + path)`.
+  A path without the basePath silently 404s and revalidates nothing. This is
+  why `lib/isr.ts` exports `BASE_PATH`/`postPath()` rather than hand-writing
+  paths at each call site, and why `tests/lib/isr.test.ts` pins it to
+  `next.config.js`.
+- **Don't lower the TTLs in `lib/isr.ts` to "fix" staleness.** That reintroduces
+  exactly the cost this removed. If content is stale, the webhook is broken —
+  check the Vercel function logs for `/api/revalidate`.

--- a/docs/on-demand-revalidation.md
+++ b/docs/on-demand-revalidation.md
@@ -65,17 +65,35 @@ and the chart turns that into an `envFrom.secretRef` — so every key in that
 SealedSecret becomes a pod environment variable. Add the secret there and the
 plugin reads it with `getenv()`. No `wp-config.php` change is needed at all.
 
-Re-seal the existing secret with the new key (needs cluster access):
+Add the new key with `kubeseal --raw` and paste the output under
+`encryptedData`. Do **not** rebuild the whole SealedSecret: `kubeseal` cannot
+decrypt the existing `WORDPRESS_DB_PASSWORD`, so regenerating the resource from
+scratch would destroy it.
 
 ```bash
 kubectl -n prod get secret wordpress-secrets -o jsonpath='{.data}'   # existing keys
-kubeseal --controller-name sealed-secrets --controller-namespace kube-system \
-  --format yaml < updated-wordpress-secrets.yaml
+
+# The controller is `sealed-secrets-controller` in `flux-system`
+# (clusters/prod-azure/infra/sealed-secrets.yaml) — not the chart defaults.
+# The SealedSecret has no scope annotation, so it is strict-scoped and the
+# value is bound to this exact namespace + name.
+printf %s "$REVALIDATE_SECRET" | kubeseal --raw \
+  --namespace prod --name wordpress-secrets \
+  --controller-name sealed-secrets-controller \
+  --controller-namespace flux-system
 ```
 
-then commit the regenerated `SealedSecret` block in
-`clusters/prod-azure/prod/wordpress.yaml`. Use the same value as the Vercel
+Paste that blob under `encryptedData.KEPLOY_REVALIDATE_SECRET` in
+`clusters/prod-azure/prod/wordpress.yaml`, using the same value as the Vercel
 `REVALIDATE_SECRET`.
+
+**The pods will not pick it up on their own.** The deployment checksums only
+`secureconfig` and `extendedconfig`; nothing rolls pods when `wordpress-secrets`
+changes, and `envFrom` is read once at container start. Finish with:
+
+```bash
+kubectl -n prod rollout restart deployment/wordpress
+```
 
 **Outbound traffic.** The ingress `configuration-snippet` restricts `wp-admin`,
 `wp-login.php`, and REST *write* methods to the VPN allowlist. That is inbound

--- a/docs/on-demand-revalidation.md
+++ b/docs/on-demand-revalidation.md
@@ -43,17 +43,44 @@ is unset it returns 500 rather than allowing unauthenticated regeneration.
 
 ### 2. WordPress
 
-Save the file below as
-`wp-content/mu-plugins/keploy-revalidate.php` on `wp.keploy.io`. `mu-plugins`
-(must-use) load automatically and cannot be deactivated from the admin UI by
-accident.
+`wp.keploy.io` is **not** a hand-managed server. It runs on the `prod-azure`
+cluster in namespace `prod`, deployed by Flux from
+[`keploy/k8s-env`](https://github.com/keploy/k8s-env)
+(`clusters/prod-azure/prod/wordpress.yaml`) via a custom Helm chart at
+[`slayerjain/wordpress-helm-chart`](https://github.com/slayerjain/wordpress-helm-chart).
 
-Then add the matching secret to `wp-config.php`:
+So do **not** SSH in, drop a file into `wp-content/mu-plugins/`, or edit
+`wp-config.php`. `wp-content` is on a 200Gi PVC with `keepPvc: true`, so a
+hand-placed file would survive a pod restart and appear to work — which is
+exactly what makes it dangerous. It would be undeclared drift, invisible to
+anyone reading either repo, and lost the moment the PVC is recreated.
 
-```php
-define('KEPLOY_REVALIDATE_SECRET', '<the same value as REVALIDATE_SECRET>');
-define('KEPLOY_REVALIDATE_ENDPOINT', 'https://keploy.io/blog/api/revalidate');
+The chart already has a mu-plugin delivery mechanism. `rest-api-users-access.php`
+is stored as data in the `-extended` ConfigMap
+(`wordpress/templates/extendedconfig.yaml`) and mounted with `subPath` into
+`wp-content/mu-plugins/`. Ship this plugin the same way.
+
+**Secret injection.** `wordpress.yaml` sets `extraEnvSecrets: [wordpress-secrets]`,
+and the chart turns that into an `envFrom.secretRef` — so every key in that
+SealedSecret becomes a pod environment variable. Add the secret there and the
+plugin reads it with `getenv()`. No `wp-config.php` change is needed at all.
+
+Re-seal the existing secret with the new key (needs cluster access):
+
+```bash
+kubectl -n prod get secret wordpress-secrets -o jsonpath='{.data}'   # existing keys
+kubeseal --controller-name sealed-secrets --controller-namespace kube-system \
+  --format yaml < updated-wordpress-secrets.yaml
 ```
+
+then commit the regenerated `SealedSecret` block in
+`clusters/prod-azure/prod/wordpress.yaml`. Use the same value as the Vercel
+`REVALIDATE_SECRET`.
+
+**Outbound traffic.** The ingress `configuration-snippet` restricts `wp-admin`,
+`wp-login.php`, and REST *write* methods to the VPN allowlist. That is inbound
+only and does not affect this plugin, which makes an outbound POST to
+`keploy.io`.
 
 ```php
 <?php
@@ -78,8 +105,15 @@ function keploy_ping_revalidate($post) {
         return;
     }
 
-    if (!defined('KEPLOY_REVALIDATE_SECRET') || !defined('KEPLOY_REVALIDATE_ENDPOINT')) {
-        error_log('[keploy-revalidate] KEPLOY_REVALIDATE_SECRET / _ENDPOINT not defined in wp-config.php');
+    // Injected by envFrom.secretRef from the wordpress-secrets SealedSecret —
+    // NOT defined in wp-config.php, which this deployment does not hand-edit.
+    $secret = getenv('KEPLOY_REVALIDATE_SECRET');
+    $endpoint = getenv('KEPLOY_REVALIDATE_ENDPOINT');
+    if ($endpoint === false || $endpoint === '') {
+        $endpoint = 'https://keploy.io/blog/api/revalidate';
+    }
+    if ($secret === false || $secret === '') {
+        error_log('[keploy-revalidate] KEPLOY_REVALIDATE_SECRET missing from the pod environment');
         return;
     }
 
@@ -127,12 +161,12 @@ function keploy_ping_revalidate($post) {
         $body['author'] = $author;
     }
 
-    wp_remote_post(KEPLOY_REVALIDATE_ENDPOINT, array(
+    wp_remote_post($endpoint, array(
         'timeout'  => 5,
         'blocking' => false,
         'headers'  => array(
             'Content-Type'        => 'application/json',
-            'x-revalidate-secret' => KEPLOY_REVALIDATE_SECRET,
+            'x-revalidate-secret' => $secret,
         ),
         'body'     => wp_json_encode($body),
     ));
@@ -171,6 +205,65 @@ function keploy_revalidate_on_delete($post_id) {
 }
 add_action('before_delete_post', 'keploy_revalidate_on_delete');
 ```
+
+### 3. Wiring the plugin in (two repos)
+
+The chart currently hardcodes its one mu-plugin. Rather than hardcode a second
+Keploy-specific one into a shared chart, add a generic `extraMuPlugins` knob so
+the PHP itself lives in `k8s-env` alongside the rest of the Keploy config.
+
+**`slayerjain/wordpress-helm-chart`**
+
+`wordpress/values.yaml`:
+
+```yaml
+# Extra must-use plugins. Key = filename, value = PHP source. Rendered into the
+# -extended ConfigMap and mounted into wp-content/mu-plugins/.
+extraMuPlugins: {}
+```
+
+`wordpress/templates/extendedconfig.yaml` — append to `data:`:
+
+```yaml
+{{- range $name, $content := .Values.extraMuPlugins }}
+  {{ $name }}: |
+{{ $content | indent 4 }}
+{{- end }}
+```
+
+`wordpress/templates/deployment.yaml` — after the `rest-api-users-access.php`
+mount:
+
+```yaml
+            {{- range $name, $_ := .Values.extraMuPlugins }}
+            - mountPath: /var/www/html{{ if $.Values.settings.wordpressSubDirectory }}{{ $.Values.settings.wordpressSubDirectory }}{{ end }}/wp-content/mu-plugins/{{ $name }}
+              subPath: {{ $name }}
+              name: extended
+            {{- end }}
+```
+
+No image rebuild is required — this is ConfigMap data, not a layer. The
+deployment already carries a `checksum/extendedconfig` pod annotation, so
+changing the ConfigMap rolls the pods automatically.
+
+**`keploy/k8s-env`** — in `clusters/prod-azure/prod/wordpress.yaml`, under
+`spec.values`, add the plugin from the previous section:
+
+```yaml
+    extraMuPlugins:
+      keploy-revalidate.php: |
+        <?php
+        /**
+         * Plugin Name: Keploy Blog On-Demand Revalidation
+         */
+        ... (the PHP above)
+```
+
+and add `KEPLOY_REVALIDATE_SECRET` to the `wordpress-secrets` SealedSecret in
+the same file.
+
+Flux watches the chart repo on a 5m interval and the cluster repo continuously,
+so both land without a manual deploy.
 
 ## Verifying
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,6 +1,3 @@
-export const maxDuration = 300; // This can run Vercel Functions for a maximum of 300 seconds
-export const dynamic = 'force-dynamic';
-
 const API_URL = process.env.WORDPRESS_API_URL || process.env.NEXT_PUBLIC_WORDPRESS_API_URL
 
 /**
@@ -262,6 +259,139 @@ export async function getReviewAuthorDetails(authorName) {
   return data?.users;
 }
 
+/**
+ * Process-local memo with a short TTL.
+ *
+ * Post renders repeat several byte-for-byte identical WordPress queries, and a
+ * single build shares one process across hundreds of pages — so memoizing
+ * removes almost all of that duplicate work.
+ *
+ * The TTL is the important part. A warm Vercel lambda is reused across many
+ * on-demand regenerations, so a memo with no expiry would serve every
+ * webhook-triggered rebuild whatever that lambda happened to cache when it
+ * first warmed — meaning a freshly published post could be missing from the
+ * "More Stories" rail on newly regenerated pages. Five minutes keeps the
+ * dedupe benefit (a build finishes well inside it) while bounding staleness.
+ */
+const MEMO_TTL_MS = 5 * 60 * 1000;
+
+/** Above this many live keys the memo resets rather than growing unbounded. */
+const MEMO_MAX_ENTRIES = 500;
+
+function createMemo<T>(ttlMs: number = MEMO_TTL_MS) {
+  type Entry = { value: Promise<T>; expiresAt: number };
+  const entries = new Map<string, Entry>();
+
+  return function memo(key: string, produce: () => Promise<T>): Promise<T> {
+    const now = Date.now();
+    const hit = entries.get(key);
+    if (hit && hit.expiresAt > now) return hit.value;
+
+    if (entries.size >= MEMO_MAX_ENTRIES) {
+      // forEach rather than for..of: this tsconfig targets below es2015, where
+      // iterating a Map needs --downlevelIteration. Deleting during forEach is
+      // well-defined for Map.
+      entries.forEach((entry, entryKey) => {
+        if (entry.expiresAt <= now) entries.delete(entryKey);
+      });
+      if (entries.size >= MEMO_MAX_ENTRIES) entries.clear();
+    }
+
+    // Cache the promise, not the result, so concurrent callers share one
+    // request. On failure evict, so the next caller retries instead of pinning
+    // a rejection for the whole TTL — but only if we're still the current
+    // entry, so a later attempt is never clobbered by an earlier failure.
+    const entry = { expiresAt: now + ttlMs } as Entry;
+    entry.value = produce().catch((error) => {
+      if (entries.get(key) === entry) entries.delete(key);
+      throw error;
+    });
+
+    entries.set(key, entry);
+    return entry.value;
+  };
+}
+
+/**
+ * The two reviewing authors are the same for every single post, but
+ * `getReviewAuthorDetails` was being called twice inside every post's
+ * getStaticProps — 1.27s of the ~3.5s render budget spent re-fetching two
+ * identical, never-changing records.
+ */
+const reviewAuthorMemo = createMemo<any>();
+
+export function getReviewAuthorDetailsCached(authorName: string) {
+  return reviewAuthorMemo(authorName, () => getReviewAuthorDetails(authorName));
+}
+
+/** Reviewing authors shown on every post page. */
+export const REVIEW_AUTHORS = ["neha", "Jain"];
+
+/** Fetch both reviewing authors, deduped and in parallel. */
+export function getReviewAuthors() {
+  return Promise.all(REVIEW_AUTHORS.map(getReviewAuthorDetailsCached));
+}
+
+/**
+ * Every slug in a category, paginating until WordPress runs out.
+ *
+ * `getAllPostsForTechnology`/`getAllPostsForCommunity` are capped at `first: 22`
+ * and were feeding getStaticPaths directly, so only 44 of ~520 posts were ever
+ * pre-rendered. The rest fell through to on-demand rendering. This query asks
+ * for slugs only, so pages are cheap and 100-at-a-time is safe.
+ */
+export async function getAllSlugsForCategory(categoryName: string): Promise<string[]> {
+  const slugs: string[] = [];
+  let after: string | null = null;
+  const wanted = categoryName.toLowerCase();
+
+  // Hard page ceiling so a malformed cursor can never spin forever.
+  for (let page = 0; page < 100; page++) {
+    const data = await fetchAPI(
+      `
+      query AllSlugsForCategory($after: String, $categoryName: String!) {
+        posts(
+          first: 100
+          after: $after
+          where: { orderby: { field: DATE, order: DESC }, categoryName: $categoryName }
+        ) {
+          edges { node { slug categories { edges { node { name } } } } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+      `,
+      { variables: { after, categoryName } }
+    );
+
+    for (const edge of data?.posts?.edges || []) {
+      if (!edge?.node?.slug) continue;
+
+      // WPGraphQL's `categoryName` filter matches on the category SLUG, but the
+      // page's own guard in getStaticProps compares category NAMES. When those
+      // disagree for a post, getStaticProps returns a `redirect` — and Next.js
+      // throws "`redirect` can not be returned from getStaticProps during
+      // prerendering", failing the whole build.
+      //
+      // Filtering here on the *same* criterion the page uses makes that
+      // unreachable for pre-rendered paths by construction, instead of relying
+      // on the old accident that getStaticPaths only ever returned 22 slugs.
+      // Genuinely cross-filed posts fall through to fallback: "blocking" and
+      // get their 301 at runtime, where returning a redirect is legal.
+      const names = (edge.node.categories?.edges || []).map(
+        (c: any) => c?.node?.name?.toLowerCase()
+      );
+      if (!names.includes(wanted)) continue;
+
+      slugs.push(edge.node.slug);
+    }
+
+    const pageInfo = data?.posts?.pageInfo;
+    if (!pageInfo?.hasNextPage || !pageInfo?.endCursor) break;
+    after = pageInfo.endCursor;
+  }
+
+  return slugs;
+}
 
 
 // Function for fetching post with technology category
@@ -501,11 +631,13 @@ export async function getPostsByAuthor() {
   return { edges: allPosts };
 }
 
+/** Shared "more stories" results, keyed by tag set. See fetchNodes below. */
+const moreStoriesMemo = createMemo<any[]>();
+
 export async function getMoreStoriesForSlugs(tags, slug) {
   const tagFilter = tags?.edges?.length > 0;
   const variables = tagFilter ? { tags: tags.edges.map((edge) => edge.node.name) } : undefined;
   let stories = [];
-  let data;
 
   const queryWithTags = `
     query Posts($tags: [String!]) {
@@ -548,19 +680,31 @@ export async function getMoreStoriesForSlugs(tags, slug) {
     }
   `;
 
+  // Both queries depend only on the tag list — the current post is filtered out
+  // afterwards, in JS. So the network result is shareable across every post with
+  // the same tags, and the untagged fallback is shared by all posts outright.
+  // Memoizing collapses ~1000 queries per build into a handful. Callers only
+  // ever .filter()/.map() the result, so the cached arrays are never mutated.
+  const fetchNodes = (cacheKey: string, query: string, vars?: any) =>
+    moreStoriesMemo(cacheKey, () =>
+      fetchAPI(query, { variables: vars }).then(
+        (result) => result?.posts?.edges.map(({ node }) => node) || []
+      )
+    );
+
   // Fetch posts with tags if applicable
   if (tagFilter) {
-    data = await fetchAPI(queryWithTags, { variables });
-    stories = data?.posts?.edges.map(({ node }) => node) || [];
-    stories = stories.filter((story) => story.slug !== slug);
+    const tagKey = `tags:${[...variables.tags].sort().join("|")}`;
+    stories = (await fetchNodes(tagKey, queryWithTags, variables)).filter(
+      (story) => story.slug !== slug
+    );
   }
 
   // If no posts are found, fetch without tag filter
   if (!stories.length) {
-    data = await fetchAPI(fallbackQuery);
-    stories = data?.posts?.edges.map(({ node }) => node) || [];
-    stories = stories.filter((story) => story.slug !== slug);
-
+    stories = (await fetchNodes("recent", fallbackQuery)).filter(
+      (story) => story.slug !== slug
+    );
   }
 
   // Remove posts with the same slug

--- a/lib/isr.ts
+++ b/lib/isr.ts
@@ -1,0 +1,58 @@
+/**
+ * ISR revalidation policy.
+ *
+ * Freshness comes from on-demand revalidation (`/api/revalidate`, driven by a
+ * WordPress publish/update webhook), NOT from time-based polling. The values
+ * below are therefore safety nets that only fire if the webhook is misconfigured
+ * or a delivery is dropped — they are not the primary freshness mechanism.
+ *
+ * Why this matters: these pages used to carry `revalidate: 10`/`60`. Every
+ * expiry served a stale hit and fired a background regeneration, and each
+ * regeneration is a full serverless invocation costing ~3.5s of WordPress
+ * round-trips. Across ~520 posts under crawler traffic that was ~1.2M renders
+ * and 2,224 GB-Hrs of function duration per billing period, re-fetching content
+ * that changes a few times a week.
+ *
+ * Keep these values LARGE. If content feels stale, fix the webhook — do not
+ * lower these numbers.
+ */
+
+/** Safety net for content pages. Real updates arrive via the webhook. */
+export const REVALIDATE_CONTENT = 86400 // 24h
+
+/**
+ * Must mirror `basePath` in next.config.js.
+ *
+ * `res.revalidate(path)` is not a route lookup — on Vercel it performs a real
+ * `fetch('https://' + host + path)` against the deployment (see
+ * next/dist/server/api-utils/node/api-resolver.js). So the path has to be the
+ * public URL path *including* the basePath, or every revalidation silently
+ * 404s. `tests/lib/isr.test.ts` asserts this stays in sync with next.config.js.
+ */
+export const BASE_PATH = '/blog'
+
+/** Public URL path for a post, ready to hand to `res.revalidate()`. */
+export function postPath(category: string, slug: string) {
+  return `${BASE_PATH}/${category}/${slug}`
+}
+
+/**
+ * Genuine "this post does not exist" responses.
+ *
+ * Must stay large: a short TTL here lets bot-sprayed URLs re-render on every
+ * expiry, turning random 404 traffic into unbounded function duration. A slug
+ * that doesn't exist now will still not exist in a minute, and a newly
+ * published post arrives via the webhook rather than by expiry.
+ */
+export const REVALIDATE_NOT_FOUND = 86400 // 24h
+
+/**
+ * Degraded responses caused by WordPress being unreachable — NOT by the
+ * content genuinely being absent.
+ *
+ * Deliberately short. These pages must self-heal quickly once WP recovers,
+ * otherwise a momentary blip during regeneration would pin a real post as a
+ * 404 for a full day. The cost is bounded because it only applies to pages
+ * that actually errored, not to the ~520 healthy ones.
+ */
+export const REVALIDATE_ERROR = 60 // 1m

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -6,6 +6,7 @@ import { getAllPostsForTechnology, getAllPostsForCommunity } from "../lib/api";
 import { GetStaticProps } from "next";
 import { getBreadcrumbListSchema, SITE_URL } from "../lib/structured-data";
 import { safeJsonLdStringify } from "../utils/seo";
+import { REVALIDATE_CONTENT, REVALIDATE_ERROR } from "../lib/isr";
 
 interface Custom404Props {
   latestPosts: { edges: Array<{ node: any }> };
@@ -91,7 +92,7 @@ export const getStaticProps: GetStaticProps = async () => {
         communityPosts: latestCommunityPosts,
         technologyPosts: latestTechnologyPosts,
       },
-      revalidate: 60, // Revalidate every minute
+      revalidate: REVALIDATE_CONTENT,
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -107,7 +108,7 @@ export const getStaticProps: GetStaticProps = async () => {
         "1. Verify WPGraphQL is up: curl -sS -X POST <endpoint> -H 'Content-Type: application/json' -d '{\"query\":\"{ __typename }\"}'",
         "2. If the curl 5xx's or hangs, check wp.keploy.io host status and the WPGraphQL plugin (WP admin → Plugins)",
         "3. If the endpoint logged above is unexpected, double-check WORDPRESS_API_URL in Vercel project settings and redeploy",
-        "4. Page is served with revalidate: 60, so the rails self-heal within ~1 min after WP recovers",
+        "4. The degraded response uses REVALIDATE_ERROR (60s), so the rails self-heal within ~1 min after WP recovers",
       ],
     });
     return {
@@ -116,7 +117,7 @@ export const getStaticProps: GetStaticProps = async () => {
         communityPosts: { edges: [] },
         technologyPosts: { edges: [] },
       },
-      revalidate: 60,
+      revalidate: REVALIDATE_ERROR,
     };
   }
 };

--- a/pages/api/nav-latest.ts
+++ b/pages/api/nav-latest.ts
@@ -7,11 +7,19 @@ export default async function handler(_req: NextApiRequest, res: NextApiResponse
       getAllPostsForTechnology(false),
       getAllPostsForCommunity(false),
     ]);
+    // Public, identical for every visitor — cache at the edge so this costs a
+    // function invocation once an hour rather than once per navbar render.
+    res.setHeader(
+      "Cache-Control",
+      "public, s-maxage=3600, stale-while-revalidate=86400"
+    );
     res.status(200).json({
       technology: (tech?.edges || []).slice(0, 4),
       community: (comm?.edges || []).slice(0, 4),
     });
   } catch (e: any) {
+    // Never cache a failure — see the note in search-all.ts.
+    res.setHeader("Cache-Control", "no-store");
     res.status(500).json({ error: e?.message || "Failed to load latest posts" });
   }
 }

--- a/pages/api/proxy-image.ts
+++ b/pages/api/proxy-image.ts
@@ -14,6 +14,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const urlParam = req.query.url;
 
     if (typeof urlParam !== "string") {
+      res.setHeader("Cache-Control", "no-store");
       res.status(400).send("Missing url parameter");
       return;
     }
@@ -22,16 +23,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     try {
       targetUrl = new URL(urlParam);
     } catch {
+      res.setHeader("Cache-Control", "no-store");
       res.status(400).send("Invalid url parameter");
       return;
     }
 
     if (targetUrl.protocol !== "https:") {
+      res.setHeader("Cache-Control", "no-store");
       res.status(400).send("Only https protocol is allowed");
       return;
     }
 
     if (!ALLOWED_HOSTNAMES.has(targetUrl.hostname)) {
+      res.setHeader("Cache-Control", "no-store");
       res.status(403).send("Host not allowed");
       return;
     }
@@ -45,6 +49,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     });
 
     if (!upstream.ok || !upstream.body) {
+      res.setHeader("Cache-Control", "no-store");
       res.status(upstream.status).send("Failed to fetch image");
       return;
     }
@@ -64,6 +69,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
     res.end();
   } catch (err) {
+    res.setHeader("Cache-Control", "no-store");
     res.status(500).send("Unexpected error");
   }
 }

--- a/pages/api/revalidate.ts
+++ b/pages/api/revalidate.ts
@@ -1,0 +1,206 @@
+import { createHash, timingSafeEqual } from "crypto";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { BASE_PATH, postPath } from "../../lib/isr";
+import { sanitizeAuthorSlug } from "../../utils/sanitizeAuthorSlug";
+
+/**
+ * On-demand ISR — the blog's primary freshness mechanism.
+ *
+ * WordPress calls this on publish/update/delete and we regenerate exactly the
+ * affected pages. That replaces time-based revalidation, which was regenerating
+ * every post every 10-60s regardless of whether anything had changed (~1.2M
+ * wasted renders and 2,224 GB-Hrs per billing period). See lib/isr.ts.
+ *
+ * Because every page now sits behind a 24h safety-net TTL, anything NOT
+ * revalidated here stays stale for up to a day. So this must cover every page
+ * type a publish can affect — post, listings, search indexes, tag and author
+ * pages — not just the post itself.
+ *
+ * Setup: set REVALIDATE_SECRET in the Vercel project, then install the
+ * companion mu-plugin on wp.keploy.io (docs/on-demand-revalidation.md).
+ */
+
+/**
+ * Each target is a full blocking page render. The default function timeout is
+ * too tight for a fan-out of ~10 against a slow WordPress, and the mu-plugin
+ * fires non-blocking so a timeout would fail silently.
+ */
+export const maxDuration = 60;
+
+const CATEGORIES = ["community", "technology"];
+
+/** Bounds the fan-out an authenticated caller can request in one POST. */
+const MAX_EXPLICIT_PATHS = 50;
+const MAX_TAGS = 20;
+
+/** How many regenerations to run at once. Keeps us inside maxDuration without
+ *  stampeding WordPress with a burst of concurrent renders. */
+const CONCURRENCY = 4;
+
+/**
+ * Constant-time secret comparison.
+ *
+ * Hashing first gives both sides a fixed 32-byte length, so timingSafeEqual
+ * never throws on a length mismatch and the comparison leaks nothing about
+ * the expected secret's length.
+ */
+function secretMatches(provided: string, expected: string): boolean {
+  const a = createHash("sha256").update(provided).digest();
+  const b = createHash("sha256").update(expected).digest();
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * Sanitize one URL path segment (slug, tag name, author name).
+ *
+ * Rejects anything that could escape its segment and returns it percent-encoded
+ * so tag names containing spaces still resolve. Returns null if unusable.
+ */
+function safeSegment(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === "." || trimmed === "..") return null;
+  if (/[\/\\]/.test(trimmed)) return null;
+  return encodeURIComponent(trimmed);
+}
+
+/** Run tasks with a bounded number in flight. */
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  task: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (cursor < items.length) {
+      const index = cursor++;
+      results[index] = await task(items[index]);
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  // Never cache this response — vercel.json also pins no-store on this route.
+  res.setHeader("Cache-Control", "no-store");
+
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const expected = process.env.REVALIDATE_SECRET;
+  if (!expected) {
+    // Fail closed: without a configured secret this endpoint would let anyone
+    // force unbounded regeneration, which is the exact cost we're removing.
+    console.error("/api/revalidate called but REVALIDATE_SECRET is not set");
+    return res.status(500).json({ error: "Revalidation is not configured" });
+  }
+
+  const provided = req.headers["x-revalidate-secret"];
+  if (typeof provided !== "string" || !secretMatches(provided, expected)) {
+    return res.status(401).json({ error: "Invalid secret" });
+  }
+
+  const {
+    slug,
+    category,
+    tags,
+    author,
+    paths: explicitPaths,
+  } = (req.body ?? {}) as {
+    slug?: string;
+    category?: string;
+    tags?: string[];
+    author?: string;
+    paths?: string[];
+  };
+
+  const targets = new Set<string>();
+
+  if (Array.isArray(explicitPaths)) {
+    for (const path of explicitPaths.slice(0, MAX_EXPLICIT_PATHS)) {
+      // Only ever revalidate our own pages — never let the caller aim this at
+      // an arbitrary URL — and never let a path climb out of the basePath.
+      if (
+        typeof path === "string" &&
+        path.startsWith(`${BASE_PATH}/`) &&
+        !path.includes("..") &&
+        !path.includes("//")
+      ) {
+        targets.add(path);
+      }
+    }
+  }
+
+  const safeSlug = safeSegment(slug);
+  if (safeSlug) {
+    if (typeof category === "string" && CATEGORIES.includes(category)) {
+      targets.add(postPath(category, safeSlug));
+    } else {
+      // Category unknown or changed — a post can move between the two, and the
+      // old URL needs regenerating so it starts serving its 301.
+      for (const c of CATEGORIES) targets.add(postPath(c, safeSlug));
+    }
+  }
+
+  if (targets.size === 0) {
+    return res.status(400).json({ error: "Provide { slug, category } or { paths }" });
+  }
+
+  // A publish changes every surface that lists or indexes the post. All of
+  // these sit behind the 24h safety net, so if they aren't refreshed here the
+  // new post simply won't be findable until tomorrow.
+  targets.add(BASE_PATH);
+  for (const c of CATEGORIES) targets.add(`${BASE_PATH}/${c}`);
+  targets.add(`${BASE_PATH}/search`);
+  targets.add(`${BASE_PATH}/community/search`);
+  targets.add(`${BASE_PATH}/tag`);
+  targets.add(`${BASE_PATH}/authors`);
+
+  // Tag pages are keyed by tag NAME (see pages/tag/[slug].tsx getStaticPaths).
+  if (Array.isArray(tags)) {
+    for (const tag of tags.slice(0, MAX_TAGS)) {
+      const safeTag = safeSegment(tag);
+      if (safeTag) targets.add(`${BASE_PATH}/tag/${safeTag}`);
+    }
+  }
+
+  // Author pages are keyed by sanitizeAuthorSlug(name), not the raw name, so
+  // sanitize with the same helper getStaticPaths uses or the path won't match.
+  if (typeof author === "string" && author.trim()) {
+    const safeAuthor = safeSegment(sanitizeAuthorSlug(author));
+    if (safeAuthor) targets.add(`${BASE_PATH}/authors/${safeAuthor}`);
+  }
+
+  // Revalidate independently so one bad path can't drop the rest. A path that
+  // legitimately 404s (e.g. the category the post is NOT in) is reported, not
+  // treated as a failure of the whole request.
+  const results = await mapWithConcurrency(
+    Array.from(targets),
+    CONCURRENCY,
+    async (path) => {
+      try {
+        await res.revalidate(path);
+        return { path, revalidated: true };
+      } catch (error: any) {
+        return { path, revalidated: false, reason: error?.message ?? String(error) };
+      }
+    }
+  );
+
+  const failed = results.filter((r) => !r.revalidated);
+  if (failed.length === results.length) {
+    console.error("/api/revalidate: every path failed", failed);
+    return res.status(500).json({ revalidated: false, results });
+  }
+  if (failed.length > 0) {
+    console.warn("/api/revalidate: some paths failed", failed);
+  }
+
+  return res.status(200).json({ revalidated: true, results });
+}

--- a/pages/api/search-all.ts
+++ b/pages/api/search-all.ts
@@ -13,9 +13,20 @@ export default async function handler(_req: NextApiRequest, res: NextApiResponse
       ...(technology?.edges || []),
     ];
 
+    // Public, identical for every visitor. Without this the search box burned a
+    // serverless invocation (two WordPress queries) every time a user opened it.
+    // Served from the edge instead, and refreshed in the background thereafter.
+    res.setHeader(
+      "Cache-Control",
+      "public, s-maxage=3600, stale-while-revalidate=86400"
+    );
     res.status(200).json({ results });
   } catch (e) {
     console.error("/api/search-all failed", e);
+    // Never cache a failure. Without this the error falls through to the
+    // blanket /blog/(.*) rule in vercel.json and a transient WordPress blip
+    // gets pinned in visitors' browsers for an hour.
+    res.setHeader("Cache-Control", "no-store");
     res.status(500).json({ error: "Failed to load posts" });
   }
 }

--- a/pages/authors/[slug].tsx
+++ b/pages/authors/[slug].tsx
@@ -12,6 +12,7 @@ import PostByAuthorMapping from "../../components/postByAuthorMapping";
 import { HOME_OG_IMAGE_URL } from "../../lib/constants";
 import { sanitizeAuthorSlug } from "../../utils/sanitizeAuthorSlug";
 import { getBreadcrumbListSchema, MAIN_SITE_URL, SITE_URL } from "../../lib/structured-data";
+import { REVALIDATE_CONTENT, REVALIDATE_ERROR, REVALIDATE_NOT_FOUND } from "../../lib/isr";
 
 export default function AuthorPage({ preview, filteredPosts, content }) {
   if (!filteredPosts || filteredPosts.length === 0) {
@@ -104,13 +105,13 @@ export const getStaticPaths: GetStaticPaths = async ({ }) => {
 
     return {
       paths,
-      fallback: true,
+      fallback: "blocking",
     };
   } catch (error) {
     console.error("authors/[slug] getStaticPaths error:", error);
     return {
       paths: [],
-      fallback: true,
+      fallback: "blocking",
     };
   }
 };
@@ -124,7 +125,7 @@ export const getStaticProps: GetStaticProps = async ({
   if (typeof slugParam !== "string" || slugParam.trim().length === 0) {
     return {
       notFound: true,
-      revalidate: 60,
+      revalidate: REVALIDATE_NOT_FOUND,
     };
   }
 
@@ -150,6 +151,13 @@ export const getStaticProps: GetStaticProps = async ({
 
   let filteredPosts = [];
 
+  // fetchAPI throws on GraphQL errors and on network failure, and every WP call
+  // below is individually caught — which makes "WordPress is down" look
+  // identical to "this author has no posts". They must not share a TTL: a
+  // genuine 404 should stick, but an outage must self-heal in a minute rather
+  // than pinning a real author page as a 404 for a day.
+  let wordpressFailed = false;
+
   for (const candidate of Array.from(candidateAuthorNames)) {
     if (!candidate) continue;
     try {
@@ -160,6 +168,7 @@ export const getStaticProps: GetStaticProps = async ({
         break;
       }
     } catch (error) {
+      wordpressFailed = true;
       console.error(`authors/[slug] failed to fetch posts for candidate "${candidate}":`, error);
     }
   }
@@ -176,6 +185,7 @@ export const getStaticProps: GetStaticProps = async ({
           return sanitizeAuthorSlug(candidateName) === sanitizeAuthorSlug(slugParam);
         }) || [];
     } catch (error) {
+      wordpressFailed = true;
       console.error("authors/[slug] fallback to getAllPosts failed:", error);
       filteredPosts = [];
     }
@@ -185,7 +195,7 @@ export const getStaticProps: GetStaticProps = async ({
   if (!filteredPosts.length) {
     return {
       notFound: true,
-      revalidate: 60,
+      revalidate: wordpressFailed ? REVALIDATE_ERROR : REVALIDATE_NOT_FOUND,
     };
   }
 
@@ -205,7 +215,7 @@ export const getStaticProps: GetStaticProps = async ({
       filteredPosts,
       content,
     },
-    revalidate: 60,
+    revalidate: REVALIDATE_CONTENT,
   };
 };
 

--- a/pages/authors/index.tsx
+++ b/pages/authors/index.tsx
@@ -7,6 +7,7 @@ import AuthorMapping from "../../components/AuthorMapping";
 import { HOME_OG_IMAGE_URL } from "../../lib/constants";
 import { Post } from "../../types/post";
 import { getBreadcrumbListSchema, SITE_URL } from "../../lib/structured-data";
+import { REVALIDATE_CONTENT } from "../../lib/isr";
 
 export default function Authors({
   AllAuthors: { edges },
@@ -52,6 +53,6 @@ export const getStaticProps: GetStaticProps = async ({ preview = false }) => {
   const AllAuthors = await getAllAuthors();
   return {
     props: { AllAuthors, preview },
-    revalidate: 10,
+    revalidate: REVALIDATE_CONTENT,
   };
 };

--- a/pages/community/[slug].tsx
+++ b/pages/community/[slug].tsx
@@ -1,7 +1,7 @@
 import { useRouter } from "next/router";
 import ErrorPage from "next/error";
 import Head from "next/head";
-import { getRedirectSlug } from "../../config/redirect";
+import { getRedirectSlug, hasRedirect } from "../../config/redirect";
 import { GetStaticPaths, GetStaticProps } from "next";
 import Container from "../../components/container";
 import MoreStories from "../../components/more-stories";
@@ -12,14 +12,15 @@ import Layout from "../../components/layout";
 import PostTitle from "../../components/post-title";
 import Tag from "../../components/tag";
 import {
-  getAllPostsForCommunity,
+  getAllSlugsForCategory,
   getMoreStoriesForSlugs,
   getPostAndMorePosts,
+  getReviewAuthors,
 } from "../../lib/api";
 import ContainerSlug from "../../components/containerSlug";
 import { useEffect, useRef } from "react";
 import { useScroll, useSpringValue } from "@react-spring/web";
-import { getReviewAuthorDetails } from "../../lib/api";
+import { REVALIDATE_CONTENT, REVALIDATE_ERROR, REVALIDATE_NOT_FOUND } from "../../lib/isr";
 import { calculateReadingTime } from "../../utils/calculateReadingTime";
 import dynamic from "next/dynamic";
 import "./styles.module.css"
@@ -286,7 +287,7 @@ export const getStaticProps: GetStaticProps = async ({
   if (typeof slug !== "string") {
     return {
       notFound: true,
-      revalidate: 60,
+      revalidate: REVALIDATE_NOT_FOUND,
     };
   }
 
@@ -306,7 +307,7 @@ export const getStaticProps: GetStaticProps = async ({
     if (!data?.post) {
       return {
         notFound: true,
-        revalidate: 60,
+        revalidate: REVALIDATE_NOT_FOUND,
       };
     }
 
@@ -319,7 +320,7 @@ export const getStaticProps: GetStaticProps = async ({
     ) || [];
     if (!postCategories.includes("community")) {
       // Post belongs to a different category — 301 redirect to preserve SEO signals.
-      // This only runs at ISR runtime (fallback: true), not during next build,
+      // This only runs at ISR runtime (fallback: "blocking"), not during next build,
       // because getStaticPaths only returns paths from the community category query.
       const correctCategory = postCategories.find((c: string) =>
         ['community', 'technology'].includes(c)
@@ -334,15 +335,14 @@ export const getStaticProps: GetStaticProps = async ({
       }
       return {
         notFound: true,
-        revalidate: 60,
+        revalidate: REVALIDATE_NOT_FOUND,
       };
     }
 
     const moreStories = await getMoreStoriesForSlugs(data.post?.tags, data.post?.slug);
-    const authorDetails = await Promise.all([
-      getReviewAuthorDetails("neha"),
-      getReviewAuthorDetails("Jain"),
-    ]);
+    // Same two records for every post — memoized in lib/api so a build makes
+    // this request twice in total instead of twice per post.
+    const authorDetails = await getReviewAuthors();
 
     return {
       props: {
@@ -351,25 +351,36 @@ export const getStaticProps: GetStaticProps = async ({
         posts: moreStories?.communityMoreStories || { edges: [] },
         reviewAuthorDetails: authorDetails,
       },
-      revalidate: 60,
+      revalidate: REVALIDATE_CONTENT,
     };
   } catch (error) {
     console.error("community/[slug] getStaticProps error:", error);
+    // WordPress failed, the post may well exist — retry soon rather than
+    // pinning a real post as a 404 for a day.
     return {
       notFound: true,
-      revalidate: 60,
+      revalidate: REVALIDATE_ERROR,
     };
   }
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const allPosts = await getAllPostsForCommunity(false);
-  const communityPosts =
-    allPosts?.edges
-      .map(({ node }) => `/community/${node?.slug}`) || [];
+  // getAllPostsForCommunity is capped at `first: 22`, so using it here left
+  // most posts un-prerendered and rendering on demand. Paginate for the full set.
+  const slugs = await getAllSlugsForCategory("community");
 
   return {
-    paths: communityPosts || [],
-    fallback: true,
+    // Slugs with a configured redirect must NOT be pre-rendered. getStaticProps
+    // returns `redirect` for them, and Next.js rejects that during prerendering
+    // ("`redirect` can not be returned from getStaticProps during prerendering").
+    // They were previously never hit at build time only because getStaticPaths
+    // was capped at 22 paths and happened to miss them. These URLs are already
+    // 301'd at the edge by vercel.json, so they never reach a function anyway.
+    paths: slugs.filter((slug) => !hasRedirect(slug)).map((slug) => `/community/${slug}`),
+    // 'blocking' rather than true: `true` served an empty skeleton with a 200
+    // for any unknown slug (soft 404 for crawlers) before resolving. 'blocking'
+    // returns the correct status on the first request. Real posts are all
+    // pre-rendered above, so this path is only hit by new posts and bad URLs.
+    fallback: "blocking",
   };
 };

--- a/pages/community/index.tsx
+++ b/pages/community/index.tsx
@@ -7,6 +7,7 @@ import Layout from "../../components/layout";
 import { getAllPostsForCommunity } from "../../lib/api";
 import Header from "../../components/header";
 import { getBreadcrumbListSchema, SITE_URL } from "../../lib/structured-data";
+import { REVALIDATE_CONTENT } from "../../lib/isr";
 
 export default function Community({ allPosts: { edges, pageInfo }, preview }) {
   const heroPost = edges[0]?.node;
@@ -70,6 +71,6 @@ export const getStaticProps: GetStaticProps = async ({ preview = false }) => {
 
   return {
     props: { allPosts, preview },
-    revalidate: 10,
+    revalidate: REVALIDATE_CONTENT,
   };
 };

--- a/pages/community/search.tsx
+++ b/pages/community/search.tsx
@@ -11,6 +11,7 @@ import { Post } from "../../types/post";
 import { HOME_OG_IMAGE_URL } from "../../lib/constants";
 import { getExcerpt } from "../../utils/excerpt"; // Importing from utils instead of inline
 import { getBreadcrumbListSchema, SITE_URL } from "../../lib/structured-data";
+import { REVALIDATE_CONTENT } from "../../lib/isr";
 
 export default function CommunitySearch({ allPosts }: { allPosts: { node: Post }[] }) {
   const router = useRouter();
@@ -112,6 +113,6 @@ export const getStaticProps = async () => {
   const allPosts = await getAllPostsForSearch(false);
   return {
     props: { allPosts },
-    revalidate: 60,
+    revalidate: REVALIDATE_CONTENT,
   };
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,6 +15,7 @@ import {
   getWebSiteSchema,
   SITE_URL,
 } from "../lib/structured-data";
+import { REVALIDATE_CONTENT } from "../lib/isr";
 // Canonical /blog title. Shared by Layout's `Title` prop (which Meta.tsx
 // turns into og:title / twitter:title) and the <Head><title>, so the
 // document title and social metadata can't drift apart.
@@ -109,6 +110,6 @@ export const getStaticProps: GetStaticProps = async ({ preview = false }) => {
           : allTehcnologyPosts.edges,
       preview,
     },
-    revalidate: 10,
+    revalidate: REVALIDATE_CONTENT,
   };
 };

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -7,6 +7,7 @@ import { getAllPostsForSearch } from "../lib/api"; // This now exists
 import { Post } from "../types/post";
 import { HOME_OG_IMAGE_URL } from "../lib/constants";
 import { getBreadcrumbListSchema, SITE_URL } from "../lib/structured-data";
+import { REVALIDATE_CONTENT } from "../lib/isr";
 
 export default function SearchPage({ allPosts }: { allPosts: { node: Post }[] }) {
   const router = useRouter();
@@ -57,6 +58,6 @@ export const getStaticProps = async () => {
   
   return {
     props: { allPosts },
-    revalidate: 60,
+    revalidate: REVALIDATE_CONTENT,
   };
 };

--- a/pages/tag/[slug].tsx
+++ b/pages/tag/[slug].tsx
@@ -8,6 +8,7 @@ import { getAllPostsFromTags, getAllTags } from "../../lib/api";
 import TagsStories from "../../components/TagsStories";
 import { useRouter } from "next/router";
 import { getBreadcrumbListSchema, SITE_URL } from "../../lib/structured-data";
+import { REVALIDATE_CONTENT, REVALIDATE_ERROR, REVALIDATE_NOT_FOUND } from "../../lib/isr";
 export default function PostByTags({ postsByTags, preview, tagSlug: tagSlugProp }) {
   const posts = postsByTags?.edges || [];
   const router = useRouter();
@@ -44,7 +45,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
   const paths = edgesAllTags.map((node) => `/tag/${node.name}`) || []; // Extract tag names from the nodes and create paths
   return {
     paths: paths,
-    fallback: true,
+    fallback: "blocking",
   };
 };
 
@@ -57,7 +58,7 @@ export const getStaticProps: GetStaticProps = async ({
   if (!paramSlug) {
     return {
       notFound: true,
-      revalidate: 60,
+      revalidate: REVALIDATE_NOT_FOUND,
     };
   }
 
@@ -69,13 +70,13 @@ export const getStaticProps: GetStaticProps = async ({
 
     return {
       props: { postsByTags: postsByTags || { edges: [] }, preview, tagSlug: slug },
-      revalidate: 10,
+      revalidate: REVALIDATE_CONTENT,
     };
   } catch (error) {
     console.error("tag/[slug] getStaticProps error:", error);
     return {
       notFound: true,
-      revalidate: 60,
+      revalidate: REVALIDATE_ERROR,
     };
   }
 };

--- a/pages/tag/index.tsx
+++ b/pages/tag/index.tsx
@@ -11,6 +11,7 @@ import { FaSearch } from 'react-icons/fa';
 import { useEffect, useRef } from "react";
 import { getIconComponentForTag } from "../../utils/tagIcons";
 import { getBreadcrumbListSchema, SITE_URL } from "../../lib/structured-data";
+import { REVALIDATE_CONTENT } from "../../lib/isr";
  
  export default function Tags({ edgesAllTags, preview }) {
    const [searchTerm, setSearchTerm] = useState("");
@@ -163,6 +164,6 @@ export const getStaticProps: GetStaticProps = async ({ preview = false }) => {
   const edgesAllTags = await getAllTags();
   return {
     props: { edgesAllTags, preview },
-    revalidate: 10,
+    revalidate: REVALIDATE_CONTENT,
   };
 };

--- a/pages/technology/[slug].tsx
+++ b/pages/technology/[slug].tsx
@@ -10,17 +10,18 @@ import Layout from "../../components/layout";
 import PostTitle from "../../components/post-title";
 import Tags from "../../components/tag";
 import {
-  getAllPostsForTechnology,
+  getAllSlugsForCategory,
   getMoreStoriesForSlugs,
   getPostAndMorePosts,
+  getReviewAuthors,
 } from "../../lib/api";
 import ContainerSlug from "../../components/containerSlug";
 import { useRef, useEffect } from "react";
 import { useScroll, useSpringValue } from "@react-spring/web";
-import { getReviewAuthorDetails } from "../../lib/api";
+import { REVALIDATE_CONTENT, REVALIDATE_ERROR, REVALIDATE_NOT_FOUND } from "../../lib/isr";
 import { calculateReadingTime } from "../../utils/calculateReadingTime";
 import dynamic from "next/dynamic";
-import { getRedirectSlug } from "../../config/redirect";
+import { getRedirectSlug, hasRedirect } from "../../config/redirect";
 import {
   getBlogPostingSchema,
   getBreadcrumbListSchema,
@@ -262,7 +263,7 @@ export const getStaticProps: GetStaticProps = async ({
   if (typeof slugParam !== "string") {
     return {
       notFound: true,
-      revalidate: 60,
+      revalidate: REVALIDATE_NOT_FOUND,
     };
   }
 
@@ -279,7 +280,7 @@ export const getStaticProps: GetStaticProps = async ({
     if (!data?.post) {
       return {
         notFound: true,
-        revalidate: 60,
+        revalidate: REVALIDATE_NOT_FOUND,
       };
     }
 
@@ -292,7 +293,7 @@ export const getStaticProps: GetStaticProps = async ({
     ) || [];
     if (!postCategories.includes("technology")) {
       // Post belongs to a different category — 301 redirect to preserve SEO signals.
-      // This only runs at ISR runtime (fallback: true), not during next build,
+      // This only runs at ISR runtime (fallback: "blocking"), not during next build,
       // because getStaticPaths only returns paths from the technology category query.
       const correctCategory = postCategories.find((c: string) =>
         ['community', 'technology'].includes(c)
@@ -307,15 +308,14 @@ export const getStaticProps: GetStaticProps = async ({
       }
       return {
         notFound: true,
-        revalidate: 60,
+        revalidate: REVALIDATE_NOT_FOUND,
       };
     }
 
     const moreStories = await getMoreStoriesForSlugs(data.post?.tags, data.post?.slug);
-    const authorDetails = await Promise.all([
-      getReviewAuthorDetails("neha"),
-      getReviewAuthorDetails("Jain"),
-    ]);
+    // Same two records for every post — memoized in lib/api so a build makes
+    // this request twice in total instead of twice per post.
+    const authorDetails = await getReviewAuthors();
 
     // If we resolved a redirect slug, send a proper 301 redirect response
     if (redirectSlug) {
@@ -334,24 +334,36 @@ export const getStaticProps: GetStaticProps = async ({
         posts: moreStories?.techMoreStories || { edges: [] },
         reviewAuthorDetails: authorDetails,
       },
-      revalidate: 10,
+      revalidate: REVALIDATE_CONTENT,
     };
   } catch (error) {
     console.error("technology/[slug] getStaticProps error:", error);
+    // WordPress failed, the post may well exist — retry soon rather than
+    // pinning a real post as a 404 for a day.
     return {
       notFound: true,
-      revalidate: 60,
+      revalidate: REVALIDATE_ERROR,
     };
   }
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const allPosts = await getAllPostsForTechnology(false);
-  const technologyPosts =
-    allPosts?.edges
-      ?.map(({ node }) => `/technology/${node?.slug}`) || [];
+  // getAllPostsForTechnology is capped at `first: 22`, so using it here left
+  // most posts un-prerendered and rendering on demand. Paginate for the full set.
+  const slugs = await getAllSlugsForCategory("technology");
+
   return {
-    paths: technologyPosts || [],
-    fallback: true,
+    // Slugs with a configured redirect must NOT be pre-rendered. getStaticProps
+    // returns `redirect` for them, and Next.js rejects that during prerendering
+    // ("`redirect` can not be returned from getStaticProps during prerendering").
+    // They were previously never hit at build time only because getStaticPaths
+    // was capped at 22 paths and happened to miss them. These URLs are already
+    // 301'd at the edge by vercel.json, so they never reach a function anyway.
+    paths: slugs.filter((slug) => !hasRedirect(slug)).map((slug) => `/technology/${slug}`),
+    // 'blocking' rather than true: `true` served an empty skeleton with a 200
+    // for any unknown slug (soft 404 for crawlers) before resolving. 'blocking'
+    // returns the correct status on the first request. Real posts are all
+    // pre-rendered above, so this path is only hit by new posts and bad URLs.
+    fallback: "blocking",
   };
 };

--- a/pages/technology/index.tsx
+++ b/pages/technology/index.tsx
@@ -8,6 +8,7 @@ import { getAllPostsForTechnology } from "../../lib/api";
 import Header from "../../components/header";
 import { getExcerpt } from "../../utils/excerpt";
 import { getBreadcrumbListSchema, SITE_URL } from "../../lib/structured-data";
+import { REVALIDATE_CONTENT, REVALIDATE_ERROR } from "../../lib/isr";
 
 export default function Index({ allPosts: { edges, pageInfo }, preview }) {
   console.log("tech posts: ", edges.length)
@@ -63,13 +64,13 @@ export const getStaticProps: GetStaticProps = async ({ preview = false }) => {
 
     return {
       props: { allPosts: allPosts ?? emptyData, preview },
-      revalidate: 10,
+      revalidate: REVALIDATE_CONTENT,
     };
   } catch (error) {
     console.error("technology/index getStaticProps error:", error);
     return {
       props: { allPosts: emptyData, preview },
-      revalidate: 60,
+      revalidate: REVALIDATE_ERROR,
     };
   }
 };

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,6 +26,14 @@ const GRAPHQL_API_URL = process.env.PLAYWRIGHT_GRAPHQL_URL || 'http://localhost:
 export default defineConfig({
   testDir: './tests',
 
+  // tests/lib/** are node:test unit tests, run by `npm run test:unit` — not
+  // Playwright specs. Playwright's default testMatch is
+  // `**/*.@(spec|test).?(c|m)[jt]s?(x)`, which matches *.test.ts, so without
+  // this Playwright imports them during collection. Importing a node:test file
+  // outside node's own runner EXECUTES it, leaking its console output and
+  // process.env mutations into the e2e run.
+  testIgnore: '**/lib/**',
+
   /* Output directory for test artifacts */
   outputDir: 'test-results',
 

--- a/tests/lib/isr.test.ts
+++ b/tests/lib/isr.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for the ISR revalidation policy (lib/isr.ts).
+ *
+ * Run via: `npm run test:unit`
+ *
+ * These pin two things that fail *silently* in production if they drift:
+ *
+ *   1. BASE_PATH vs next.config.js. `res.revalidate(path)` does not look up a
+ *      route — on Vercel it performs a real `fetch('https://' + host + path)`.
+ *      If BASE_PATH stops matching the app's basePath, every webhook-driven
+ *      revalidation 404s, nothing regenerates, and the only symptom is content
+ *      going stale up to 24h later. Nothing else in the build catches this.
+ *
+ *   2. The TTL ordering. The whole point of the on-demand setup is that
+ *      content and not-found TTLs stay large; someone "fixing" perceived
+ *      staleness by dropping them back to 10/60s would quietly restore the
+ *      ~2,224 GB-Hrs/period regeneration bill.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import {
+  BASE_PATH,
+  postPath,
+  REVALIDATE_CONTENT,
+  REVALIDATE_ERROR,
+  REVALIDATE_NOT_FOUND,
+} from "../../lib/isr";
+
+// Read next.config.js as text rather than importing it: the config throws at
+// module load unless WORDPRESS_API_URL is set, which we don't want to require
+// just to assert a constant.
+function basePathFromNextConfig(): string {
+  const configPath = path.join(process.cwd(), "next.config.js");
+  const source = readFileSync(configPath, "utf8");
+  const match = source.match(/^\s*basePath:\s*['"]([^'"]+)['"]/m);
+  assert.ok(match, "could not find `basePath` in next.config.js");
+  return match![1];
+}
+
+test("BASE_PATH matches basePath in next.config.js", () => {
+  assert.equal(
+    BASE_PATH,
+    basePathFromNextConfig(),
+    "lib/isr.ts BASE_PATH has drifted from next.config.js — on-demand " +
+      "revalidation would silently 404 on every path"
+  );
+});
+
+test("postPath builds a public URL path including the basePath", () => {
+  assert.equal(postPath("community", "my-post"), `${BASE_PATH}/community/my-post`);
+  assert.equal(postPath("technology", "my-post"), `${BASE_PATH}/technology/my-post`);
+});
+
+test("postPath output is absolute — res.revalidate rejects relative paths", () => {
+  // Next throws "Invalid urlPath provided to revalidate()" for anything not
+  // starting with "/".
+  assert.ok(postPath("community", "x").startsWith("/"));
+});
+
+test("content and not-found TTLs stay long enough to keep regeneration off the hot path", () => {
+  const ONE_HOUR = 3600;
+
+  assert.ok(
+    REVALIDATE_CONTENT >= ONE_HOUR,
+    `REVALIDATE_CONTENT is ${REVALIDATE_CONTENT}s. Freshness comes from the ` +
+      `WordPress webhook, not from polling — see docs/on-demand-revalidation.md`
+  );
+
+  assert.ok(
+    REVALIDATE_NOT_FOUND >= ONE_HOUR,
+    `REVALIDATE_NOT_FOUND is ${REVALIDATE_NOT_FOUND}s. A short TTL lets ` +
+      `bot-sprayed URLs re-render on every expiry — unbounded function duration`
+  );
+});
+
+test("error TTL stays short so a WordPress blip self-heals", () => {
+  assert.ok(
+    REVALIDATE_ERROR <= 300,
+    `REVALIDATE_ERROR is ${REVALIDATE_ERROR}s — too long. A transient WP ` +
+      `failure would pin a real post as a 404 for that whole window.`
+  );
+  assert.ok(
+    REVALIDATE_ERROR < REVALIDATE_NOT_FOUND,
+    "degraded responses must retry sooner than genuine 404s"
+  );
+});

--- a/tests/lib/revalidate.test.ts
+++ b/tests/lib/revalidate.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Unit tests for the on-demand revalidation endpoint (pages/api/revalidate.ts).
+ *
+ * Run via: `npm run test:unit`
+ *
+ * This endpoint is the blog's entire freshness mechanism now that every page
+ * sits behind a 24h safety-net TTL, and it is reachable from the public
+ * internet. Two classes of regression matter:
+ *
+ *   1. Auth / input handling. It can force unbounded page regeneration, so a
+ *      bypass is both a correctness and a cost problem.
+ *   2. Target coverage. If a page type stops being revalidated here, nothing
+ *      fails loudly — the page just silently serves stale content for up to a
+ *      day. That is precisely the bug this file is meant to catch.
+ */
+
+import { test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import handler from "../../pages/api/revalidate";
+import { BASE_PATH } from "../../lib/isr";
+
+const SECRET = "unit-test-secret";
+
+function mockRes() {
+  const revalidated: string[] = [];
+  const failFor = new Set<string>();
+  const res: any = {
+    statusCode: 0,
+    headers: {} as Record<string, string>,
+    body: undefined as any,
+    revalidated,
+    failFor,
+    setHeader(key: string, value: string) {
+      res.headers[key.toLowerCase()] = value;
+    },
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    json(payload: any) {
+      res.body = payload;
+      return res;
+    },
+    async revalidate(path: string) {
+      if (failFor.has(path)) throw new Error(`Failed to revalidate ${path}`);
+      revalidated.push(path);
+    },
+  };
+  return res;
+}
+
+function mockReq(overrides: any = {}) {
+  return {
+    method: "POST",
+    headers: { "x-revalidate-secret": SECRET },
+    body: {},
+    ...overrides,
+  } as any;
+}
+
+let originalSecret: string | undefined;
+
+beforeEach(() => {
+  originalSecret = process.env.REVALIDATE_SECRET;
+  process.env.REVALIDATE_SECRET = SECRET;
+});
+
+afterEach(() => {
+  if (originalSecret === undefined) delete process.env.REVALIDATE_SECRET;
+  else process.env.REVALIDATE_SECRET = originalSecret;
+});
+
+test("rejects non-POST", async () => {
+  const res = mockRes();
+  await handler(mockReq({ method: "GET" }), res);
+  assert.equal(res.statusCode, 405);
+  assert.equal(res.revalidated.length, 0);
+});
+
+test("fails closed when REVALIDATE_SECRET is unset", async () => {
+  delete process.env.REVALIDATE_SECRET;
+  const res = mockRes();
+  await handler(mockReq({ body: { slug: "a", category: "community" } }), res);
+  assert.equal(res.statusCode, 500);
+  assert.equal(res.revalidated.length, 0);
+});
+
+test("rejects a missing or wrong secret", async () => {
+  for (const headers of [{}, { "x-revalidate-secret": "nope" }, { "x-revalidate-secret": "" }]) {
+    const res = mockRes();
+    await handler(mockReq({ headers, body: { slug: "a", category: "community" } }), res);
+    assert.equal(res.statusCode, 401, `expected 401 for ${JSON.stringify(headers)}`);
+    assert.equal(res.revalidated.length, 0);
+  }
+});
+
+test("secret comparison tolerates a length mismatch instead of throwing", async () => {
+  // timingSafeEqual throws on unequal buffer lengths; the handler hashes first.
+  const res = mockRes();
+  await handler(
+    mockReq({ headers: { "x-revalidate-secret": "x" }, body: { slug: "a" } }),
+    res
+  );
+  assert.equal(res.statusCode, 401);
+});
+
+test("requires slug or paths", async () => {
+  const res = mockRes();
+  await handler(mockReq({ body: {} }), res);
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.revalidated.length, 0);
+});
+
+test("revalidates the post plus every surface that lists it", async () => {
+  const res = mockRes();
+  await handler(
+    mockReq({
+      body: {
+        slug: "my-post",
+        category: "community",
+        tags: ["API Testing"],
+        author: "neha",
+      },
+    }),
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.revalidated, true);
+
+  // A publish that isn't reflected on these pages is invisible for up to 24h.
+  for (const expected of [
+    `${BASE_PATH}/community/my-post`,
+    BASE_PATH,
+    `${BASE_PATH}/community`,
+    `${BASE_PATH}/technology`,
+    `${BASE_PATH}/search`,
+    `${BASE_PATH}/community/search`,
+    `${BASE_PATH}/tag`,
+    `${BASE_PATH}/authors`,
+    `${BASE_PATH}/tag/API%20Testing`,
+    `${BASE_PATH}/authors/neha`,
+  ]) {
+    assert.ok(
+      res.revalidated.includes(expected),
+      `expected ${expected} to be revalidated, got ${JSON.stringify(res.revalidated)}`
+    );
+  }
+});
+
+test("revalidates both category URLs when the category is unknown", async () => {
+  const res = mockRes();
+  await handler(mockReq({ body: { slug: "moved-post" } }), res);
+  assert.ok(res.revalidated.includes(`${BASE_PATH}/community/moved-post`));
+  assert.ok(res.revalidated.includes(`${BASE_PATH}/technology/moved-post`));
+});
+
+test("ignores an unrecognised category rather than trusting it", async () => {
+  const res = mockRes();
+  await handler(mockReq({ body: { slug: "p", category: "../../etc" } }), res);
+  assert.ok(!res.revalidated.some((p: string) => p.includes("etc")));
+  assert.ok(res.revalidated.includes(`${BASE_PATH}/community/p`));
+});
+
+test("rejects slugs and segments that could escape their path segment", async () => {
+  for (const slug of ["..", ".", "a/b", "a\\b", "", "   "]) {
+    const res = mockRes();
+    await handler(mockReq({ body: { slug } }), res);
+    assert.equal(res.statusCode, 400, `slug ${JSON.stringify(slug)} should be rejected`);
+  }
+});
+
+test("explicit paths are confined to the basePath", async () => {
+  const res = mockRes();
+  await handler(
+    mockReq({
+      body: {
+        paths: [
+          `${BASE_PATH}/community/ok`, // allowed
+          "/community/no-basepath", // outside basePath
+          "https://evil.example.com/x", // absolute URL
+          "//evil.example.com/x", // protocol-relative
+          `${BASE_PATH}/../../etc/passwd`, // traversal
+          `${BASE_PATH}//evil`, // double slash
+          "/etc/passwd",
+        ],
+      },
+    }),
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.ok(res.revalidated.includes(`${BASE_PATH}/community/ok`));
+  for (const bad of ["evil.example.com", "etc/passwd", "no-basepath"]) {
+    assert.ok(
+      !res.revalidated.some((p: string) => p.includes(bad)),
+      `${bad} must never be revalidated`
+    );
+  }
+});
+
+test("caps the fan-out an authenticated caller can request", async () => {
+  const res = mockRes();
+  const paths = Array.from({ length: 500 }, (_, i) => `${BASE_PATH}/community/post-${i}`);
+  await handler(mockReq({ body: { paths } }), res);
+
+  // 50 explicit + the fixed listing/search/index targets — nowhere near 500.
+  assert.ok(
+    res.revalidated.length < 100,
+    `expected the fan-out to be capped, got ${res.revalidated.length}`
+  );
+});
+
+test("one failing path does not abort the rest", async () => {
+  const res = mockRes();
+  res.failFor.add(`${BASE_PATH}/technology`);
+  await handler(mockReq({ body: { slug: "p", category: "community" } }), res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.revalidated, true);
+  assert.ok(res.revalidated.includes(`${BASE_PATH}/community/p`));
+  assert.ok(
+    res.body.results.some((r: any) => r.path === `${BASE_PATH}/technology` && !r.revalidated)
+  );
+});
+
+test("reports 500 only when every path fails", async () => {
+  const res = mockRes();
+  const failAll = { ...res, async revalidate(p: string) { throw new Error(`boom ${p}`); } };
+  failAll.setHeader = res.setHeader;
+  failAll.status = (c: number) => { failAll.statusCode = c; return failAll; };
+  failAll.json = (b: any) => { failAll.body = b; return failAll; };
+
+  await handler(mockReq({ body: { slug: "p", category: "community" } }), failAll as any);
+  assert.equal(failAll.statusCode, 500);
+  assert.equal(failAll.body.revalidated, false);
+});
+
+test("never allows its own response to be cached", async () => {
+  const res = mockRes();
+  await handler(mockReq({ body: { slug: "p", category: "community" } }), res);
+  assert.equal(res.headers["cache-control"], "no-store");
+});

--- a/tests/mock-server.js
+++ b/tests/mock-server.js
@@ -202,6 +202,15 @@ function handleGraphQL(body) {
         return reviewAuthorResponse;
     }
 
+    // getAllSlugsForCategory (lib/api.ts) — powers getStaticPaths on the post
+    // pages, so without this branch the e2e build pre-renders zero posts and
+    // silently falls back to on-demand rendering instead of exercising the
+    // real path. Selects on the variable; the literal-category branches below
+    // don't match because this query passes categoryName as $categoryName.
+    if (query.includes('AllSlugsForCategory')) {
+        return variables.categoryName === 'community' ? communityPosts : technologyPosts;
+    }
+
     if (query.includes('AllPostsForCategory')) {
         if (variables.categoryName === 'community' || query.includes('categoryName: "community"')) {
             return communityPosts;

--- a/vercel.json
+++ b/vercel.json
@@ -28,7 +28,7 @@
   ],
   "headers": [
     {
-      "source": "/blog/api/(.*)",
+      "source": "/blog/api/(preview|exit-preview|revalidate)",
       "headers": [
         {
           "key": "Cache-Control",


### PR DESCRIPTION
## Problem

Vercel function duration was **2,224 GB-Hrs** per billing period.

Every page in this app is already statically generated — there is no `getServerSideProps` anywhere — so none of that came from serving requests. It was **ISR revalidation churn**, caught live in production:

```
x-vercel-cache: STALE  age: 25    ← stale served, background regeneration fired
x-vercel-cache: STALE  age: 27
x-vercel-cache: HIT    age: 2     ← fresh, cycle restarts
```

Technology posts carried `revalidate: 10`, community posts `revalidate: 60`. Each expiry fires a full serverless invocation. Measured cost of one post render against live WordPress:

| Query | Time |
| --- | ---: |
| `getPostAndMorePosts` | 1488 ms |
| `getMoreStoriesForSlugs` | 1083 ms |
| `getReviewAuthorDetails("neha")` | 383 ms |
| `getReviewAuthorDetails("Jain")` | 889 ms |
| **total** | **~3.5 s** |

~520 posts × continuous regeneration ≈ 1.2M renders/period, re-fetching content that changes a few times a week.

## Fix

Freshness moves from a **timer** to **events**. WordPress calls `/api/revalidate` when content actually changes and only the affected pages regenerate. The TTLs in `lib/isr.ts` are a 24h safety net, not the mechanism.

This also makes the blog **fresher**, not staler: today an edit takes up to 60s to appear and some visitor always eats a stale page. With the webhook it's seconds and nobody sees stale content.

**Expected: ~2,224 → ~20-40 GB-Hrs/month.**

## Also fixed (all surfaced while making the above safe)

- **`getStaticPaths` pre-rendered 44 of 522 posts.** `getAllPostsFor{Category}` is hardcoded `first: 22` and fed `getStaticPaths` directly — technology has 37 posts, community has **485**. So ~478 posts rendered on demand and then churned forever. Added a paginated slug-only query.
- **`fallback: true` → `"blocking"`.** `true` served an empty skeleton with a **200** for any unknown slug — a soft 404 for crawlers. Now returns the correct status on the first request.
- **Genuine 404s vs WordPress failures no longer share a TTL.** A missing slug sticks for 24h (bot-sprayed URLs previously re-rendered every 60s — an amplification vector). A WP outage retries in 60s rather than pinning a real post as a 404 for a day.
- **Category-mismatch `redirect` could hard-fail `next build`.** Returning `redirect` from `getStaticProps` is illegal during prerendering; it was unreachable before only because `getStaticPaths` returned 22 slugs. `getStaticPaths` now filters on the *same* criterion the page checks, so it's unreachable by construction.
- **Redundant queries memoized.** The two reviewing-author records are identical on every post (1.27s of the 3.5s); "more stories" is shared across posts with the same tags. Short TTL so a warm lambda can't serve indefinitely stale data.
- **`vercel.json` forced `no-store` on all of `/blog/api/(.*)`**, so `search-all` and `nav-latest` could never cache and cost an invocation per call. Narrowed to the stateful routes; error paths now opt out of caching explicitly so a transient 500 can't get cached for an hour.
- **`getRedirectSlug`/`hasRedirect` walked the prototype chain** — a post slugged `toString` would get a *function* as its redirect target.
- **Playwright was executing the `node:test` unit files.** Its default `testMatch` includes `*.test.ts`, and importing a `node:test` file outside node's runner runs it. Excluded `tests/lib/**`.

## Verification

- **Build green**: 230s, **0 prerender errors**, **521 posts pre-rendered** (was 44), all routes `ISR: 86400`, redirect slugs correctly excluded.
- **Unit tests**: 34 pass, including new coverage for the endpoint's auth, path allowlist (traversal / protocol-relative / absolute URLs), fan-out cap, and partial-failure handling.
- **E2E**: 229 pass. One failure (`LeadCapture` fail-open) **reproduces identically on a clean `main`** under 4 local workers — pre-existing and unrelated. CI runs `workers: 1` with `retries: 1`, so it's unlikely to surface there.
- **Runtime** (against `next start`): `/api/revalidate` returns `revalidated: true` for every path; 401 on bad secret, 405 on GET, 400 on empty body; allowlist rejects `/community/foo`, `https://evil.example.com/x`, `/etc/passwd`; bogus slug 404s on the **first** hit; pre-rendered post serves in **2.8ms** with no WordPress call.

## Required before this delivers the full win

1. Set `REVALIDATE_SECRET` in the Vercel project (`openssl rand -hex 32`). The endpoint **fails closed** without it.
2. Install the mu-plugin from `docs/on-demand-revalidation.md` on `wp.keploy.io`.

Without step 2 the code change alone still removes ~99% of the cost, but a published post won't appear until the 24h safety net fires.

## One thing to check on the preview deploy

`res.revalidate()` on Vercel does a real `fetch('https://' + host + urlPath)`, so paths **must** include the `/blog` basePath — a missing basePath silently 404s and revalidates nothing. That's pinned by `tests/lib/isr.test.ts` (verified to actually fail when drifted).

What I could **not** determine from the repo or locally is which value wins when a `vercel.json` header rule and a handler's `res.setHeader` set the same key, since `vercel.json` headers are applied by the platform. Please confirm on the preview URL before merge:

```bash
curl -sI https://<preview>.vercel.app/blog/api/search-all | grep -i cache-control
# want: public, s-maxage=3600, stale-while-revalidate=86400
```

If the blanket `/blog/(.*)` rule wins instead, add an explicit `/blog/api/(search-all|nav-latest|proxy-image)` entry to `vercel.json`.