### PR TITLE
feat(ui): add skeleton loaders for blog posts during loading state

### DIFF
--- a/components/SkeletonCard.tsx
+++ b/components/SkeletonCard.tsx
@@ -1,0 +1,21 @@
+export default function SkeletonCard() {
+  return (
+    <div className="animate-pulse border border-gray-200 dark:border-gray-800 rounded-xl p-5 space-y-4 bg-gray-100 dark:bg-gray-800/50 w-full">
+      {/* Blog Thumbnail / Title Placeholder */}
+      <div className="h-6 bg-gray-300 dark:bg-gray-700 rounded-md w-3/4"></div>
+      
+      {/* Author & Date Placeholder */}
+      <div className="flex items-center space-x-2">
+        <div className="h-4 bg-gray-300 dark:bg-gray-700 rounded-full w-24"></div>
+        <div className="h-2 bg-gray-300 dark:bg-gray-700 rounded-full w-2"></div>
+        <div className="h-4 bg-gray-300 dark:bg-gray-700 rounded-full w-20"></div>
+      </div>
+
+      {/* Description Lines Placeholder */}
+      <div className="space-y-2">
+        <div className="h-3 bg-gray-300 dark:bg-gray-700 rounded w-full"></div>
+        <div className="h-3 bg-gray-300 dark:bg-gray-700 rounded w-5/6"></div>
+      </div>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -276,6 +276,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.34.1.tgz",
       "integrity": "sha512-t1zK/l9UiRqwUNPm+pdIT0qzJlzuVckbTEMVNFhfWkGiBQClstzg+78vedCvLSX0xJEZ6lwZbPpnljL7L6iwMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.4.0",
         "style-mod": "^4.1.0",
@@ -1919,6 +1920,7 @@
       "version": "18.2.36",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.36.tgz",
       "integrity": "sha512-o9XFsHYLLZ4+sb9CWUYwHqFVoG61SesydF353vFMMsQziiyRu8np4n2OYMUSDZ8XuImxDr9c5tR7gidlH29Vnw==",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -1929,6 +1931,7 @@
       "version": "18.2.14",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.14.tgz",
       "integrity": "sha512-V835xgdSVmyQmI1KLV2BEIUgqEuinxp9O4G6g3FqO/SqLac049E53aysv0oEFD2kHfejeKU+ZqL2bcFWj9gLAQ==",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -1987,6 +1990,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2258,6 +2262,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2646,6 +2651,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001541",
         "electron-to-chromium": "^1.4.535",
@@ -3296,6 +3302,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
       "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3448,6 +3455,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
       "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.7",
         "array.prototype.findlastindex": "^1.2.3",
@@ -5479,6 +5487,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -5658,6 +5667,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5669,6 +5679,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -6366,6 +6377,7 @@
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.5.tgz",
       "integrity": "sha512-5SEZU4J7pxZgSkv7FP1zY8i2TIAOooNZ1e/OGtxIEv6GltpoiXUqWvLy89+a10qYTB1N5Ifkuw9lqQkN9sscvA==",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -6629,6 +6641,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,7 @@
+import SkeletonCard from '../components/SkeletonCard';
 import Head from "next/head";
 import { GetStaticProps } from "next";
+import { useRouter } from "next/router";
 import Container from "../components/container";
 import Layout from "../components/layout";
 import { getAllPostsForCommunity, getAllPostsForTechnology } from "../lib/api";
@@ -16,21 +18,19 @@ import {
   SITE_URL,
 } from "../lib/structured-data";
 import { REVALIDATE_CONTENT } from "../lib/isr";
-// Canonical /blog title. Shared by Layout's `Title` prop (which Meta.tsx
-// turns into og:title / twitter:title) and the <Head><title>, so the
-// document title and social metadata can't drift apart.
+
 const BLOG_TITLE =
   "Keploy Blog — API Testing, Test Automation & eBPF Deep-Dives";
 
 export default function Index({ communityPosts, technologyPosts, preview }) {
-  // Organization schema is in _document.tsx (global) — not duplicated here
+  const router = useRouter();
+
   const structuredData = [
     getWebSiteSchema(),
     getBreadcrumbListSchema([{ name: "Home", url: SITE_URL }]),
   ];
 
   return (
-
     <Layout
       preview={preview}
       featuredImage={HOME_OG_IMAGE_URL}
@@ -41,10 +41,6 @@ export default function Index({ communityPosts, technologyPosts, preview }) {
       ogType="website"
     >
       <Head>
-        {/* Meta.tsx renders og:title / twitter:title from Layout's `Title`
-            prop but does NOT emit a <title> tag (see LIVE-11 note in
-            authors/[slug].tsx). Without this <Head><title>, /blog ships
-            with no document title — same regression that hit author pages. */}
         <title>{BLOG_TITLE}</title>
       </Head>
       <Header />
@@ -84,10 +80,21 @@ export default function Index({ communityPosts, technologyPosts, preview }) {
             </div>
           </div>
         </div>
-        <TopBlogs
-          communityPosts={communityPosts}
-          technologyPosts={technologyPosts}
-        />
+
+        {/* Loading State Check: Router fallback ya posts empty hone par Skeleton Loader render hoga */}
+        {router.isFallback || (!communityPosts && !technologyPosts) ? (
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 my-10">
+            <SkeletonCard />
+            <SkeletonCard />
+            <SkeletonCard />
+          </div>
+        ) : (
+          <TopBlogs
+            communityPosts={communityPosts}
+            technologyPosts={technologyPosts}
+          />
+        )}
+
         <Testimonials />
       </Container>
     </Layout>


### PR DESCRIPTION
### What does this PR do?
Adds skeleton loader components to the home page while fetching blog posts to prevent blank screens and improve UX on slower networks.

Fixes keploy/keploy#3293