### PR TITLE
fix: remove outdated fallback for VS Code install count

### DIFF
--- a/hooks/useVSCodeInstalls.tsx
+++ b/hooks/useVSCodeInstalls.tsx
@@ -1,6 +1,7 @@
+// Corrected by Zidaan 
 import { useEffect, useState } from "react";
 
-export function useVSCodeInstalls(initialInstalls = "540K") {
+export function useVSCodeInstalls(initialInstalls = "") {
   const [installs, setInstalls] = useState(initialInstalls);
 
   useEffect(() => {
@@ -18,7 +19,7 @@ export function useVSCodeInstalls(initialInstalls = "540K") {
               criteria: [
                 {
                   filterType: 7,
-                  value: "Keploy.keployio", // Replace with actual extension ID
+                  value: "Keploy.keployio",
                 },
               ],
             },
@@ -34,11 +35,12 @@ export function useVSCodeInstalls(initialInstalls = "540K") {
             (stat: { statisticName: string }) =>
               stat.statisticName === "install"
           )?.value || 0;
-        const formattedCount = formatInstallCount(count);
-        setInstalls(formattedCount);
+
+        setInstalls(formatInstallCount(count));
       })
       .catch(() => {});
   }, []);
+
   return installs;
 }
 
@@ -49,13 +51,16 @@ function formatInstallCount(count: number): string {
       ? `${(Math.round(millions * 10) / 10).toString().replace(/\.0$/, "")}M`
       : `${Math.round(millions)}M`;
   }
+
   if (count >= 100_000) {
-    return `${Math.round(count / 1_000)}K`;
+    return `${Math.round(count / 1000)}K`;
   }
+
   if (count >= 1_000) {
-    return `${(Math.round((count / 1_000) * 10) / 10)
+    return `${(Math.round((count / 1000) * 10) / 10)
       .toString()
       .replace(/\.0$/, "")}K`;
   }
+
   return count.toString();
 }


### PR DESCRIPTION
Removed the hardcoded "540K" fallback value from useVSCodeInstalls to prevent displaying an outdated install count before the latest value is fetched from the Visual Studio Marketplace.

## Related Tickets & Documents

Fixes: #4308

## Description

This PR fixes the issue where the mobile navigation briefly displays an outdated VS Code install count (`540K`) before updating to the latest value.

### Changes

- Removed the hardcoded `540K` fallback value.
- Used an empty initial state to avoid displaying outdated install counts before the latest value is fetched.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- Verified that the outdated `540K` value is no longer shown before the latest install count is loaded.

## Demo

- N/A

## Environment and Dependencies

- **New Dependencies:** None
- **Configuration Changes:** None

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added corresponding tests
- [ ] I have run the build command to ensure there are no build errors
- [x] My changes have been tested across relevant browsers/devices
- [ ] For UI changes, I've included visual evidence of my changes