### PR TITLE
feat: track banner impressions (for per-banner CTR)

### DIFF
--- a/components/BlogSidebar.tsx
+++ b/components/BlogSidebar.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import Link from "next/link";
-import Image from "next/image";
 import { useRouter } from "next/router";
 import SubscribeNewsletter from "./subscribe-newsletter";
 import {
@@ -102,152 +101,163 @@ function SidebarShare() {
   );
 }
 
-
-const AD_ITEMS = [
-  {
-    src: "https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/coverage.mp4",
-    title: "Record API calls from real user flows.",
-    description: "Auto-generated on every PR diff, from real behavior. VS Code & JetBrains, 1M+ installs.",
-    primaryCTA: { label: "Start Free", href: "https://app.keploy.io/signin" },
-    secondaryCTA: { label: "Read the docs →", href: "https://keploy.io/docs" },
-  },
-  {
-    src: "https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/load+testing.mp4",
-    title: "Real traffic. Real tests. Zero manual effort.",
-    description: "Captures live API calls and turns them into test cases. Coverage that reflects production.",
-    primaryCTA: { label: "Try for Free", href: "https://app.keploy.io/signin" },
-    secondaryCTA: { label: "Read the docs →", href: "https://keploy.io/docs" },
-  },
-  {
-    src: "https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/api+test+generation+ai+powered+automation.mp4",
-    title: "Replay captured traffic to instantly catch regressions.",
-    description: "Replay production traffic at scale. No scripted scenarios, no guesswork.",
-    primaryCTA: { label: "Get Started", href: "https://app.keploy.io/signin" },
-    secondaryCTA: { label: "Read the docs →", href: "https://keploy.io/docs" },
-  },
+// 4 banner variants for A/B rotation. Each artwork is an edge-to-edge card with
+// an empty bottom band; the CTA is built in code and overlaid there (per-variant
+// colors). btnCenter = that band's vertical center (% from the top).
+const AD_BANNERS = [
+  { id: "banner_1", src: "https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/banner1.webp", btnBg: "#ED5D0F", btnText: "#ffffff", btnCenter: "88.5%" },
+  { id: "banner_2", src: "https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/banner2.webp", btnBg: "#ffffff", btnText: "#ED5D0F", btnCenter: "88.5%" },
+  { id: "banner_3", src: "https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/banner3.webp", btnBg: "#ED5D0F", btnText: "#ffffff", btnCenter: "88.5%" },
+  { id: "banner_4", src: "https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/banner4.webp", btnBg: "#16324F", btnText: "#ffffff", btnCenter: "88.5%" },
 ];
+
+const CTA_HREF = "https://app.keploy.io/signin";
+// Shared artwork shape (not a fixed size) — reserves space to avoid layout shift.
+const AD_ASPECT = "260 / 360";
+
+// Clarity (lazyOnload) + GA (afterInteractive) are set up in components/layout.tsx.
+declare global {
+  interface Window {
+    clarity?: (...args: unknown[]) => void;
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+// Clarity (lazyOnload) and GA (afterInteractive) may be undefined on an early
+// click, so run each call once its global exists — poll briefly, then give up.
+function whenReady(get: () => unknown, use: () => void) {
+  if (typeof window === "undefined") return;
+  if (typeof get() === "function") { use(); return; }
+  let tries = 0;
+  const timer = setInterval(() => {
+    tries += 1;
+    if (typeof get() === "function") {
+      clearInterval(timer);
+      use();
+    } else if (tries >= 20) {
+      clearInterval(timer); // ~5s elapsed; script never loaded (blocked?)
+    }
+  }, 250);
+}
+
+function trackBannerClick(bannerId: string) {
+  whenReady(() => window.gtag, () => window.gtag!("event", "banner_click", { banner_id: bannerId }));
+  whenReady(() => window.clarity, () => window.clarity!("set", "banner_clicked", bannerId));
+}
 
 /* ── Ad / CTA Banner ── */
 function SidebarAdBanner() {
-  const [videoError, setVideoError] = React.useState(false);
-  const [ad, setAd] = React.useState<typeof AD_ITEMS[number] | null>(null);
+  const [banner, setBanner] = React.useState<(typeof AD_BANNERS)[number] | null>(null);
+  const [loaded, setLoaded] = React.useState(false);
+  const [errored, setErrored] = React.useState(false);
 
   React.useEffect(() => {
-    setAd(AD_ITEMS[Math.floor(Math.random() * AD_ITEMS.length)]);
+    setBanner(AD_BANNERS[Math.floor(Math.random() * AD_BANNERS.length)]);
   }, []);
 
-  const reducedMotion =
-    typeof window !== 'undefined' &&
-    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-
-  if (!ad) {
+  // Text fallback so the ad slot is never blank if the artwork fails to load
+  // (content blocker, S3 hiccup, etc.). Keeps a working CTA + click tracking.
+  if (banner && errored) {
     return (
       <div
-        className="rounded-2xl bg-white border border-gray-200"
-        style={{ maxWidth: 320, margin: '0 auto', minHeight: 360, boxShadow: '0 4px 24px rgba(0,0,0,0.08)' }}
-        aria-hidden="true"
-      />
+        className="rounded-2xl p-5 flex flex-col justify-center"
+        style={{ width: '100%', aspectRatio: AD_ASPECT, backgroundColor: '#FFF4EE' }}
+      >
+        <h4 className="font-bold text-base leading-snug mb-1.5" style={{ fontFamily: "'DM Sans', sans-serif", color: '#1D2022' }}>
+          Try Keploy for free
+        </h4>
+        <p className="text-sm leading-relaxed mb-3" style={{ fontFamily: "'DM Sans', sans-serif", color: '#4b5563' }}>
+          Generate test cases and data mocks with one click. Reduce unit test development time by 90%.
+        </p>
+        <Link
+          href={CTA_HREF}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-banner-id={banner.id}
+          onClick={() => trackBannerClick(banner.id)}
+          className="inline-flex items-center gap-1 font-semibold text-sm transition-colors duration-150 hover:opacity-80"
+          style={{ fontFamily: "'DM Sans', sans-serif", color: '#ED5D0F' }}
+        >
+          Sign up <span aria-hidden="true">→</span>
+        </Link>
+      </div>
     );
   }
 
+  // Banner is picked client-side (avoids a hydration mismatch): reserve the
+  // slot, show a skeleton until the image decodes, then fade the artwork in.
   return (
     <div
-      className="rounded-2xl bg-white border border-gray-200 flex flex-col overflow-hidden"
+      className="rounded-2xl overflow-hidden"
       style={{
-        maxWidth: 320,
-        margin: '0 auto',
-        boxShadow: '0 4px 24px rgba(0,0,0,0.08)',
+        position: 'relative',
+        width: '100%',
+        aspectRatio: AD_ASPECT,
+        // container-query context so the overlaid button scales with the card
+        containerType: 'inline-size',
       }}
     >
-      {!videoError ? (
-        <video
-          src={ad.src}
-          autoPlay={!reducedMotion}
-          muted
-          loop={!reducedMotion}
-          playsInline
-          preload="none"
-          poster="/blog/images/keploy-ad-banner.jpg"
-          aria-hidden="true"
-          onError={() => setVideoError(true)}
-          style={{ width: '100%', height: 'auto', display: 'block' }}
-        />
-      ) : (
-        <Link
-          href={ad.primaryCTA.href}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label={ad.primaryCTA.label}
-          style={{ display: 'block', width: '100%' }}
-        >
-          <Image
-            src="/blog/images/keploy-ad-banner.jpg"
-            alt={ad.title}
-            width={260}
-            height={200}
-            sizes="260px"
-            className="transition-shadow duration-200 ease-in-out cursor-pointer hover:shadow-lg"
-            style={{ width: '100%', height: 'auto', display: 'block' }}
-            loading="lazy"
-          />
-        </Link>
+      {/* Skeleton shown until the banner image has loaded (or errored). */}
+      {!loaded && (
+        <div className="absolute inset-0 bg-gray-200 animate-pulse" aria-hidden="true" />
       )}
 
-      <div className="px-5 pt-5 pb-6 flex flex-col gap-4">
-        <div>
-          <h4
-            className="font-bold text-base leading-snug mb-2"
-            style={{ fontFamily: "'DM Sans', sans-serif", color: "#1D2022" }}
+      {banner && (
+        <>
+          {/* Banner artwork (CTA excluded); fills the slot and fades in on load. */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={banner.src}
+            alt="Keploy — 300M+ mocks and 12.8M+ tests generated"
+            onLoad={() => setLoaded(true)}
+            onError={() => setErrored(true)}
+            style={{
+              position: 'absolute',
+              inset: 0,
+              width: '100%',
+              height: '100%',
+              objectFit: 'cover',
+              display: 'block',
+              opacity: loaded ? 1 : 0,
+              transition: 'opacity 0.3s ease',
+            }}
+            loading="lazy"
+          />
+
+          {/* CTA overlaid in the artwork's empty band. Tracking lives here (not
+              the card) so only real clickthroughs count. */}
+          <Link
+            href={CTA_HREF}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Try for Free"
+            data-banner-id={banner.id}
+            onClick={() => trackBannerClick(banner.id)}
+            className="block text-center font-bold transition-all duration-300 hover:brightness-95 active:scale-[0.98]"
+            style={{
+              position: 'absolute',
+              zIndex: 2,
+              left: '11%',
+              right: '11%',
+              top: banner.btnCenter,
+              transform: 'translateY(-50%)',
+              // sized in cqw so the button scales with the card and always fits the band
+              padding: '4.2cqw 0',
+              borderRadius: '4cqw',
+              fontSize: '6.6cqw',
+              lineHeight: 1.2,
+              background: banner.btnBg,
+              color: banner.btnText,
+              boxShadow: '0 2px 10px rgba(0,0,0,0.12)',
+              fontFamily: "'DM Sans', sans-serif",
+              opacity: loaded ? 1 : 0,
+              transition: 'opacity 0.3s ease',
+            }}
           >
-            {ad.title}
-          </h4>
-          <p
-            className="text-sm leading-relaxed"
-            style={{ fontFamily: "'DM Sans', sans-serif", color: "#4b5563" }}
-          >
-            {ad.description}
-          </p>
-        </div>
-
-        <Link
-          href={ad.primaryCTA.href}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="w-full text-center font-bold text-sm py-3 rounded-xl transition-all duration-150 hover:brightness-90 active:scale-[0.98]"
-          style={{
-            background: '#ED5D0F',
-            color: '#fff',
-            boxShadow: '0 2px 10px rgba(232, 98, 42, 0.35)',
-            fontFamily: "'DM Sans', sans-serif",
-          }}
-        >
-          {ad.primaryCTA.label}
-        </Link>
-
-        <Link
-          href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ2l-psdTCNCLYAJ-Jt5ESyGP7gi1_U70ySTjtFNr0Kmx5UagNJnyzg7lNjA3NKnaP6qFfpAgcdZ"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="w-full text-center font-bold text-sm py-3 rounded-xl border transition-all duration-150 hover:bg-orange-50 active:scale-[0.98]"
-          style={{
-            background: 'transparent',
-            border: '1.5px solid #ED5D0F',
-            color: '#ED5D0F',
-            fontFamily: "'DM Sans', sans-serif",
-          }}
-        >
-          Book a Demo
-        </Link>
-
-        <Link
-          href={ad.secondaryCTA.href}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-center text-sm font-medium hover:underline pt-1 text-[#20883d]"
-        >
-          {ad.secondaryCTA.label}
-        </Link>
-      </div>
+            Try for Free!
+          </Link>
+        </>
+      )}
     </div>
   );
 }

--- a/components/BlogSidebar.tsx
+++ b/components/BlogSidebar.tsx
@@ -145,21 +145,46 @@ function trackBannerClick(bannerId: string) {
   whenReady(() => window.clarity, () => window.clarity!("set", "banner_clicked", bannerId));
 }
 
+function trackBannerImpression(bannerId: string) {
+  whenReady(() => window.gtag, () => window.gtag!("event", "banner_impression", { banner_id: bannerId }));
+  whenReady(() => window.clarity, () => window.clarity!("set", "banner_shown", bannerId));
+}
+
 /* ── Ad / CTA Banner ── */
 function SidebarAdBanner() {
   const [banner, setBanner] = React.useState<(typeof AD_BANNERS)[number] | null>(null);
   const [loaded, setLoaded] = React.useState(false);
   const [errored, setErrored] = React.useState(false);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const impressionFired = React.useRef(false);
 
   React.useEffect(() => {
     setBanner(AD_BANNERS[Math.floor(Math.random() * AD_BANNERS.length)]);
   }, []);
+
+  // Count a viewable impression once the picked banner scrolls ≥50% into view
+  // (fires a single time per load, so clicks / impressions gives a real CTR).
+  React.useEffect(() => {
+    if (!banner || impressionFired.current) return;
+    const el = containerRef.current;
+    if (!el || typeof IntersectionObserver === "undefined") return;
+    const io = new IntersectionObserver((entries) => {
+      if (entries.some((e) => e.isIntersecting) && !impressionFired.current) {
+        impressionFired.current = true;
+        trackBannerImpression(banner.id);
+        io.disconnect();
+      }
+    }, { threshold: 0.5 });
+    io.observe(el);
+    return () => io.disconnect();
+  }, [banner, errored]);
 
   // Text fallback so the ad slot is never blank if the artwork fails to load
   // (content blocker, S3 hiccup, etc.). Keeps a working CTA + click tracking.
   if (banner && errored) {
     return (
       <div
+        ref={containerRef}
         className="rounded-2xl p-5 flex flex-col justify-center"
         style={{ width: '100%', aspectRatio: AD_ASPECT, backgroundColor: '#FFF4EE' }}
       >
@@ -188,6 +213,7 @@ function SidebarAdBanner() {
   // slot, show a skeleton until the image decodes, then fade the artwork in.
   return (
     <div
+      ref={containerRef}
       className="rounded-2xl overflow-hidden"
       style={{
         position: 'relative',

--- a/components/navbar/FloatingNavbarClient.tsx
+++ b/components/navbar/FloatingNavbarClient.tsx
@@ -161,7 +161,7 @@ export default function FloatingNavbarClient({ techLatest = [], communityLatest 
         if (techState.length === 0 || communityState.length === 0) {
           const endpoint = process.env.NEXT_PUBLIC_WORDPRESS_API_URL as string | undefined;
           if (!endpoint) {
-            const res = await fetch(`${router.basePath || ''}/api/nav-latest`, { cache: "no-store" });
+            const res = await fetch(`${router.basePath || ''}/api/nav-latest`);
             if (!res.ok) throw new Error("Failed to fetch latest posts (no env, API 404)");
             const data = await res.json();
             if (!mounted) return;
@@ -771,7 +771,10 @@ function SearchBox({ onClose, techLatest = [], communityLatest = [] as any[] }: 
     (async () => {
       try {
         const base = (router?.basePath as string) || "";
-        const res = await fetch(`${base}/api/search-all`, { cache: "no-store" });
+        // No `cache: "no-store"` — the post list is public and identical for
+        // everyone, so let the browser and edge cache serve it. Opening the
+        // search box previously forced a fresh serverless invocation each time.
+        const res = await fetch(`${base}/api/search-all`);
         if (!res.ok) throw new Error("Failed to load posts");
         const data = await res.json();
         if (!mounted) return;

--- a/config/redirect.ts
+++ b/config/redirect.ts
@@ -23,6 +23,10 @@ export const slugRedirects: Record<string, string> = {
  * @returns The new slug if a redirect exists, otherwise null
  */
 export function getRedirectSlug(slug: string): string | null {
+    // Guard the prototype chain: a bare `slugRedirects[slug]` lookup returns
+    // Object.prototype's method for a slug like "toString", and that function
+    // is truthy — which would send a real post into a bogus redirect.
+    if (!hasRedirect(slug)) return null;
     return slugRedirects[slug] || null;
 }
 
@@ -32,5 +36,8 @@ export function getRedirectSlug(slug: string): string | null {
  * @returns true if the slug should be redirected
  */
 export function hasRedirect(slug: string): boolean {
-    return slug in slugRedirects;
+    // hasOwnProperty, not `in`: `in` walks the prototype chain, so a post
+    // legitimately slugged "constructor" or "toString" would report as having
+    // a redirect and get silently dropped from getStaticPaths.
+    return Object.prototype.hasOwnProperty.call(slugRedirects, slug);
 }

--- a/docs/on-demand-revalidation.md
+++ b/docs/on-demand-revalidation.md
@@ -1,0 +1,343 @@
+# On-demand revalidation
+
+## Why this exists
+
+Every page in this app is statically generated (ISR). Freshness used to come
+from *time-based* revalidation — `revalidate: 10` on technology posts and the
+listing pages, `revalidate: 60` on community posts.
+
+That is the wrong mechanism for a blog. Each time a page's window expired, the
+next request served a stale copy and fired a background regeneration, and each
+regeneration is a full serverless invocation costing ~3.5s of WordPress
+round-trips:
+
+| Query | Time |
+| --- | ---: |
+| `getPostAndMorePosts` | 1488 ms |
+| `getMoreStoriesForSlugs` | 1083 ms |
+| `getReviewAuthorDetails("neha")` | 383 ms |
+| `getReviewAuthorDetails("Jain")` | 889 ms |
+| **total** | **~3.5 s** |
+
+Across ~520 posts under crawler traffic that was roughly 1.2M renders and
+**2,224 GB-Hrs** of Vercel function duration per billing period — almost all of
+it re-fetching content that had not changed.
+
+WordPress content changes a few times a week, not every 10 seconds. So
+regeneration is now driven by *events*, not by a timer: WordPress calls
+`/blog/api/revalidate` when a post actually changes, and the ISR TTLs in
+`lib/isr.ts` are just a 24h safety net.
+
+## Setup
+
+### 1. Vercel
+
+Add a project environment variable:
+
+```
+REVALIDATE_SECRET=<a long random string>
+```
+
+Generate one with `openssl rand -hex 32`. The endpoint fails closed — if this
+is unset it returns 500 rather than allowing unauthenticated regeneration.
+
+### 2. WordPress
+
+`wp.keploy.io` is **not** a hand-managed server. It runs on the `prod-azure`
+cluster in namespace `prod`, deployed by Flux from
+[`keploy/k8s-env`](https://github.com/keploy/k8s-env)
+(`clusters/prod-azure/prod/wordpress.yaml`) via a custom Helm chart at
+[`slayerjain/wordpress-helm-chart`](https://github.com/slayerjain/wordpress-helm-chart).
+
+So do **not** SSH in, drop a file into `wp-content/mu-plugins/`, or edit
+`wp-config.php`. `wp-content` is on a 200Gi PVC with `keepPvc: true`, so a
+hand-placed file would survive a pod restart and appear to work — which is
+exactly what makes it dangerous. It would be undeclared drift, invisible to
+anyone reading either repo, and lost the moment the PVC is recreated.
+
+The chart already has a mu-plugin delivery mechanism. `rest-api-users-access.php`
+is stored as data in the `-extended` ConfigMap
+(`wordpress/templates/extendedconfig.yaml`) and mounted with `subPath` into
+`wp-content/mu-plugins/`. Ship this plugin the same way.
+
+**Secret injection.** `wordpress.yaml` sets `extraEnvSecrets: [wordpress-secrets]`,
+and the chart turns that into an `envFrom.secretRef` — so every key in that
+SealedSecret becomes a pod environment variable. Add the secret there and the
+plugin reads it with `getenv()`. No `wp-config.php` change is needed at all.
+
+Add the new key with `kubeseal --raw` and paste the output under
+`encryptedData`. Do **not** rebuild the whole SealedSecret: `kubeseal` cannot
+decrypt the existing `WORDPRESS_DB_PASSWORD`, so regenerating the resource from
+scratch would destroy it.
+
+```bash
+kubectl -n prod get secret wordpress-secrets -o jsonpath='{.data}'   # existing keys
+
+# The controller is `sealed-secrets-controller` in `flux-system`
+# (clusters/prod-azure/infra/sealed-secrets.yaml) — not the chart defaults.
+# The SealedSecret has no scope annotation, so it is strict-scoped and the
+# value is bound to this exact namespace + name.
+printf %s "$REVALIDATE_SECRET" | kubeseal --raw \
+  --namespace prod --name wordpress-secrets \
+  --controller-name sealed-secrets-controller \
+  --controller-namespace flux-system
+```
+
+Paste that blob under `encryptedData.KEPLOY_REVALIDATE_SECRET` in
+`clusters/prod-azure/prod/wordpress.yaml`, using the same value as the Vercel
+`REVALIDATE_SECRET`.
+
+**The pods will not pick it up on their own.** The deployment checksums only
+`secureconfig` and `extendedconfig`; nothing rolls pods when `wordpress-secrets`
+changes, and `envFrom` is read once at container start. Finish with:
+
+```bash
+kubectl -n prod rollout restart deployment/wordpress
+```
+
+**Outbound traffic.** The ingress `configuration-snippet` restricts `wp-admin`,
+`wp-login.php`, and REST *write* methods to the VPN allowlist. That is inbound
+only and does not affect this plugin, which makes an outbound POST to
+`keploy.io`.
+
+```php
+<?php
+/**
+ * Plugin Name: Keploy Blog On-Demand Revalidation
+ * Description: Pings the Next.js blog so it regenerates pages the moment
+ *              content changes, instead of polling on a timer.
+ */
+
+defined('ABSPATH') || exit;
+
+/**
+ * Ping the blog for a single post.
+ *
+ * Sent non-blocking so saving a post in the editor is never slowed down by
+ * page regeneration (which can take a few seconds per page). Delivery failures
+ * are therefore not visible here — they surface in the Vercel function logs,
+ * and the 24h ISR safety net in lib/isr.ts backstops anything genuinely lost.
+ */
+function keploy_ping_revalidate($post) {
+    if (!($post instanceof WP_Post) || $post->post_type !== 'post') {
+        return;
+    }
+
+    // Injected by envFrom.secretRef from the wordpress-secrets SealedSecret —
+    // NOT defined in wp-config.php, which this deployment does not hand-edit.
+    $secret = getenv('KEPLOY_REVALIDATE_SECRET');
+    $endpoint = getenv('KEPLOY_REVALIDATE_ENDPOINT');
+    if ($endpoint === false || $endpoint === '') {
+        $endpoint = 'https://keploy.io/blog/api/revalidate';
+    }
+    if ($secret === false || $secret === '') {
+        error_log('[keploy-revalidate] KEPLOY_REVALIDATE_SECRET missing from the pod environment');
+        return;
+    }
+
+    // WordPress appends "__trashed" to post_name when a post is trashed. The
+    // blog still knows the page by its original slug, so strip the suffix.
+    $slug = preg_replace('/__trashed$/', '', $post->post_name);
+    if ($slug === '') {
+        return;
+    }
+
+    $body = array('slug' => $slug);
+
+    // Only the two categories the blog actually routes on. If the post is in
+    // neither (or is moving between them), omit `category` and the endpoint
+    // will revalidate both URLs — which is what makes a category change work.
+    $slugs = wp_get_post_categories($post->ID, array('fields' => 'slugs'));
+    foreach (array('community', 'technology') as $category) {
+        if (in_array($category, $slugs, true)) {
+            $body['category'] = $category;
+            break;
+        }
+    }
+
+    // Tag and author pages are ALSO behind the 24h safety net, so a publish
+    // that doesn't refresh them leaves the new post missing from those
+    // listings for a full day. Send them so the endpoint can target them.
+    $tags = wp_get_post_tags($post->ID, array('fields' => 'names'));
+    if (!is_wp_error($tags) && !empty($tags)) {
+        $body['tags'] = array_slice($tags, 0, 20);
+    }
+
+    // PublishPress Multiple Authors (ppmaAuthorName) is the display author the
+    // blog routes on; fall back to the WP account only if it isn't available.
+    $author = '';
+    if (function_exists('get_multiple_authors')) {
+        $authors = get_multiple_authors($post->ID);
+        if (!empty($authors) && !empty($authors[0]->display_name)) {
+            $author = $authors[0]->display_name;
+        }
+    }
+    if ($author === '') {
+        $author = get_the_author_meta('display_name', $post->post_author);
+    }
+    if ($author !== '') {
+        $body['author'] = $author;
+    }
+
+    wp_remote_post($endpoint, array(
+        'timeout'  => 5,
+        'blocking' => false,
+        'headers'  => array(
+            'Content-Type'        => 'application/json',
+            'x-revalidate-secret' => $secret,
+        ),
+        'body'     => wp_json_encode($body),
+    ));
+}
+
+/**
+ * Fires on publish, update, unpublish and trash.
+ *
+ * transition_post_status covers every status change in one hook, so an
+ * unpublish correctly turns the live page into a 404 instead of leaving the
+ * last good render cached for 24h.
+ */
+function keploy_revalidate_on_transition($new_status, $old_status, $post) {
+    // Ignore autosaves/revisions and no-op transitions.
+    if (wp_is_post_revision($post->ID) || wp_is_post_autosave($post->ID)) {
+        return;
+    }
+    if ($new_status === $old_status && $new_status !== 'publish') {
+        return;
+    }
+    // Only care if the post is, or just stopped being, publicly visible.
+    if ($new_status !== 'publish' && $old_status !== 'publish') {
+        return;
+    }
+
+    keploy_ping_revalidate($post);
+}
+add_action('transition_post_status', 'keploy_revalidate_on_transition', 10, 3);
+
+/** Permanent deletion doesn't go through transition_post_status. */
+function keploy_revalidate_on_delete($post_id) {
+    $post = get_post($post_id);
+    if ($post) {
+        keploy_ping_revalidate($post);
+    }
+}
+add_action('before_delete_post', 'keploy_revalidate_on_delete');
+```
+
+### 3. Wiring the plugin in (two repos)
+
+The chart currently hardcodes its one mu-plugin. Rather than hardcode a second
+Keploy-specific one into a shared chart, add a generic `extraMuPlugins` knob so
+the PHP itself lives in `k8s-env` alongside the rest of the Keploy config.
+
+**`slayerjain/wordpress-helm-chart`**
+
+`wordpress/values.yaml`:
+
+```yaml
+# Extra must-use plugins. Key = filename, value = PHP source. Rendered into the
+# -extended ConfigMap and mounted into wp-content/mu-plugins/.
+extraMuPlugins: {}
+```
+
+`wordpress/templates/extendedconfig.yaml` — append to `data:`:
+
+```yaml
+{{- range $name, $content := .Values.extraMuPlugins }}
+  {{ $name }}: |
+{{ $content | indent 4 }}
+{{- end }}
+```
+
+`wordpress/templates/deployment.yaml` — after the `rest-api-users-access.php`
+mount:
+
+```yaml
+            {{- range $name, $_ := .Values.extraMuPlugins }}
+            - mountPath: /var/www/html{{ if $.Values.settings.wordpressSubDirectory }}{{ $.Values.settings.wordpressSubDirectory }}{{ end }}/wp-content/mu-plugins/{{ $name }}
+              subPath: {{ $name }}
+              name: extended
+            {{- end }}
+```
+
+No image rebuild is required — this is ConfigMap data, not a layer. The
+deployment already carries a `checksum/extendedconfig` pod annotation, so
+changing the ConfigMap rolls the pods automatically.
+
+**`keploy/k8s-env`** — in `clusters/prod-azure/prod/wordpress.yaml`, under
+`spec.values`, add the plugin from the previous section:
+
+```yaml
+    extraMuPlugins:
+      keploy-revalidate.php: |
+        <?php
+        /**
+         * Plugin Name: Keploy Blog On-Demand Revalidation
+         */
+        ... (the PHP above)
+```
+
+and add `KEPLOY_REVALIDATE_SECRET` to the `wordpress-secrets` SealedSecret in
+the same file.
+
+Flux watches the chart repo on a 5m interval and the cluster repo continuously,
+so both land without a manual deploy.
+
+## Verifying
+
+Trigger a revalidation by hand:
+
+```bash
+curl -X POST https://keploy.io/blog/api/revalidate \
+  -H 'content-type: application/json' \
+  -H "x-revalidate-secret: $REVALIDATE_SECRET" \
+  -d '{"slug":"what-is-api-testing","category":"community"}'
+```
+
+A success returns `{"revalidated": true, "results": [...]}` with one entry per
+regenerated path — the post itself plus `/blog`, both category listings, both
+search pages, the tag and author indexes, and any tag/author pages named in the
+request.
+
+Individual paths can report `revalidated: false` without the request failing —
+that is expected when a slug legitimately doesn't exist in one of the two
+categories. Only an all-paths failure returns a 500.
+
+Then confirm the page actually re-rendered:
+
+```bash
+curl -sI https://keploy.io/blog/community/what-is-api-testing | grep -i x-vercel-cache
+# x-vercel-cache: HIT   (age resets to ~0 right after a revalidation)
+```
+
+### Verify the API cache headers on the preview deployment
+
+`vercel.json` previously forced `no-store` on all of `/blog/api/(.*)`; it is now
+scoped to `preview|exit-preview|revalidate` so the read-only data routes can be
+served from the edge. Those routes set their own `Cache-Control` in the handler
+(and `no-store` on their error paths).
+
+What is NOT established from the repo alone is which value wins when a
+`vercel.json` header rule and a handler's `res.setHeader` set the same key —
+`/blog/api/search-all` also matches the blanket `/blog/(.*)` rule. Check it on
+the preview URL before merging:
+
+```bash
+curl -sI https://<preview>.vercel.app/blog/api/search-all | grep -i cache-control
+# want: public, s-maxage=3600, stale-while-revalidate=86400
+```
+
+If the blanket rule wins instead, add an explicit `/blog/api/(search-all|nav-latest|proxy-image)`
+entry to `vercel.json` with those values.
+
+## Gotchas
+
+- **Paths must include the `/blog` basePath.** `res.revalidate()` is not a
+  route lookup; on Vercel it performs a real `fetch('https://' + host + path)`.
+  A path without the basePath silently 404s and revalidates nothing. This is
+  why `lib/isr.ts` exports `BASE_PATH`/`postPath()` rather than hand-writing
+  paths at each call site, and why `tests/lib/isr.test.ts` pins it to
+  `next.config.js`.
+- **Don't lower the TTLs in `lib/isr.ts` to "fix" staleness.** That reintroduces
+  exactly the cost this removed. If content is stale, the webhook is broken —
+  check the Vercel function logs for `/api/revalidate`.

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,6 +1,3 @@
-export const maxDuration = 300; // This can run Vercel Functions for a maximum of 300 seconds
-export const dynamic = 'force-dynamic';
-
 const API_URL = process.env.WORDPRESS_API_URL || process.env.NEXT_PUBLIC_WORDPRESS_API_URL
 
 /**
@@ -262,6 +259,139 @@ export async function getReviewAuthorDetails(authorName) {
   return data?.users;
 }
 
+/**
+ * Process-local memo with a short TTL.
+ *
+ * Post renders repeat several byte-for-byte identical WordPress queries, and a
+ * single build shares one process across hundreds of pages — so memoizing
+ * removes almost all of that duplicate work.
+ *
+ * The TTL is the important part. A warm Vercel lambda is reused across many
+ * on-demand regenerations, so a memo with no expiry would serve every
+ * webhook-triggered rebuild whatever that lambda happened to cache when it
+ * first warmed — meaning a freshly published post could be missing from the
+ * "More Stories" rail on newly regenerated pages. Five minutes keeps the
+ * dedupe benefit (a build finishes well inside it) while bounding staleness.
+ */
+const MEMO_TTL_MS = 5 * 60 * 1000;
+
+/** Above this many live keys the memo resets rather than growing unbounded. */
+const MEMO_MAX_ENTRIES = 500;
+
+function createMemo<T>(ttlMs: number = MEMO_TTL_MS) {
+  type Entry = { value: Promise<T>; expiresAt: number };
+  const entries = new Map<string, Entry>();
+
+  return function memo(key: string, produce: () => Promise<T>): Promise<T> {
+    const now = Date.now();
+    const hit = entries.get(key);
+    if (hit && hit.expiresAt > now) return hit.value;
+
+    if (entries.size >= MEMO_MAX_ENTRIES) {
+      // forEach rather than for..of: this tsconfig targets below es2015, where
+      // iterating a Map needs --downlevelIteration. Deleting during forEach is
+      // well-defined for Map.
+      entries.forEach((entry, entryKey) => {
+        if (entry.expiresAt <= now) entries.delete(entryKey);
+      });
+      if (entries.size >= MEMO_MAX_ENTRIES) entries.clear();
+    }
+
+    // Cache the promise, not the result, so concurrent callers share one
+    // request. On failure evict, so the next caller retries instead of pinning
+    // a rejection for the whole TTL — but only if we're still the current
+    // entry, so a later attempt is never clobbered by an earlier failure.
+    const entry = { expiresAt: now + ttlMs } as Entry;
+    entry.value = produce().catch((error) => {
+      if (entries.get(key) === entry) entries.delete(key);
+      throw error;
+    });
+
+    entries.set(key, entry);
+    return entry.value;
+  };
+}
+
+/**
+ * The two reviewing authors are the same for every single post, but
+ * `getReviewAuthorDetails` was being called twice inside every post's
+ * getStaticProps — 1.27s of the ~3.5s render budget spent re-fetching two
+ * identical, never-changing records.
+ */
+const reviewAuthorMemo = createMemo<any>();
+
+export function getReviewAuthorDetailsCached(authorName: string) {
+  return reviewAuthorMemo(authorName, () => getReviewAuthorDetails(authorName));
+}
+
+/** Reviewing authors shown on every post page. */
+export const REVIEW_AUTHORS = ["neha", "Jain"];
+
+/** Fetch both reviewing authors, deduped and in parallel. */
+export function getReviewAuthors() {
+  return Promise.all(REVIEW_AUTHORS.map(getReviewAuthorDetailsCached));
+}
+
+/**
+ * Every slug in a category, paginating until WordPress runs out.
+ *
+ * `getAllPostsForTechnology`/`getAllPostsForCommunity` are capped at `first: 22`
+ * and were feeding getStaticPaths directly, so only 44 of ~520 posts were ever
+ * pre-rendered. The rest fell through to on-demand rendering. This query asks
+ * for slugs only, so pages are cheap and 100-at-a-time is safe.
+ */
+export async function getAllSlugsForCategory(categoryName: string): Promise<string[]> {
+  const slugs: string[] = [];
+  let after: string | null = null;
+  const wanted = categoryName.toLowerCase();
+
+  // Hard page ceiling so a malformed cursor can never spin forever.
+  for (let page = 0; page < 100; page++) {
+    const data = await fetchAPI(
+      `
+      query AllSlugsForCategory($after: String, $categoryName: String!) {
+        posts(
+          first: 100
+          after: $after
+          where: { orderby: { field: DATE, order: DESC }, categoryName: $categoryName }
+        ) {
+          edges { node { slug categories { edges { node { name } } } } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+      `,
+      { variables: { after, categoryName } }
+    );
+
+    for (const edge of data?.posts?.edges || []) {
+      if (!edge?.node?.slug) continue;
+
+      // WPGraphQL's `categoryName` filter matches on the category SLUG, but the
+      // page's own guard in getStaticProps compares category NAMES. When those
+      // disagree for a post, getStaticProps returns a `redirect` — and Next.js
+      // throws "`redirect` can not be returned from getStaticProps during
+      // prerendering", failing the whole build.
+      //
+      // Filtering here on the *same* criterion the page uses makes that
+      // unreachable for pre-rendered paths by construction, instead of relying
+      // on the old accident that getStaticPaths only ever returned 22 slugs.
+      // Genuinely cross-filed posts fall through to fallback: "blocking" and
+      // get their 301 at runtime, where returning a redirect is legal.
+      const names = (edge.node.categories?.edges || []).map(
+        (c: any) => c?.node?.name?.toLowerCase()
+      );
+      if (!names.includes(wanted)) continue;
+
+      slugs.push(edge.node.slug);
+    }
+
+    const pageInfo = data?.posts?.pageInfo;
+    if (!pageInfo?.hasNextPage || !pageInfo?.endCursor) break;
+    after = pageInfo.endCursor;
+  }
+
+  return slugs;
+}
 
 
 // Function for fetching post with technology category
@@ -501,11 +631,13 @@ export async function getPostsByAuthor() {
   return { edges: allPosts };
 }
 
+/** Shared "more stories" results, keyed by tag set. See fetchNodes below. */
+const moreStoriesMemo = createMemo<any[]>();
+
 export async function getMoreStoriesForSlugs(tags, slug) {
   const tagFilter = tags?.edges?.length > 0;
   const variables = tagFilter ? { tags: tags.edges.map((edge) => edge.node.name) } : undefined;
   let stories = [];
-  let data;
 
   const queryWithTags = `
     query Posts($tags: [String!]) {
@@ -548,19 +680,31 @@ export async function getMoreStoriesForSlugs(tags, slug) {
     }
   `;
 
+  // Both queries depend only on the tag list — the current post is filtered out
+  // afterwards, in JS. So the network result is shareable across every post with
+  // the same tags, and the untagged fallback is shared by all posts outright.
+  // Memoizing collapses ~1000 queries per build into a handful. Callers only
+  // ever .filter()/.map() the result, so the cached arrays are never mutated.
+  const fetchNodes = (cacheKey: string, query: string, vars?: any) =>
+    moreStoriesMemo(cacheKey, () =>
+      fetchAPI(query, { variables: vars }).then(
+        (result) => result?.posts?.edges.map(({ node }) => node) || []
+      )
+    );
+
   // Fetch posts with tags if applicable
   if (tagFilter) {
-    data = await fetchAPI(queryWithTags, { variables });
-    stories = data?.posts?.edges.map(({ node }) => node) || [];
-    stories = stories.filter((story) => story.slug !== slug);
+    const tagKey = `tags:${[...variables.tags].sort().join("|")}`;
+    stories = (await fetchNodes(tagKey, queryWithTags, variables)).filter(
+      (story) => story.slug !== slug
+    );
   }
 
   // If no posts are found, fetch without tag filter
   if (!stories.length) {
-    data = await fetchAPI(fallbackQuery);
-    stories = data?.posts?.edges.map(({ node }) => node) || [];
-    stories = stories.filter((story) => story.slug !== slug);
-
+    stories = (await fetchNodes("recent", fallbackQuery)).filter(
+      (story) => story.slug !== slug
+    );
   }
 
   // Remove posts with the same slug

--- a/lib/isr.ts
+++ b/lib/isr.ts
@@ -1,0 +1,58 @@
+/**
+ * ISR revalidation policy.
+ *
+ * Freshness comes from on-demand revalidation (`/api/revalidate`, driven by a
+ * WordPress publish/update webhook), NOT from time-based polling. The values
+ * below are therefore safety nets that only fire if the webhook is misconfigured
+ * or a delivery is dropped — they are not the primary freshness mechanism.
+ *
+ * Why this matters: these pages used to carry `revalidate: 10`/`60`. Every
+ * expiry served a stale hit and fired a background regeneration, and each
+ * regeneration is a full serverless invocation costing ~3.5s of WordPress
+ * round-trips. Across ~520 posts under crawler traffic that was ~1.2M renders
+ * and 2,224 GB-Hrs of function duration per billing period, re-fetching content
+ * that changes a few times a week.
+ *
+ * Keep these values LARGE. If content feels stale, fix the webhook — do not
+ * lower these numbers.
+ */
+
+/** Safety net for content pages. Real updates arrive via the webhook. */
+export const REVALIDATE_CONTENT = 86400 // 24h
+
+/**
+ * Must mirror `basePath` in next.config.js.
+ *
+ * `res.revalidate(path)` is not a route lookup — on Vercel it performs a real
+ * `fetch('https://' + host + path)` against the deployment (see
+ * next/dist/server/api-utils/node/api-resolver.js). So the path has to be the
+ * public URL path *including* the basePath, or every revalidation silently
+ * 404s. `tests/lib/isr.test.ts` asserts this stays in sync with next.config.js.
+ */
+export const BASE_PATH = '/blog'
+
+/** Public URL path for a post, ready to hand to `res.revalidate()`. */
+export function postPath(category: string, slug: string) {
+  return `${BASE_PATH}/${category}/${slug}`
+}
+
+/**
+ * Genuine "this post does not exist" responses.
+ *
+ * Must stay large: a short TTL here lets bot-sprayed URLs re-render on every
+ * expiry, turning random 404 traffic into unbounded function duration. A slug
+ * that doesn't exist now will still not exist in a minute, and a newly
+ * published post arrives via the webhook rather than by expiry.
+ */
+export const REVALIDATE_NOT_FOUND = 86400 // 24h
+
+/**
+ * Degraded responses caused by WordPress being unreachable — NOT by the
+ * content genuinely being absent.
+ *
+ * Deliberately short. These pages must self-heal quickly once WP recovers,
+ * otherwise a momentary blip during regeneration would pin a real post as a
+ * 404 for a full day. The cost is bounded because it only applies to pages
+ * that actually errored, not to the ~520 healthy ones.
+ */
+export const REVALIDATE_ERROR = 60 // 1m

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -6,6 +6,7 @@ import { getAllPostsForTechnology, getAllPostsForCommunity } from "../lib/api";
 import { GetStaticProps } from "next";
 import { getBreadcrumbListSchema, SITE_URL } from "../lib/structured-data";
 import { safeJsonLdStringify } from "../utils/seo";
+import { REVALIDATE_CONTENT, REVALIDATE_ERROR } from "../lib/isr";
 
 interface Custom404Props {
   latestPosts: { edges: Array<{ node: any }> };
@@ -91,7 +92,7 @@ export const getStaticProps: GetStaticProps = async () => {
         communityPosts: latestCommunityPosts,
         technologyPosts: latestTechnologyPosts,
       },
-      revalidate: 60, // Revalidate every minute
+      revalidate: REVALIDATE_CONTENT,
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -107,7 +108,7 @@ export const getStaticProps: GetStaticProps = async () => {
         "1. Verify WPGraphQL is up: curl -sS -X POST <endpoint> -H 'Content-Type: application/json' -d '{\"query\":\"{ __typename }\"}'",
         "2. If the curl 5xx's or hangs, check wp.keploy.io host status and the WPGraphQL plugin (WP admin → Plugins)",
         "3. If the endpoint logged above is unexpected, double-check WORDPRESS_API_URL in Vercel project settings and redeploy",
-        "4. Page is served with revalidate: 60, so the rails self-heal within ~1 min after WP recovers",
+        "4. The degraded response uses REVALIDATE_ERROR (60s), so the rails self-heal within ~1 min after WP recovers",
       ],
     });
     return {
@@ -116,7 +117,7 @@ export const getStaticProps: GetStaticProps = async () => {
         communityPosts: { edges: [] },
         technologyPosts: { edges: [] },
       },
-      revalidate: 60,
+      revalidate: REVALIDATE_ERROR,
     };
   }
 };

--- a/pages/api/nav-latest.ts
+++ b/pages/api/nav-latest.ts
@@ -7,11 +7,19 @@ export default async function handler(_req: NextApiRequest, res: NextApiResponse
       getAllPostsForTechnology(false),
       getAllPostsForCommunity(false),
     ]);
+    // Public, identical for every visitor — cache at the edge so this costs a
+    // function invocation once an hour rather than once per navbar render.
+    res.setHeader(
+      "Cache-Control",
+      "public, s-maxage=3600, stale-while-revalidate=86400"
+    );
     res.status(200).json({
       technology: (tech?.edges || []).slice(0, 4),
       community: (comm?.edges || []).slice(0, 4),
     });
   } catch (e: any) {
+    // Never cache a failure — see the note in search-all.ts.
+    res.setHeader("Cache-Control", "no-store");
     res.status(500).json({ error: e?.message || "Failed to load latest posts" });
   }
 }

--- a/pages/api/proxy-image.ts
+++ b/pages/api/proxy-image.ts
@@ -14,6 +14,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const urlParam = req.query.url;
 
     if (typeof urlParam !== "string") {
+      res.setHeader("Cache-Control", "no-store");
       res.status(400).send("Missing url parameter");
       return;
     }
@@ -22,16 +23,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     try {
       targetUrl = new URL(urlParam);
     } catch {
+      res.setHeader("Cache-Control", "no-store");
       res.status(400).send("Invalid url parameter");
       return;
     }
 
     if (targetUrl.protocol !== "https:") {
+      res.setHeader("Cache-Control", "no-store");
       res.status(400).send("Only https protocol is allowed");
       return;
     }
 
     if (!ALLOWED_HOSTNAMES.has(targetUrl.hostname)) {
+      res.setHeader("Cache-Control", "no-store");
       res.status(403).send("Host not allowed");
       return;
     }
@@ -45,6 +49,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     });
 
     if (!upstream.ok || !upstream.body) {
+      res.setHeader("Cache-Control", "no-store");
       res.status(upstream.status).send("Failed to fetch image");
       return;
     }
@@ -64,6 +69,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
     res.end();
   } catch (err) {
+    res.setHeader("Cache-Control", "no-store");
     res.status(500).send("Unexpected error");
   }
 }

--- a/pages/api/revalidate.ts
+++ b/pages/api/revalidate.ts
@@ -1,0 +1,206 @@
+import { createHash, timingSafeEqual } from "crypto";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { BASE_PATH, postPath } from "../../lib/isr";
+import { sanitizeAuthorSlug } from "../../utils/sanitizeAuthorSlug";
+
+/**
+ * On-demand ISR — the blog's primary freshness mechanism.
+ *
+ * WordPress calls this on publish/update/delete and we regenerate exactly the
+ * affected pages. That replaces time-based revalidation, which was regenerating
+ * every post every 10-60s regardless of whether anything had changed (~1.2M
+ * wasted renders and 2,224 GB-Hrs per billing period). See lib/isr.ts.
+ *
+ * Because every page now sits behind a 24h safety-net TTL, anything NOT
+ * revalidated here stays stale for up to a day. So this must cover every page
+ * type a publish can affect — post, listings, search indexes, tag and author
+ * pages — not just the post itself.
+ *
+ * Setup: set REVALIDATE_SECRET in the Vercel project, then install the
+ * companion mu-plugin on wp.keploy.io (docs/on-demand-revalidation.md).
+ */
+
+/**
+ * Each target is a full blocking page render. The default function timeout is
+ * too tight for a fan-out of ~10 against a slow WordPress, and the mu-plugin
+ * fires non-blocking so a timeout would fail silently.
+ */
+export const maxDuration = 60;
+
+const CATEGORIES = ["community", "technology"];
+
+/** Bounds the fan-out an authenticated caller can request in one POST. */
+const MAX_EXPLICIT_PATHS = 50;
+const MAX_TAGS = 20;
+
+/** How many regenerations to run at once. Keeps us inside maxDuration without
+ *  stampeding WordPress with a burst of concurrent renders. */
+const CONCURRENCY = 4;
+
+/**
+ * Constant-time secret comparison.
+ *
+ * Hashing first gives both sides a fixed 32-byte length, so timingSafeEqual
+ * never throws on a length mismatch and the comparison leaks nothing about
+ * the expected secret's length.
+ */
+function secretMatches(provided: string, expected: string): boolean {
+  const a = createHash("sha256").update(provided).digest();
+  const b = createHash("sha256").update(expected).digest();
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * Sanitize one URL path segment (slug, tag name, author name).
+ *
+ * Rejects anything that could escape its segment and returns it percent-encoded
+ * so tag names containing spaces still resolve. Returns null if unusable.
+ */
+function safeSegment(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === "." || trimmed === "..") return null;
+  if (/[\/\\]/.test(trimmed)) return null;
+  return encodeURIComponent(trimmed);
+}
+
+/** Run tasks with a bounded number in flight. */
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  task: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (cursor < items.length) {
+      const index = cursor++;
+      results[index] = await task(items[index]);
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  // Never cache this response — vercel.json also pins no-store on this route.
+  res.setHeader("Cache-Control", "no-store");
+
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const expected = process.env.REVALIDATE_SECRET;
+  if (!expected) {
+    // Fail closed: without a configured secret this endpoint would let anyone
+    // force unbounded regeneration, which is the exact cost we're removing.
+    console.error("/api/revalidate called but REVALIDATE_SECRET is not set");
+    return res.status(500).json({ error: "Revalidation is not configured" });
+  }
+
+  const provided = req.headers["x-revalidate-secret"];
+  if (typeof provided !== "string" || !secretMatches(provided, expected)) {
+    return res.status(401).json({ error: "Invalid secret" });
+  }
+
+  const {
+    slug,
+    category,
+    tags,
+    author,
+    paths: explicitPaths,
+  } = (req.body ?? {}) as {
+    slug?: string;
+    category?: string;
+    tags?: string[];
+    author?: string;
+    paths?: string[];
+  };
+
+  const targets = new Set<string>();
+
+  if (Array.isArray(explicitPaths)) {
+    for (const path of explicitPaths.slice(0, MAX_EXPLICIT_PATHS)) {
+      // Only ever revalidate our own pages — never let the caller aim this at
+      // an arbitrary URL — and never let a path climb out of the basePath.
+      if (
+        typeof path === "string" &&
+        path.startsWith(`${BASE_PATH}/`) &&
+        !path.includes("..") &&
+        !path.includes("//")
+      ) {
+        targets.add(path);
+      }
+    }
+  }
+
+  const safeSlug = safeSegment(slug);
+  if (safeSlug) {
+    if (typeof category === "string" && CATEGORIES.includes(category)) {
+      targets.add(postPath(category, safeSlug));
+    } else {
+      // Category unknown or changed — a post can move between the two, and the
+      // old URL needs regenerating so it starts serving its 301.
+      for (const c of CATEGORIES) targets.add(postPath(c, safeSlug));
+    }
+  }
+
+  if (targets.size === 0) {
+    return res.status(400).json({ error: "Provide { slug, category } or { paths }" });
+  }
+
+  // A publish changes every surface that lists or indexes the post. All of
+  // these sit behind the 24h safety net, so if they aren't refreshed here the
+  // new post simply won't be findable until tomorrow.
+  targets.add(BASE_PATH);
+  for (const c of CATEGORIES) targets.add(`${BASE_PATH}/${c}`);
+  targets.add(`${BASE_PATH}/search`);
+  targets.add(`${BASE_PATH}/community/search`);
+  targets.add(`${BASE_PATH}/tag`);
+  targets.add(`${BASE_PATH}/authors`);
+
+  // Tag pages are keyed by tag NAME (see pages/tag/[slug].tsx getStaticPaths).
+  if (Array.isArray(tags)) {
+    for (const tag of tags.slice(0, MAX_TAGS)) {
+      const safeTag = safeSegment(tag);
+      if (safeTag) targets.add(`${BASE_PATH}/tag/${safeTag}`);
+    }
+  }
+
+  // Author pages are keyed by sanitizeAuthorSlug(name), not the raw name, so
+  // sanitize with the same helper getStaticPaths uses or the path won't match.
+  if (typeof author === "string" && author.trim()) {
+    const safeAuthor = safeSegment(sanitizeAuthorSlug(author));
+    if (safeAuthor) targets.add(`${BASE_PATH}/authors/${safeAuthor}`);
+  }
+
+  // Revalidate independently so one bad path can't drop the rest. A path that
+  // legitimately 404s (e.g. the category the post is NOT in) is reported, not
+  // treated as a failure of the whole request.
+  const results = await mapWithConcurrency(
+    Array.from(targets),
+    CONCURRENCY,
+    async (path) => {
+      try {
+        await res.revalidate(path);
+        return { path, revalidated: true };
+      } catch (error: any) {
+        return { path, revalidated: false, reason: error?.message ?? String(error) };
+      }
+    }
+  );
+
+  const failed = results.filter((r) => !r.revalidated);
+  if (failed.length === results.length) {
+    console.error("/api/revalidate: every path failed", failed);
+    return res.status(500).json({ revalidated: false, results });
+  }
+  if (failed.length > 0) {
+    console.warn("/api/revalidate: some paths failed", failed);
+  }
+
+  return res.status(200).json({ revalidated: true, results });
+}

--- a/pages/api/search-all.ts
+++ b/pages/api/search-all.ts
@@ -13,9 +13,20 @@ export default async function handler(_req: NextApiRequest, res: NextApiResponse
       ...(technology?.edges || []),
     ];
 
+    // Public, identical for every visitor. Without this the search box burned a
+    // serverless invocation (two WordPress queries) every time a user opened it.
+    // Served from the edge instead, and refreshed in the background thereafter.
+    res.setHeader(
+      "Cache-Control",
+      "public, s-maxage=3600, stale-while-revalidate=86400"
+    );
     res.status(200).json({ results });
   } catch (e) {
     console.error("/api/search-all failed", e);
+    // Never cache a failure. Without this the error falls through to the
+    // blanket /blog/(.*) rule in vercel.json and a transient WordPress blip
+    // gets pinned in visitors' browsers for an hour.
+    res.setHeader("Cache-Control", "no-store");
     res.status(500).json({ error: "Failed to load posts" });
   }
 }

--- a/pages/authors/[slug].tsx
+++ b/pages/authors/[slug].tsx
@@ -12,6 +12,7 @@ import PostByAuthorMapping from "../../components/postByAuthorMapping";
 import { HOME_OG_IMAGE_URL } from "../../lib/constants";
 import { sanitizeAuthorSlug } from "../../utils/sanitizeAuthorSlug";
 import { getBreadcrumbListSchema, MAIN_SITE_URL, SITE_URL } from "../../lib/structured-data";
+import { REVALIDATE_CONTENT, REVALIDATE_ERROR, REVALIDATE_NOT_FOUND } from "../../lib/isr";
 
 export default function AuthorPage({ preview, filteredPosts, content }) {
   if (!filteredPosts || filteredPosts.length === 0) {
@@ -104,13 +105,13 @@ export const getStaticPaths: GetStaticPaths = async ({ }) => {
 
     return {
       paths,
-      fallback: true,
+      fallback: "blocking",
     };
   } catch (error) {
     console.error("authors/[slug] getStaticPaths error:", error);
     return {
       paths: [],
-      fallback: true,
+      fallback: "blocking",
     };
   }
 };
@@ -124,7 +125,7 @@ export const getStaticProps: GetStaticProps = async ({
   if (typeof slugParam !== "string" || slugParam.trim().length === 0) {
     return {
       notFound: true,
-      revalidate: 60,
+      revalidate: REVALIDATE_NOT_FOUND,
     };
   }
 
@@ -150,6 +151,13 @@ export const getStaticProps: GetStaticProps = async ({
 
   let filteredPosts = [];
 
+  // fetchAPI throws on GraphQL errors and on network failure, and every WP call
+  // below is individually caught — which makes "WordPress is down" look
+  // identical to "this author has no posts". They must not share a TTL: a
+  // genuine 404 should stick, but an outage must self-heal in a minute rather
+  // than pinning a real author page as a 404 for a day.
+  let wordpressFailed = false;
+
   for (const candidate of Array.from(candidateAuthorNames)) {
     if (!candidate) continue;
     try {
@@ -160,6 +168,7 @@ export const getStaticProps: GetStaticProps = async ({
         break;
       }
     } catch (error) {
+      wordpressFailed = true;
       console.error(`authors/[slug] failed to fetch posts for candidate "${candidate}":`, error);
     }
   }
@@ -176,6 +185,7 @@ export const getStaticProps: GetStaticProps = async ({
           return sanitizeAuthorSlug(candidateName) === sanitizeAuthorSlug(slugParam);
         }) || [];
     } catch (error) {
+      wordpressFailed = true;
       console.error("authors/[slug] fallback to getAllPosts failed:", error);
       filteredPosts = [];
     }
@@ -185,7 +195,7 @@ export const getStaticProps: GetStaticProps = async ({
   if (!filteredPosts.length) {
     return {
       notFound: true,
-      revalidate: 60,
+      revalidate: wordpressFailed ? REVALIDATE_ERROR : REVALIDATE_NOT_FOUND,
     };
   }
 
@@ -205,7 +215,7 @@ export const getStaticProps: GetStaticProps = async ({
       filteredPosts,
       content,
     },
-    revalidate: 60,
+    revalidate: REVALIDATE_CONTENT,
   };
 };
 

--- a/pages/authors/index.tsx
+++ b/pages/authors/index.tsx
@@ -7,6 +7,7 @@ import AuthorMapping from "../../components/AuthorMapping";
 import { HOME_OG_IMAGE_URL } from "../../lib/constants";
 import { Post } from "../../types/post";
 import { getBreadcrumbListSchema, SITE_URL } from "../../lib/structured-data";
+import { REVALIDATE_CONTENT } from "../../lib/isr";
 
 export default function Authors({
   AllAuthors: { edges },
@@ -52,6 +53,6 @@ export const getStaticProps: GetStaticProps = async ({ preview = false }) => {
   const AllAuthors = await getAllAuthors();
   return {
     props: { AllAuthors, preview },
-    revalidate: 10,
+    revalidate: REVALIDATE_CONTENT,
   };
 };

--- a/pages/community/[slug].tsx
+++ b/pages/community/[slug].tsx
@@ -1,7 +1,7 @@
 import { useRouter } from "next/router";
 import ErrorPage from "next/error";
 import Head from "next/head";
-import { getRedirectSlug } from "../../config/redirect";
+import { getRedirectSlug, hasRedirect } from "../../config/redirect";
 import { GetStaticPaths, GetStaticProps } from "next";
 import Container from "../../components/container";
 import MoreStories from "../../components/more-stories";
@@ -12,14 +12,15 @@ import Layout from "../../components/layout";
 import PostTitle from "../../components/post-title";
 import Tag from "../../components/tag";
 import {
-  getAllPostsForCommunity,
+  getAllSlugsForCategory,
   getMoreStoriesForSlugs,
   getPostAndMorePosts,
+  getReviewAuthors,
 } from "../../lib/api";
 import ContainerSlug from "../../components/containerSlug";
 import { useEffect, useRef } from "react";
 import { useScroll, useSpringValue } from "@react-spring/web";
-import { getReviewAuthorDetails } from "../../lib/api";
+import { REVALIDATE_CONTENT, REVALIDATE_ERROR, REVALIDATE_NOT_FOUND } from "../../lib/isr";
 import { calculateReadingTime } from "../../utils/calculateReadingTime";
 import dynamic from "next/dynamic";
 import "./styles.module.css"
@@ -286,7 +287,7 @@ export const getStaticProps: GetStaticProps = async ({
   if (typeof slug !== "string") {
     return {
       notFound: true,
-      revalidate: 60,
+      revalidate: REVALIDATE_NOT_FOUND,
     };
   }
 
@@ -306,7 +307,7 @@ export const getStaticProps: GetStaticProps = async ({
     if (!data?.post) {
       return {
         notFound: true,
-        revalidate: 60,
+        revalidate: REVALIDATE_NOT_FOUND,
       };
     }
 
@@ -319,7 +320,7 @@ export const getStaticProps: GetStaticProps = async ({
     ) || [];
     if (!postCategories.includes("community")) {
       // Post belongs to a different category — 301 redirect to preserve SEO signals.
-      // This only runs at ISR runtime (fallback: true), not during next build,
+      // This only runs at ISR runtime (fallback: "blocking"), not during next build,
       // because getStaticPaths only returns paths from the community category query.
       const correctCategory = postCategories.find((c: string) =>
         ['community', 'technology'].includes(c)
@@ -334,15 +335,14 @@ export const getStaticProps: GetStaticProps = async ({
       }
       return {
         notFound: true,
-        revalidate: 60,
+        revalidate: REVALIDATE_NOT_FOUND,
       };
     }
 
     const moreStories = await getMoreStoriesForSlugs(data.post?.tags, data.post?.slug);
-    const authorDetails = await Promise.all([
-      getReviewAuthorDetails("neha"),
-      getReviewAuthorDetails("Jain"),
-    ]);
+    // Same two records for every post — memoized in lib/api so a build makes
+    // this request twice in total instead of twice per post.
+    const authorDetails = await getReviewAuthors();
 
     return {
       props: {
@@ -351,25 +351,36 @@ export const getStaticProps: GetStaticProps = async ({
         posts: moreStories?.communityMoreStories || { edges: [] },
         reviewAuthorDetails: authorDetails,
       },
-      revalidate: 60,
+      revalidate: REVALIDATE_CONTENT,
     };
   } catch (error) {
     console.error("community/[slug] getStaticProps error:", error);
+    // WordPress failed, the post may well exist — retry soon rather than
+    // pinning a real post as a 404 for a day.
     return {
       notFound: true,
-      revalidate: 60,
+      revalidate: REVALIDATE_ERROR,
     };
   }
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const allPosts = await getAllPostsForCommunity(false);
-  const communityPosts =
-    allPosts?.edges
-      .map(({ node }) => `/community/${node?.slug}`) || [];
+  // getAllPostsForCommunity is capped at `first: 22`, so using it here left
+  // most posts un-prerendered and rendering on demand. Paginate for the full set.
+  const slugs = await getAllSlugsForCategory("community");
 
   return {
-    paths: communityPosts || [],
-    fallback: true,
+    // Slugs with a configured redirect must NOT be pre-rendered. getStaticProps
+    // returns `redirect` for them, and Next.js rejects that during prerendering
+    // ("`redirect` can not be returned from getStaticProps during prerendering").
+    // They were previously never hit at build time only because getStaticPaths
+    // was capped at 22 paths and happened to miss them. These URLs are already
+    // 301'd at the edge by vercel.json, so they never reach a function anyway.
+    paths: slugs.filter((slug) => !hasRedirect(slug)).map((slug) => `/community/${slug}`),
+    // 'blocking' rather than true: `true` served an empty skeleton with a 200
+    // for any unknown slug (soft 404 for crawlers) before resolving. 'blocking'
+    // returns the correct status on the first request. Real posts are all
+    // pre-rendered above, so this path is only hit by new posts and bad URLs.
+    fallback: "blocking",
   };
 };

--- a/pages/community/index.tsx
+++ b/pages/community/index.tsx
@@ -7,6 +7,7 @@ import Layout from "../../components/layout";
 import { getAllPostsForCommunity } from "../../lib/api";
 import Header from "../../components/header";
 import { getBreadcrumbListSchema, SITE_URL } from "../../lib/structured-data";
+import { REVALIDATE_CONTENT } from "../../lib/isr";
 
 export default function Community({ allPosts: { edges, pageInfo }, preview }) {
   const heroPost = edges[0]?.node;
@@ -70,6 +71,6 @@ export const getStaticProps: GetStaticProps = async ({ preview = false }) => {
 
   return {
     props: { allPosts, preview },
-    revalidate: 10,
+    revalidate: REVALIDATE_CONTENT,
   };
 };

--- a/pages/community/search.tsx
+++ b/pages/community/search.tsx
@@ -11,6 +11,7 @@ import { Post } from "../../types/post";
 import { HOME_OG_IMAGE_URL } from "../../lib/constants";
 import { getExcerpt } from "../../utils/excerpt"; // Importing from utils instead of inline
 import { getBreadcrumbListSchema, SITE_URL } from "../../lib/structured-data";
+import { REVALIDATE_CONTENT } from "../../lib/isr";
 
 export default function CommunitySearch({ allPosts }: { allPosts: { node: Post }[] }) {
   const router = useRouter();
@@ -112,6 +113,6 @@ export const getStaticProps = async () => {
   const allPosts = await getAllPostsForSearch(false);
   return {
     props: { allPosts },
-    revalidate: 60,
+    revalidate: REVALIDATE_CONTENT,
   };
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,6 +15,7 @@ import {
   getWebSiteSchema,
   SITE_URL,
 } from "../lib/structured-data";
+import { REVALIDATE_CONTENT } from "../lib/isr";
 // Canonical /blog title. Shared by Layout's `Title` prop (which Meta.tsx
 // turns into og:title / twitter:title) and the <Head><title>, so the
 // document title and social metadata can't drift apart.
@@ -109,6 +110,6 @@ export const getStaticProps: GetStaticProps = async ({ preview = false }) => {
           : allTehcnologyPosts.edges,
       preview,
     },
-    revalidate: 10,
+    revalidate: REVALIDATE_CONTENT,
   };
 };

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -7,6 +7,7 @@ import { getAllPostsForSearch } from "../lib/api"; // This now exists
 import { Post } from "../types/post";
 import { HOME_OG_IMAGE_URL } from "../lib/constants";
 import { getBreadcrumbListSchema, SITE_URL } from "../lib/structured-data";
+import { REVALIDATE_CONTENT } from "../lib/isr";
 
 export default function SearchPage({ allPosts }: { allPosts: { node: Post }[] }) {
   const router = useRouter();
@@ -57,6 +58,6 @@ export const getStaticProps = async () => {
   
   return {
     props: { allPosts },
-    revalidate: 60,
+    revalidate: REVALIDATE_CONTENT,
   };
 };

--- a/pages/tag/[slug].tsx
+++ b/pages/tag/[slug].tsx
@@ -8,6 +8,7 @@ import { getAllPostsFromTags, getAllTags } from "../../lib/api";
 import TagsStories from "../../components/TagsStories";
 import { useRouter } from "next/router";
 import { getBreadcrumbListSchema, SITE_URL } from "../../lib/structured-data";
+import { REVALIDATE_CONTENT, REVALIDATE_ERROR, REVALIDATE_NOT_FOUND } from "../../lib/isr";
 export default function PostByTags({ postsByTags, preview, tagSlug: tagSlugProp }) {
   const posts = postsByTags?.edges || [];
   const router = useRouter();
@@ -44,7 +45,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
   const paths = edgesAllTags.map((node) => `/tag/${node.name}`) || []; // Extract tag names from the nodes and create paths
   return {
     paths: paths,
-    fallback: true,
+    fallback: "blocking",
   };
 };
 
@@ -57,7 +58,7 @@ export const getStaticProps: GetStaticProps = async ({
   if (!paramSlug) {
     return {
       notFound: true,
-      revalidate: 60,
+      revalidate: REVALIDATE_NOT_FOUND,
     };
   }
 
@@ -69,13 +70,13 @@ export const getStaticProps: GetStaticProps = async ({
 
     return {
       props: { postsByTags: postsByTags || { edges: [] }, preview, tagSlug: slug },
-      revalidate: 10,
+      revalidate: REVALIDATE_CONTENT,
     };
   } catch (error) {
     console.error("tag/[slug] getStaticProps error:", error);
     return {
       notFound: true,
-      revalidate: 60,
+      revalidate: REVALIDATE_ERROR,
     };
   }
 };

--- a/pages/tag/index.tsx
+++ b/pages/tag/index.tsx
@@ -11,6 +11,7 @@ import { FaSearch } from 'react-icons/fa';
 import { useEffect, useRef } from "react";
 import { getIconComponentForTag } from "../../utils/tagIcons";
 import { getBreadcrumbListSchema, SITE_URL } from "../../lib/structured-data";
+import { REVALIDATE_CONTENT } from "../../lib/isr";
  
  export default function Tags({ edgesAllTags, preview }) {
    const [searchTerm, setSearchTerm] = useState("");
@@ -163,6 +164,6 @@ export const getStaticProps: GetStaticProps = async ({ preview = false }) => {
   const edgesAllTags = await getAllTags();
   return {
     props: { edgesAllTags, preview },
-    revalidate: 10,
+    revalidate: REVALIDATE_CONTENT,
   };
 };

--- a/pages/technology/[slug].tsx
+++ b/pages/technology/[slug].tsx
@@ -10,17 +10,18 @@ import Layout from "../../components/layout";
 import PostTitle from "../../components/post-title";
 import Tags from "../../components/tag";
 import {
-  getAllPostsForTechnology,
+  getAllSlugsForCategory,
   getMoreStoriesForSlugs,
   getPostAndMorePosts,
+  getReviewAuthors,
 } from "../../lib/api";
 import ContainerSlug from "../../components/containerSlug";
 import { useRef, useEffect } from "react";
 import { useScroll, useSpringValue } from "@react-spring/web";
-import { getReviewAuthorDetails } from "../../lib/api";
+import { REVALIDATE_CONTENT, REVALIDATE_ERROR, REVALIDATE_NOT_FOUND } from "../../lib/isr";
 import { calculateReadingTime } from "../../utils/calculateReadingTime";
 import dynamic from "next/dynamic";
-import { getRedirectSlug } from "../../config/redirect";
+import { getRedirectSlug, hasRedirect } from "../../config/redirect";
 import {
   getBlogPostingSchema,
   getBreadcrumbListSchema,
@@ -262,7 +263,7 @@ export const getStaticProps: GetStaticProps = async ({
   if (typeof slugParam !== "string") {
     return {
       notFound: true,
-      revalidate: 60,
+      revalidate: REVALIDATE_NOT_FOUND,
     };
   }
 
@@ -279,7 +280,7 @@ export const getStaticProps: GetStaticProps = async ({
     if (!data?.post) {
       return {
         notFound: true,
-        revalidate: 60,
+        revalidate: REVALIDATE_NOT_FOUND,
       };
     }
 
@@ -292,7 +293,7 @@ export const getStaticProps: GetStaticProps = async ({
     ) || [];
     if (!postCategories.includes("technology")) {
       // Post belongs to a different category — 301 redirect to preserve SEO signals.
-      // This only runs at ISR runtime (fallback: true), not during next build,
+      // This only runs at ISR runtime (fallback: "blocking"), not during next build,
       // because getStaticPaths only returns paths from the technology category query.
       const correctCategory = postCategories.find((c: string) =>
         ['community', 'technology'].includes(c)
@@ -307,15 +308,14 @@ export const getStaticProps: GetStaticProps = async ({
       }
       return {
         notFound: true,
-        revalidate: 60,
+        revalidate: REVALIDATE_NOT_FOUND,
       };
     }
 
     const moreStories = await getMoreStoriesForSlugs(data.post?.tags, data.post?.slug);
-    const authorDetails = await Promise.all([
-      getReviewAuthorDetails("neha"),
-      getReviewAuthorDetails("Jain"),
-    ]);
+    // Same two records for every post — memoized in lib/api so a build makes
+    // this request twice in total instead of twice per post.
+    const authorDetails = await getReviewAuthors();
 
     // If we resolved a redirect slug, send a proper 301 redirect response
     if (redirectSlug) {
@@ -334,24 +334,36 @@ export const getStaticProps: GetStaticProps = async ({
         posts: moreStories?.techMoreStories || { edges: [] },
         reviewAuthorDetails: authorDetails,
       },
-      revalidate: 10,
+      revalidate: REVALIDATE_CONTENT,
     };
   } catch (error) {
     console.error("technology/[slug] getStaticProps error:", error);
+    // WordPress failed, the post may well exist — retry soon rather than
+    // pinning a real post as a 404 for a day.
     return {
       notFound: true,
-      revalidate: 60,
+      revalidate: REVALIDATE_ERROR,
     };
   }
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const allPosts = await getAllPostsForTechnology(false);
-  const technologyPosts =
-    allPosts?.edges
-      ?.map(({ node }) => `/technology/${node?.slug}`) || [];
+  // getAllPostsForTechnology is capped at `first: 22`, so using it here left
+  // most posts un-prerendered and rendering on demand. Paginate for the full set.
+  const slugs = await getAllSlugsForCategory("technology");
+
   return {
-    paths: technologyPosts || [],
-    fallback: true,
+    // Slugs with a configured redirect must NOT be pre-rendered. getStaticProps
+    // returns `redirect` for them, and Next.js rejects that during prerendering
+    // ("`redirect` can not be returned from getStaticProps during prerendering").
+    // They were previously never hit at build time only because getStaticPaths
+    // was capped at 22 paths and happened to miss them. These URLs are already
+    // 301'd at the edge by vercel.json, so they never reach a function anyway.
+    paths: slugs.filter((slug) => !hasRedirect(slug)).map((slug) => `/technology/${slug}`),
+    // 'blocking' rather than true: `true` served an empty skeleton with a 200
+    // for any unknown slug (soft 404 for crawlers) before resolving. 'blocking'
+    // returns the correct status on the first request. Real posts are all
+    // pre-rendered above, so this path is only hit by new posts and bad URLs.
+    fallback: "blocking",
   };
 };

--- a/pages/technology/index.tsx
+++ b/pages/technology/index.tsx
@@ -8,6 +8,7 @@ import { getAllPostsForTechnology } from "../../lib/api";
 import Header from "../../components/header";
 import { getExcerpt } from "../../utils/excerpt";
 import { getBreadcrumbListSchema, SITE_URL } from "../../lib/structured-data";
+import { REVALIDATE_CONTENT, REVALIDATE_ERROR } from "../../lib/isr";
 
 export default function Index({ allPosts: { edges, pageInfo }, preview }) {
   console.log("tech posts: ", edges.length)
@@ -63,13 +64,13 @@ export const getStaticProps: GetStaticProps = async ({ preview = false }) => {
 
     return {
       props: { allPosts: allPosts ?? emptyData, preview },
-      revalidate: 10,
+      revalidate: REVALIDATE_CONTENT,
     };
   } catch (error) {
     console.error("technology/index getStaticProps error:", error);
     return {
       props: { allPosts: emptyData, preview },
-      revalidate: 60,
+      revalidate: REVALIDATE_ERROR,
     };
   }
 };

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,6 +26,14 @@ const GRAPHQL_API_URL = process.env.PLAYWRIGHT_GRAPHQL_URL || 'http://localhost:
 export default defineConfig({
   testDir: './tests',
 
+  // tests/lib/** are node:test unit tests, run by `npm run test:unit` — not
+  // Playwright specs. Playwright's default testMatch is
+  // `**/*.@(spec|test).?(c|m)[jt]s?(x)`, which matches *.test.ts, so without
+  // this Playwright imports them during collection. Importing a node:test file
+  // outside node's own runner EXECUTES it, leaking its console output and
+  // process.env mutations into the e2e run.
+  testIgnore: '**/lib/**',
+
   /* Output directory for test artifacts */
   outputDir: 'test-results',
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,12 +3,12 @@
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
     <loc>https://keploy.io/blog</loc>
-    <lastmod>2026-07-29</lastmod>
+    <lastmod>2026-07-31</lastmod>
     <priority>1.00</priority>
   </url>
   <url>
     <loc>https://keploy.io/blog/community</loc>
-    <lastmod>2026-07-29</lastmod>
+    <lastmod>2026-07-31</lastmod>
     <priority>0.80</priority>
   </url>
   <url>
@@ -822,6 +822,15 @@
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/01/Brown-Minimalist-Helping-Value-Business-Blog-Banner.png</image:loc>
       <image:title>Cannot Use Import Statement Outside a Module</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://keploy.io/blog/community/change-failure-rate</loc>
+    <lastmod>2026-07-31</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/07/Change-Failure-Rate-CFR-Formula-Benchmarks-Fixes-2026.webp</image:loc>
+      <image:title>Change Failure Rate (CFR): Formula, Benchmarks &amp; Fixes (2026)</image:title>
     </image:image>
   </url>
   <url>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1378,7 +1378,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/getting-started-with-microservices-testing</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/06/Getting-Started-with-Microservices-Testing.webp</image:loc>
@@ -3269,7 +3269,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/top-5-tools-for-performance-testing-boost-your-applications-speed</loc>
-    <lastmod>2026-07-13</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/10/performance-tools.webp</image:loc>
@@ -3799,7 +3799,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-is-a-flaky-test</loc>
-    <lastmod>2026-07-09</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/07/What-is-a-Flaky-Test.webp</image:loc>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,12 +3,12 @@
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
     <loc>https://keploy.io/blog</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-10</lastmod>
     <priority>1.00</priority>
   </url>
   <url>
     <loc>https://keploy.io/blog/community</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-10</lastmod>
     <priority>0.80</priority>
   </url>
   <url>
@@ -458,7 +458,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/api-testing-tools</loc>
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-08-10</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/06/api_testing_tools_featured_image_v2-scaled.webp</image:loc>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,12 +3,12 @@
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
     <loc>https://keploy.io/blog</loc>
-    <lastmod>2026-07-31</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <priority>1.00</priority>
   </url>
   <url>
     <loc>https://keploy.io/blog/community</loc>
-    <lastmod>2026-07-31</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <priority>0.80</priority>
   </url>
   <url>
@@ -1672,7 +1672,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/how-to-improve-dora-metrics</loc>
-    <lastmod>2026-07-06</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/06/Dora-Metrics-Benchmarks-Tools-Strategies.webp</image:loc>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -90,7 +90,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/7-principles-of-software-testing</loc>
-    <lastmod>2026-07-01</lastmod>
+    <lastmod>2026-08-12</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/05/Principles-of-Software-Testing.webp</image:loc>
@@ -2027,6 +2027,15 @@
     </image:image>
   </url>
   <url>
+    <loc>https://keploy.io/blog/community/maintenance-testing-guide</loc>
+    <lastmod>2026-08-12</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/08/Maintenance-Testing-Types-Challenges-Tools-2026.webp</image:loc>
+      <image:title>Maintenance Testing: Types, Challenges &amp; Tools (2026)</image:title>
+    </image:image>
+  </url>
+  <url>
     <loc>https://keploy.io/blog/community/manage-config-files-on-aws-s3</loc>
     <lastmod>2025-06-24</lastmod>
     <priority>0.70</priority>
@@ -2163,7 +2172,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/modified-condition-decision-coverage</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-08-12</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/11/Modified-Condition-Decision-Coverage.webp</image:loc>
@@ -2815,7 +2824,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/software-testing-basics</loc>
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-08-12</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/02/Software-Testing-Basics-Simplified-A-Guide-for-Beginners.webp</image:loc>
@@ -3037,7 +3046,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/test-data-management</loc>
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-08-12</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/04/ChatGPT-Image-May-27-2026-05_23_46-PM.webp</image:loc>
@@ -3117,7 +3126,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/testing-methodologies-in-software-testing</loc>
-    <lastmod>2026-07-20</lastmod>
+    <lastmod>2026-08-12</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/05/Testing-Methodologies-in-Software-Testing.webp</image:loc>
@@ -3458,7 +3467,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/uft-testing-guide</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-08-12</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/08/UFT-Testing.webp</image:loc>
@@ -3682,7 +3691,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/verification-vs-validation</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-08-12</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/12/Verification-vs-Validation-for-API-first-Software-Development.webp</image:loc>
@@ -4131,7 +4140,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-is-scripting</loc>
-    <lastmod>2025-06-18</lastmod>
+    <lastmod>2026-08-12</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/03/What-is-Scripting-1-e1742209007267.png</image:loc>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2815,7 +2815,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/software-testing-basics</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/02/Software-Testing-Basics-Simplified-A-Guide-for-Beginners.webp</image:loc>
@@ -3431,7 +3431,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/types-of-software-testing</loc>
-    <lastmod>2026-07-17</lastmod>
+    <lastmod>2026-08-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/02/Types-of-Software-Testing-Explained-2026-Guide.webp</image:loc>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3008,6 +3008,15 @@
     </image:image>
   </url>
   <url>
+    <loc>https://keploy.io/blog/community/test-automation-roi</loc>
+    <lastmod>2026-08-14</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/08/Test-Automation-ROI-Cover-Image.webp</image:loc>
+      <image:title>Test Automation ROI: Formula, Examples &amp; Benchmarks</image:title>
+    </image:image>
+  </url>
+  <url>
     <loc>https://keploy.io/blog/community/test-automation-tools</loc>
     <lastmod>2026-07-21</lastmod>
     <priority>0.70</priority>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,12 +3,12 @@
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
     <loc>https://keploy.io/blog</loc>
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-08-12</lastmod>
     <priority>1.00</priority>
   </url>
   <url>
     <loc>https://keploy.io/blog/community</loc>
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-08-12</lastmod>
     <priority>0.80</priority>
   </url>
   <url>
@@ -2592,7 +2592,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/sandbox-testing</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-12</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/05/What-Is-Sandbox-Testing.webp</image:loc>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,12 +3,12 @@
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
     <loc>https://keploy.io/blog</loc>
-    <lastmod>2026-07-28</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <priority>1.00</priority>
   </url>
   <url>
     <loc>https://keploy.io/blog/community</loc>
-    <lastmod>2026-07-28</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <priority>0.80</priority>
   </url>
   <url>
@@ -2037,7 +2037,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/mastering-api-test-automation-best-practices-and-tools</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-28</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/10/Mastering-API-Test-Automation-e1709840517552.webp</image:loc>
@@ -2242,7 +2242,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/paired-vs-unpaired-t-test</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/10/Paired-vs-Unpaired-Test.webp</image:loc>
@@ -2991,6 +2991,15 @@
     </image:image>
   </url>
   <url>
+    <loc>https://keploy.io/blog/community/test-bed-in-software-testing</loc>
+    <lastmod>2026-07-28</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/07/test-bed-banner1.png</image:loc>
+      <image:title>Test Bed in Software Testing: Meaning, Types &amp; Setup</image:title>
+    </image:image>
+  </url>
+  <url>
     <loc>https://keploy.io/blog/community/test-case-generation-for-faster-api-testing</loc>
     <lastmod>2026-07-16</lastmod>
     <priority>0.70</priority>
@@ -3189,7 +3198,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/top-10-open-source-automation-tools</loc>
-    <lastmod>2026-07-17</lastmod>
+    <lastmod>2026-07-28</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/12/Top-10-Open-Source-Automation-Tools-for-Modern-Software-Testing.webp</image:loc>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,12 +3,12 @@
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
     <loc>https://keploy.io/blog</loc>
-    <lastmod>2026-08-03</lastmod>
+    <lastmod>2026-08-05</lastmod>
     <priority>1.00</priority>
   </url>
   <url>
     <loc>https://keploy.io/blog/community</loc>
-    <lastmod>2026-08-03</lastmod>
+    <lastmod>2026-08-05</lastmod>
     <priority>0.80</priority>
   </url>
   <url>
@@ -2592,7 +2592,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/sandbox-testing</loc>
-    <lastmod>2026-08-03</lastmod>
+    <lastmod>2026-08-04</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/05/What-Is-Sandbox-Testing.webp</image:loc>
@@ -2641,6 +2641,15 @@
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/05/ChatGPT-Image-May-27-2026-05_14_26-PM.webp</image:loc>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://keploy.io/blog/community/shift-left-vs-shift-right-testing</loc>
+    <lastmod>2026-08-05</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/08/Shift-Left-vs-Shift-Right-Testing-Key-Differences-Use-Cases-2026.webp</image:loc>
+      <image:title>Shift Left vs Shift Right Testing: Key Differences &amp; Use Cases (2026)</image:title>
     </image:image>
   </url>
   <url>
@@ -2806,7 +2815,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/software-testing-basics</loc>
-    <lastmod>2026-07-21</lastmod>
+    <lastmod>2026-08-04</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/02/Software-Testing-Basics-Simplified-A-Guide-for-Beginners.webp</image:loc>
@@ -4167,7 +4176,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-is-test-automation</loc>
-    <lastmod>2026-06-09</lastmod>
+    <lastmod>2026-08-04</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/09/Test-Automation-Cover-Image.webp</image:loc>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,12 +3,12 @@
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
     <loc>https://keploy.io/blog</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-06</lastmod>
     <priority>1.00</priority>
   </url>
   <url>
     <loc>https://keploy.io/blog/community</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-06</lastmod>
     <priority>0.80</priority>
   </url>
   <url>
@@ -1672,7 +1672,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/how-to-improve-dora-metrics</loc>
-    <lastmod>2026-08-03</lastmod>
+    <lastmod>2026-08-06</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/06/Dora-Metrics-Benchmarks-Tools-Strategies.webp</image:loc>
@@ -2493,7 +2493,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/regression-testing-tools</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-08-06</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/05/Top-Regression-Testing-Tools-for-2026-Compared.png</image:loc>
@@ -3817,7 +3817,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-is-a-flaky-test</loc>
-    <lastmod>2026-07-29</lastmod>
+    <lastmod>2026-08-06</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/07/What-is-a-Flaky-Test.webp</image:loc>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,12 +3,12 @@
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
     <loc>https://keploy.io/blog</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <priority>1.00</priority>
   </url>
   <url>
     <loc>https://keploy.io/blog/community</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <priority>0.80</priority>
   </url>
   <url>
@@ -700,7 +700,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/black-box-testing-and-white-box-testing-a-complete-guide</loc>
-    <lastmod>2026-07-03</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/05/Black-box-Testing-and-White-Box-Testing.webp</image:loc>
@@ -1663,7 +1663,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/how-to-get-your-chatgpt-api-key</loc>
-    <lastmod>2025-11-27</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/06/How-to-get-your-ChatGPT-API-key.webp</image:loc>
@@ -1984,11 +1984,10 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/know-about-record-and-replay-testing</loc>
-    <lastmod>2026-06-08</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <priority>0.70</priority>
     <image:image>
-      <image:loc>https://wp.keploy.io/wp-content/uploads/2023/06/Know-about-Record-e1711083608287.webp</image:loc>
-      <image:title>Record and replay testing is an automated testing method. The tool records the user’s actions, then it replays them.</image:title>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2023/06/Frame-145-1-scaled.webp</image:loc>
     </image:image>
   </url>
   <url>
@@ -2601,7 +2600,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/sandbox-testing</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/05/What-Is-Sandbox-Testing.webp</image:loc>
@@ -4105,7 +4104,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-is-rapid-application-development</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/04/What-is-Rapid-Application-Development.webp</image:loc>
@@ -4185,10 +4184,11 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-is-test-automation</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/09/Test-Automation-Cover-Image.webp</image:loc>
+      <image:title>Test Automation in Software Testing</image:title>
     </image:image>
   </url>
   <url>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -682,7 +682,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/best-uat-testing-software-tools</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-08-10</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/06/UAT-Testing-Software-Top-Picks-That-Work-in-2026.webp</image:loc>
@@ -2010,7 +2010,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/levels-of-software-testing</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-08-10</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/07/levels-of-software-testing-feature.png</image:loc>
@@ -2815,7 +2815,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/software-testing-basics</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-10</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/02/Software-Testing-Basics-Simplified-A-Guide-for-Beginners.webp</image:loc>
@@ -3037,7 +3037,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/test-data-management</loc>
-    <lastmod>2026-05-27</lastmod>
+    <lastmod>2026-08-10</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/04/ChatGPT-Image-May-27-2026-05_23_46-PM.webp</image:loc>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2592,7 +2592,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/sandbox-testing</loc>
-    <lastmod>2026-07-14</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/05/What-Is-Sandbox-Testing.webp</image:loc>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-        xmlns:image="http://www.google.com/schemas/sitemap-image/0.9">
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
     <loc>https://keploy.io/blog</loc>
-    <lastmod>2026-04-15</lastmod>
+    <lastmod>2026-07-28</lastmod>
     <priority>1.00</priority>
   </url>
   <url>
     <loc>https://keploy.io/blog/community</loc>
-    <lastmod>2026-04-15</lastmod>
+    <lastmod>2026-07-28</lastmod>
     <priority>0.80</priority>
   </url>
   <url>
     <loc>https://keploy.io/blog/technology</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-07-02</lastmod>
     <priority>0.80</priority>
   </url>
   <url>
@@ -27,7 +27,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/10-unit-testing-best-practices</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/03/10-Essential-Unit-Testing-Best-Practices-for-Bug-Free-Code.jpg</image:loc>
@@ -45,7 +45,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/4-ways-to-accelerate-your-software-testing-life-cycle</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/07/4-Ways-to-Accelerate-e1710137625882.webp</image:loc>
@@ -54,7 +54,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/4-ways-to-write-comments-in-json</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/06/My-Banner-1-e1742200656969.png</image:loc>
@@ -63,7 +63,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/5-best-open-source-api-testing-tools-in-2025</loc>
-    <lastmod>2025-10-07</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/08/5-Best-Open-Source-API-Testing-Tools-in-2025.webp</image:loc>
@@ -81,15 +81,25 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/7-best-test-data-management-tools-in-2024</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-07-28</lastmod>
     <priority>0.70</priority>
     <image:image>
-      <image:loc>https://wp.keploy.io/wp-content/uploads/2024/07/My-Banner-e1721211434531.png</image:loc>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/07/Cover-Image-Test-Data-Management-Tools.webp</image:loc>
+      <image:title>Best Test Data Management Tools in 2026</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://keploy.io/blog/community/7-principles-of-software-testing</loc>
+    <lastmod>2026-07-01</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/05/Principles-of-Software-Testing.webp</image:loc>
+      <image:title>Principles of Software Testing</image:title>
     </image:image>
   </url>
   <url>
     <loc>https://keploy.io/blog/community/a-guide-for-observing-go-process-with-ebpf</loc>
-    <lastmod>2025-06-18</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/08/A-Guide-for-Observing-e1709887192629.webp</image:loc>
@@ -98,16 +108,16 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/a-guide-to-test-cases-in-software-testing</loc>
-    <lastmod>2026-03-02</lastmod>
+    <lastmod>2026-07-02</lastmod>
     <priority>0.70</priority>
     <image:image>
-      <image:loc>https://wp.keploy.io/wp-content/uploads/2024/08/A-Guide-to-Test-Cases-in-Software-Testing.webp</image:loc>
-      <image:title>Master software testing with our guide on writing effective test cases. Explore types, coverage, and edge cases to boost quality and reduce defects.</image:title>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2024/08/test-cases-in-software-testing-featured.webp</image:loc>
+      <image:title>Test cases in software testing guide covering types, examples and how to write test cases</image:title>
     </image:image>
   </url>
   <url>
     <loc>https://keploy.io/blog/community/a-guide-to-testing-react-components-with-jest-and-react-testing-library</loc>
-    <lastmod>2025-10-31</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/08/testing-react.webp</image:loc>
@@ -116,7 +126,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/a-guide-to-various-api-architectures</loc>
-    <lastmod>2025-08-19</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/06/A-Comprehensive-Guide-to-REST-API-e1711609260330.webp</image:loc>
@@ -134,7 +144,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/a-test-strategy-is-critical-for-your-project-success</loc>
-    <lastmod>2025-07-18</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/12/Test-Strategy.webp</image:loc>
@@ -161,7 +171,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/agile-vs-waterfall-methodology-guide</loc>
-    <lastmod>2025-12-04</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/12/Agile-vs-Waterfall-Choosing-the-Right-Approach-for-Your-Project.webp</image:loc>
@@ -188,7 +198,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/ai-code-checker</loc>
-    <lastmod>2025-09-04</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/05/88f7b145-5e7d-41fa-83d7-7c49e3d7367f.jpeg</image:loc>
@@ -215,7 +225,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/ai-for-coding</loc>
-    <lastmod>2025-12-01</lastmod>
+    <lastmod>2026-06-04</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/08/ai-for-coding-e1756188770536.webp</image:loc>
@@ -233,7 +243,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/ai-model-testing</loc>
-    <lastmod>2025-09-01</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/08/AI-Model-Testing.webp</image:loc>
@@ -242,7 +252,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/ai-powered-test-automation</loc>
-    <lastmod>2026-02-27</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/03/AI-powered-test-automation-e1742445888402.webp</image:loc>
@@ -269,16 +279,16 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/ai-test-generator</loc>
-    <lastmod>2026-04-08</lastmod>
+    <lastmod>2026-04-28</lastmod>
     <priority>0.70</priority>
     <image:image>
-      <image:loc>https://wp.keploy.io/wp-content/uploads/2025/08/AI-Test-Generator-for-APIs.webp</image:loc>
-      <image:title>AI Test Generator for APIs: How It Works and Why It Matters</image:title>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/04/Cover-Image-AI-Test-Case-Generator.webp</image:loc>
+      <image:title>AI Test Case Generator: Workflow &amp; Use Cases</image:title>
     </image:image>
   </url>
   <url>
     <loc>https://keploy.io/blog/community/ai-testing-prompt-engineering</loc>
-    <lastmod>2025-11-03</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/02/AI-Testing-Prompt-Engineering-e1740632841356.webp</image:loc>
@@ -287,7 +297,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/ai-testing-tools</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-04-28</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/08/best-ai-testing-tools-banner.webp</image:loc>
@@ -296,7 +306,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/all-about-api-testing-keploy</loc>
-    <lastmod>2025-08-27</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/11/All-about-API-testing-e1709285587703.webp</image:loc>
@@ -305,7 +315,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/all-about-load-testing-a-detailed-guide</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/10/load-testing.webp</image:loc>
@@ -314,7 +324,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/all-about-system-integration-testing-in-software-testing</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/01/All-about-System-Integration-Testing-e1705862897493.png</image:loc>
@@ -323,16 +333,16 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/alpha-vs-beta-testing</loc>
-    <lastmod>2025-03-31</lastmod>
+    <lastmod>2026-05-28</lastmod>
     <priority>0.70</priority>
     <image:image>
-      <image:loc>https://wp.keploy.io/wp-content/uploads/2025/03/Alpha-vs-Beta-Testing-e1743167807317.webp</image:loc>
-      <image:title>Alpha vs Beta Testing</image:title>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2025/03/featured-dark1-scaled.webp</image:loc>
+      <image:title>Alpha vs beta testing key differences and best practices guide for QA engineers - Keploy 2026</image:title>
     </image:image>
   </url>
   <url>
     <loc>https://keploy.io/blog/community/an-introduction-to-api-testing</loc>
-    <lastmod>2025-08-27</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2022/12/An-Introduction-To-API.webp</image:loc>
@@ -358,7 +368,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/api-automation-testing</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/12/API-Automation-Testing.webp</image:loc>
@@ -367,11 +377,20 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/api-automation-testing-pynt-keploy</loc>
-    <lastmod>2025-06-20</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/06/API-Automation-Testing-e1711026593111.webp</image:loc>
       <image:title>Pynt &amp; Keploy: API automated testing is critical for product quality and CI/CD processes. Unlike GUI tests, API tests can cope with short release cycles and frequent changes — without breaking the test outputs.</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://keploy.io/blog/community/api-design</loc>
+    <lastmod>2026-05-11</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/05/api-design-hero.webp</image:loc>
+      <image:title>api-design-hero</image:title>
     </image:image>
   </url>
   <url>
@@ -385,7 +404,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/api-functional-testing</loc>
-    <lastmod>2025-08-12</lastmod>
+    <lastmod>2026-04-28</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/08/A-Complete-Guide-to-API-Functional-Testing.webp</image:loc>
@@ -394,7 +413,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/api-integration-importance-and-best-practices</loc>
-    <lastmod>2026-04-02</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/06/My-Banner-2-e1718602640671.png</image:loc>
@@ -412,7 +431,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/api-security-testing-101</loc>
-    <lastmod>2025-07-04</lastmod>
+    <lastmod>2026-04-28</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/07/API-Security-Testing-101-scaled.webp</image:loc>
@@ -421,7 +440,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/api-testing-services</loc>
-    <lastmod>2026-04-06</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/04/api-testing-services.webp</image:loc>
@@ -430,7 +449,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/api-testing-strategies</loc>
-    <lastmod>2026-04-08</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/04/API-Testing-Strategies-1.webp</image:loc>
@@ -438,8 +457,17 @@
     </image:image>
   </url>
   <url>
+    <loc>https://keploy.io/blog/community/api-testing-tools</loc>
+    <lastmod>2026-07-16</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/06/api_testing_tools_featured_image_v2-scaled.webp</image:loc>
+      <image:title>API testing tools comparison guide for developers in 2026</image:title>
+    </image:image>
+  </url>
+  <url>
     <loc>https://keploy.io/blog/community/apis-vs-webhooks-make-a-github-webhook</loc>
-    <lastmod>2025-07-18</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/06/APIs-vs-Webhooks-e1711953980579.webp</image:loc>
@@ -448,7 +476,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/assertion-testing-techniques</loc>
-    <lastmod>2025-09-23</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/03/assertions.jpg</image:loc>
@@ -462,6 +490,24 @@
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/02/Automate-Testing-on-BitBucket-for-Golang-CRUD-App-with-Docker-e1740557583999.webp</image:loc>
       <image:title>Learn how to set up automated testing on Bitbucket for a Golang CRUD app using Docker, Docker Compose, and CI/CD for efficient DevOps workflows.</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://keploy.io/blog/community/automated-regression-testing</loc>
+    <lastmod>2026-06-22</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/04/Cover-Image-Automated-Regression-Testing.webp</image:loc>
+      <image:title>Automated Regression Testing - A Modern Perspective</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://keploy.io/blog/community/automated-software-testing-tools</loc>
+    <lastmod>2026-07-17</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/06/Automated-Software-Testing-Tools-Cover-Image.webp</image:loc>
+      <image:title>Automated Software Testing Tools</image:title>
     </image:image>
   </url>
   <url>
@@ -484,7 +530,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/bdd-testing-with-cucumber</loc>
-    <lastmod>2025-06-18</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/01/BDD-Testing-with-Cucumber-js-e1705779818445.webp</image:loc>
@@ -493,7 +539,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/benchmark-testing-in-software-the-key-to-optimizing-performance</loc>
-    <lastmod>2025-07-31</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/10/Benchmark-Testing.webp</image:loc>
@@ -502,7 +548,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/benefits-of-test-automation</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-06-09</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/03/Benefits-of-Test-Automation-That-Improve-Release-Confidence-1.png</image:loc>
@@ -510,7 +556,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/best-ai-coding-assistant-for-beginners-and-experts</loc>
-    <lastmod>2025-09-04</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/05/Best-AI-Coding-Assistant-for-Beginners-and-Experts.webp</image:loc>
@@ -519,7 +565,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/best-ai-coding-tools-in-2025-for-developers</loc>
-    <lastmod>2025-09-09</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/01/Best-AI-Coding-Tools-in-2025-for-Developers.webp</image:loc>
@@ -546,7 +592,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/best-ci-tools-to-streamline-your-testing-workflow</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/01/Best-CI-Tools-to-Streamline-Your-Testing-Workflow.webp</image:loc>
@@ -564,7 +610,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/best-devops-automation-tools-in-2025</loc>
-    <lastmod>2025-12-26</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/08/Best-DevOps-Automation-Tools-in-2025.webp</image:loc>
@@ -582,7 +628,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/best-free-code-testing-tools-for-web-software-developers</loc>
-    <lastmod>2025-04-01</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/04/Best-Free-Code-Tester-Tools-for-Web-Software-Developers-e1743492106855.webp</image:loc>
@@ -600,16 +646,16 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/best-open-source-test-management-tools</loc>
-    <lastmod>2025-11-26</lastmod>
+    <lastmod>2026-07-16</lastmod>
     <priority>0.70</priority>
     <image:image>
-      <image:loc>https://wp.keploy.io/wp-content/uploads/2025/09/Best-Open-Source-Test-Management-Tools-Their-Features.webp</image:loc>
-      <image:title>Best Open Source Test Management Tools &amp; Their Features</image:title>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/06/Open-Source-Test-Management-Tools-in-2026.webp</image:loc>
+      <image:title>Best Open Source Test Management Tools in 2026</image:title>
     </image:image>
   </url>
   <url>
     <loc>https://keploy.io/blog/community/best-opensource-coding-ai</loc>
-    <lastmod>2025-07-22</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/04/Best-OpenSource-Coding-AI-e1744953387281.webp</image:loc>
@@ -635,6 +681,15 @@
     </image:image>
   </url>
   <url>
+    <loc>https://keploy.io/blog/community/best-uat-testing-software-tools</loc>
+    <lastmod>2026-06-30</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/06/UAT-Testing-Software-Top-Picks-That-Work-in-2026.webp</image:loc>
+      <image:title>UAT Testing Software: Top Picks That Work in 2026</image:title>
+    </image:image>
+  </url>
+  <url>
     <loc>https://keploy.io/blog/community/beta-testing-guide</loc>
     <lastmod>2025-12-30</lastmod>
     <priority>0.70</priority>
@@ -645,16 +700,25 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/black-box-testing-and-white-box-testing-a-complete-guide</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-07-03</lastmod>
     <priority>0.70</priority>
     <image:image>
-      <image:loc>https://wp.keploy.io/wp-content/uploads/2025/01/Black-Box-Testing-and-White-Box-Testing.webp</image:loc>
-      <image:title>Black Box Testing and White Box Testing</image:title>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/05/Black-box-Testing-and-White-Box-Testing.webp</image:loc>
+      <image:title>Black box Testing and White Box Testing</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://keploy.io/blog/community/black-box-testing-techniques</loc>
+    <lastmod>2026-07-03</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/07/Black-Box-Testing-Techniques-A-Practical-Guide-2026.webp</image:loc>
+      <image:title>Black Box Testing Techniques: A Practical Guide (2026)</image:title>
     </image:image>
   </url>
   <url>
     <loc>https://keploy.io/blog/community/boost-unit-test-efficiency-using-ai-powered-extensions-for-vs-code</loc>
-    <lastmod>2025-07-16</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/12/ai-unit-test.webp</image:loc>
@@ -672,11 +736,20 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/bug-bashing-guide</loc>
-    <lastmod>2025-12-10</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/12/Bug-Bashing.webp</image:loc>
       <image:title>Bug Bashing</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://keploy.io/blog/community/bug-life-cycle</loc>
+    <lastmod>2026-07-08</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/07/bug-life-cycle-featured11.webp</image:loc>
+      <image:title>Bug life cycle in software testing featured image showing defect workflow stages</image:title>
     </image:image>
   </url>
   <url>
@@ -708,7 +781,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/building-a-crud-application-from-scratch-using-golang</loc>
-    <lastmod>2025-07-03</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/06/Building-a-GO-CRUD-Rest-API-from-scratch-1-e1710438485136.webp</image:loc>
@@ -726,7 +799,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/building-reliable-ai-writing-tools-lessons-from-developing-textero</loc>
-    <lastmod>2026-02-17</lastmod>
+    <lastmod>2026-07-20</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/02/ChatGPT-Image-Feb-17-2026-03_48_23-PM.png</image:loc>
@@ -735,7 +808,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/canary-testing-a-comprehensive-guide-for-developers</loc>
-    <lastmod>2025-10-03</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/02/Canary-Testing-e1708416778307.webp</image:loc>
@@ -753,7 +826,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/chaos-testing-explained-a-comprehensive-guide</loc>
-    <lastmod>2025-01-09</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/01/Chaos-Testing.webp</image:loc>
@@ -779,6 +852,15 @@
     </image:image>
   </url>
   <url>
+    <loc>https://keploy.io/blog/community/ci-cd-testing-guide</loc>
+    <lastmod>2026-07-10</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/07/CICD-Testing-Complete-Guide-to-Continuous-Testing.webp</image:loc>
+      <image:title>CI/CD Testing: Complete Guide to Continuous Testing (2026)</image:title>
+    </image:image>
+  </url>
+  <url>
     <loc>https://keploy.io/blog/community/cline-vs-cursor-ai-coding-tools-comparison</loc>
     <lastmod>2025-07-16</lastmod>
     <priority>0.70</priority>
@@ -789,7 +871,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/code-integrity-explained-building-trust-in-software</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/08/Code-Integrity-Explained-e1706078363557.webp</image:loc>
@@ -807,7 +889,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/codium-vs-copilot-which-ai-coding-assistant-is-best-for-you</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/04/Codium-vs-Copilot.webp</image:loc>
@@ -816,7 +898,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/comparing-github-copilot-vs-chatgpt-for-unit-testing</loc>
-    <lastmod>2025-07-03</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/12/ChatGPT-and-GitHub-Copilot.webp</image:loc>
@@ -825,7 +907,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/complete-guide-to-ci-testing</loc>
-    <lastmod>2025-12-15</lastmod>
+    <lastmod>2026-07-16</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/12/A-Complete-Guide-to-CI-Testing-Benefits-Tools-Workflow.webp</image:loc>
@@ -860,7 +942,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/connecting-a-hosted-ui-website-to-an-aws-ec2-instance</loc>
-    <lastmod>2025-05-14</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/04/How-to-Change-Your-AWS-EC2-Instance-Type-for-a-Seamless-Hosted-UI-to-Backend-Integration.jpg</image:loc>
@@ -868,11 +950,20 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/continuous-ui-testing-pipeline-browserstack-with-github-actions</loc>
-    <lastmod>2024-12-25</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/12/UI-Testing.webp</image:loc>
       <image:title>ui testing</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://keploy.io/blog/community/contract-testing-tools</loc>
+    <lastmod>2026-07-09</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/07/12-Best-Contract-Testing-Tools-in-2026.webp</image:loc>
+      <image:title>12 Best Contract Testing Tools in 2026</image:title>
     </image:image>
   </url>
   <url>
@@ -893,7 +984,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/creating-the-balance-between-end-to-end-and-unit-testing</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/12/Creating-the-Balance-e1709193664986.webp</image:loc>
@@ -902,7 +993,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/cross-browser-testing-a-complete-guide</loc>
-    <lastmod>2025-07-02</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/07/Cross-Browser-Testing.webp</image:loc>
@@ -956,7 +1047,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/decoding-http2-traffic-is-hard-but-ebpf-can-help</loc>
-    <lastmod>2023-12-15</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/12/Simple-Technology-Blog-Banner.png</image:loc>
@@ -965,7 +1056,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/defect-management-in-software-testing</loc>
-    <lastmod>2025-07-23</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/06/Defect-Management-in-Software-Testing.webp</image:loc>
@@ -974,11 +1065,20 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/demystifying-cron-job-testing</loc>
-    <lastmod>2025-06-18</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/02/Demystifying-Cron-Job-Testing-e1706869354805.webp</image:loc>
       <image:title>The importance of cron job testing is beyond description. Ensure your automated tasks run flawlessly with proper cron job testing procedures.</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://keploy.io/blog/community/deployment-strategies</loc>
+    <lastmod>2026-06-26</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/06/Deployment-Strategies-Every-Developer-Should-Know.webp</image:loc>
+      <image:title>Deployment Strategies Every Developer Should Know</image:title>
     </image:image>
   </url>
   <url>
@@ -1000,7 +1100,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/devrel-at-keploy-experience-2</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2022/06/DevRel-at-Keploy - Experience-e1712564447236.webp</image:loc>
@@ -1018,7 +1118,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/difficulties-of-api-testing</loc>
-    <lastmod>2025-08-27</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2022/06/Difficulties-of-API-Testing-e1711957945545.webp</image:loc>
@@ -1027,7 +1127,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/dignify-your-test-automation-with-concise-code-documentation</loc>
-    <lastmod>2026-02-27</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/01/Dignify-Your-Test-Automation-with-Concise-Code-Documentation.webp</image:loc>
@@ -1036,7 +1136,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/diverse-test-data-boosting-regression-testing-efficiency</loc>
-    <lastmod>2026-03-02</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/06/Diverse-Test-Data-e1710398063194.webp</image:loc>
@@ -1063,7 +1163,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/ebpf-for-tls-traffic-tracing-secure-efficient-observability</loc>
-    <lastmod>2025-07-16</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/01/eBPF-for-TLS-Traffic-Tracing.webp</image:loc>
@@ -1081,7 +1181,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/end-to-end-testing-guide</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/09/A-Complete-Guide-to-End-to-End-Testing-with-Keploy.webp</image:loc>
@@ -1090,7 +1190,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/essential-free-api-testing-tools-every-developer-should-know</loc>
-    <lastmod>2025-10-24</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/10/My-Banner-3.png</image:loc>
@@ -1099,7 +1199,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/essential-functional-testing-tools-for-mobile-development</loc>
-    <lastmod>2025-01-13</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/01/mobile.webp</image:loc>
@@ -1117,7 +1217,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/everything-you-need-to-know-about-unit-testing</loc>
-    <lastmod>2025-07-01</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2022/12/Everything-You-Need.webp</image:loc>
@@ -1125,7 +1225,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/executing-ebpf-in-github-actions</loc>
-    <lastmod>2025-06-25</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/04/Executing-EBPF-in-Github-Actions.webp</image:loc>
@@ -1143,7 +1243,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/exploring-cypress-and-keploy-streamlining-test-automation</loc>
-    <lastmod>2026-02-27</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/05/Exploring-Cypress-and-Keploy.webp</image:loc>
@@ -1161,7 +1261,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/exploring-graphql-api-development</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/06/Exploring-GraphQL-e1710484822335.webp</image:loc>
@@ -1170,7 +1270,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/exploring-the-effectiveness-of-e2e-testing-in-comparison-with-integration-testing</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/12/Exploring-the-Effectiveness-of-E2E-Testing-e1706774363181.webp</image:loc>
@@ -1188,7 +1288,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/faster-testing-guide</loc>
-    <lastmod>2026-01-09</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/01/Faster-Testing-How-Modern-Teams-Ship-High-Quality-Software-Quickly.webp</image:loc>
@@ -1197,7 +1297,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/frustrations-of-api-testing</loc>
-    <lastmod>2025-08-27</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2022/08/Frustrations-of-API-Testing-e1712046485653.webp</image:loc>
@@ -1206,7 +1306,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/fun-facts-about-apis</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/06/Fun-Facts-About-APIs-e1711948422583.webp</image:loc>
@@ -1215,11 +1315,11 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/functional-testing-an-in-depth-overview</loc>
-    <lastmod>2026-02-17</lastmod>
+    <lastmod>2026-06-30</lastmod>
     <priority>0.70</priority>
     <image:image>
-      <image:loc>https://wp.keploy.io/wp-content/uploads/2024/11/Functional-Testing.webp</image:loc>
-      <image:title>Functional Testing: An in-depth overview</image:title>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2024/11/ChatGPT-Image-Jun-30-2026-05_08_45-PM.webp</image:loc>
+      <image:title>Functional testing illustration showing software feature validation across web and mobile applications with automated test checklist, UI verification, and quality assurance workflow</image:title>
     </image:image>
   </url>
   <url>
@@ -1260,7 +1360,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/generative-ai-testing-tools</loc>
-    <lastmod>2025-12-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/12/Generative-AI-Testing-Tools-The-Next-Evolution-of-Test-Automation.webp</image:loc>
@@ -1269,7 +1369,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/getting-started-with-keploy</loc>
-    <lastmod>2025-07-03</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/10/Getting-Started-with-Keploy-e1709834931653.webp</image:loc>
@@ -1278,7 +1378,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/getting-started-with-microservices-testing</loc>
-    <lastmod>2025-06-27</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/06/Getting-Started-with-Microservices-Testing.webp</image:loc>
@@ -1296,7 +1396,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/github-copilot-for-software-testing</loc>
-    <lastmod>2026-01-21</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/01/How-to-Use-Copilot-in-Software-Testing-A-Practical-Guide-for-Testers-scaled-e1768987600200.webp</image:loc>
@@ -1350,7 +1450,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/guide-to-automated-testing-tools-in-2025</loc>
-    <lastmod>2026-04-15</lastmod>
+    <lastmod>2026-04-28</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/05/Guide-to-Automated-Testing-Tools-in-2025.webp</image:loc>
@@ -1395,7 +1495,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/how-cicd-is-changing-the-future-of-software-development</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/03/How-CICD-is-Changing-the-Future-of-Software-Development-e1741588628556.webp</image:loc>
@@ -1404,7 +1504,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/how-did-i-get-to-know-about-apis</loc>
-    <lastmod>2024-11-20</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2022/06/How-did-I-get-to.webp</image:loc>
@@ -1430,7 +1530,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/how-i-simulated-a-response-from-a-third-party-app</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/04/How-I-simulate-a-response-from-a-Third-Party-e1714026688253.webp</image:loc>
@@ -1447,7 +1547,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/how-to-check-network-latency</loc>
-    <lastmod>2025-09-17</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/09/How-to-Check-Network-Latency.png</image:loc>
@@ -1456,7 +1556,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/how-to-choose-your-api-performance-testing-tool-a-guide</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/01/API-Performance-testing-e1705516202665.webp</image:loc>
@@ -1474,7 +1574,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/how-to-compare-two-json-files</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/06/My-Banner-3.png</image:loc>
@@ -1492,7 +1592,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/how-to-create-a-pandas-pivot-table-in-python</loc>
-    <lastmod>2025-07-09</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/07/How-to-Create-a-Pandas-Pivot-Table-in-Python.webp</image:loc>
@@ -1527,7 +1627,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/how-to-download-and-install-intellij-idea-community-edition</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/03/intellij.jpg</image:loc>
@@ -1545,7 +1645,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/how-to-generate-test-cases-with-automation-tools</loc>
-    <lastmod>2025-10-31</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/11/How-to-Generate-Test-Cases-e1709842279536.webp</image:loc>
@@ -1563,11 +1663,11 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/how-to-improve-dora-metrics</loc>
-    <lastmod>2026-03-25</lastmod>
+    <lastmod>2026-07-06</lastmod>
     <priority>0.70</priority>
     <image:image>
-      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/01/How-to-Improve-DORA-Metrics-in-Modern-DevOps-Pipelines.webp</image:loc>
-      <image:title>dora metrics</image:title>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/06/Dora-Metrics-Benchmarks-Tools-Strategies.webp</image:loc>
+      <image:title>Dora Metrics: Benchmarks, Tools &amp; Strategies to Improve</image:title>
     </image:image>
   </url>
   <url>
@@ -1598,7 +1698,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/how-to-run-pytest-program</loc>
-    <lastmod>2025-05-08</lastmod>
+    <lastmod>2026-04-28</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/05/How-to-Run-Pytest-Program.webp</image:loc>
@@ -1669,7 +1769,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/how-to-use-junit-on-vs-code-a-comprehensive-guide</loc>
-    <lastmod>2025-07-29</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/01/How-to-Use-JUnit-on-VS-Code.webp</image:loc>
@@ -1695,6 +1795,15 @@
     </image:image>
   </url>
   <url>
+    <loc>https://keploy.io/blog/community/in-depth-testing</loc>
+    <lastmod>2026-06-02</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/06/In-Depth-Testing-Stop-Shipping-Bugs-Your-Tests-Missed.webp</image:loc>
+      <image:title>In-Depth Testing: Stop Shipping Bugs Your Tests Missed</image:title>
+    </image:image>
+  </url>
+  <url>
     <loc>https://keploy.io/blog/community/infrastructure-automation-future</loc>
     <lastmod>2025-12-23</lastmod>
     <priority>0.70</priority>
@@ -1714,10 +1823,11 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/integration-testing-a-comprehensive-guide</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <priority>0.70</priority>
     <image:image>
-      <image:loc>https://wp.keploy.io/wp-content/uploads/2025/07/ChatGPT-Image-Sep-3-2025-03_48_37-PM.webp</image:loc>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2025/07/ChatGPT-Image-Jun-30-2026-04_35_54-PM.webp</image:loc>
+      <image:title>Integration testing illustration showing APIs, frontend, backend services, databases, and microservices connected to validate communication and data flow</image:title>
     </image:image>
   </url>
   <url>
@@ -1731,7 +1841,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/introduction-to-database-testing</loc>
-    <lastmod>2025-09-15</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/09/Introduction-to-Database-testing.webp</image:loc>
@@ -1758,7 +1868,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/introduction-to-selenium-software-testing</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/08/Introduction-To-Selenium-Software-Testing.webp</image:loc>
@@ -1767,7 +1877,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/introduction-to-shift-left-testing</loc>
-    <lastmod>2025-09-04</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/08/Shift-Left-Testing-e1722919942749.webp</image:loc>
@@ -1785,7 +1895,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/is-your-copilot-ai-slow-heres-what-you-can-do</loc>
-    <lastmod>2025-03-12</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/03/copilot.jpg</image:loc>
@@ -1856,7 +1966,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/key-extraction-by-uprobe-attachment-on-openssl-for-ssl-inspection</loc>
-    <lastmod>2025-04-11</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/04/ChatGPT-Image-Apr-11-2025-10_45_18-AM.png</image:loc>
@@ -1865,7 +1975,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/know-about-record-and-replay-testing</loc>
-    <lastmod>2025-07-16</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/06/Know-about-Record-e1711083608287.webp</image:loc>
@@ -1890,8 +2000,17 @@
     </image:image>
   </url>
   <url>
+    <loc>https://keploy.io/blog/community/levels-of-software-testing</loc>
+    <lastmod>2026-07-02</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/07/levels-of-software-testing-feature.png</image:loc>
+      <image:title>Level of software testing</image:title>
+    </image:image>
+  </url>
+  <url>
     <loc>https://keploy.io/blog/community/llm-txt-generator</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/06/LLM-TXT-Generator-e1749093741167.webp</image:loc>
@@ -1918,7 +2037,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/mastering-api-test-automation-best-practices-and-tools</loc>
-    <lastmod>2026-01-13</lastmod>
+    <lastmod>2026-07-23</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/10/Mastering-API-Test-Automation-e1709840517552.webp</image:loc>
@@ -1927,7 +2046,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/mastering-mcp-to-a2a</loc>
-    <lastmod>2025-09-25</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/05/MCP-A2A-Guide-for-Developers.webp</image:loc>
@@ -1945,7 +2064,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/mastering-node-js-backend-testing-with-mocha-and-chai</loc>
-    <lastmod>2025-06-18</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/10/Node.js-Backend-Testing.webp</image:loc>
@@ -1954,7 +2073,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/mastering-stress-testing-breaking-systems-to-build-better-ones</loc>
-    <lastmod>2024-12-23</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/12/Stress-Testing.webp</image:loc>
@@ -1963,7 +2082,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/mastering-test-coverage-quality-over-quantity-in-software-testing</loc>
-    <lastmod>2025-07-03</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/11/Mastering-Test-Coverage-e1709278854282.webp</image:loc>
@@ -1972,7 +2091,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/mastering-the-redo-shortcut-key-a-guide-for-efficient-workflows</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-06-19</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/12/keploy_92635_redo_shortcut_key_add_tech_guy_using_ctrl__Y_on__2c8fbd03-757f-4d7f-901d-83e060f45e2b_2.webp</image:loc>
@@ -1989,8 +2108,17 @@
     </image:image>
   </url>
   <url>
+    <loc>https://keploy.io/blog/community/mock-testing</loc>
+    <lastmod>2026-07-09</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/06/Mock-Testing-A-Complete-Guide-for-Developers-2026.webp</image:loc>
+      <image:title>Mock Testing</image:title>
+    </image:image>
+  </url>
+  <url>
     <loc>https://keploy.io/blog/community/mock-vs-stub-vs-fake-understand-the-difference</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/02/Mock-vs-Stub-vs-Fake-e1708339991637.webp</image:loc>
@@ -1999,7 +2127,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/mocking-httpx-requests-with-respx-a-comprehensive-guide</loc>
-    <lastmod>2025-06-18</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/03/How-to-mock-with-respx.png</image:loc>
@@ -2017,7 +2145,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/model-based-testing</loc>
-    <lastmod>2026-02-26</lastmod>
+    <lastmod>2026-07-01</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/12/Model-Based-Testing-Benefits-Use-Cases-Best-Practices.webp</image:loc>
@@ -2043,7 +2171,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/my-journey-of-automating-test-cases</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/06/My-journey-of-Automating-e1710746518795.webp</image:loc>
@@ -2061,7 +2189,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/my-journey-of-keploy-fellowship-program</loc>
-    <lastmod>2024-10-08</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2022/12/My-Journey-of-Keploy-e1711545090970.png</image:loc>
@@ -2070,7 +2198,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/my-keploy-api-fellowship-journey</loc>
-    <lastmod>2024-10-08</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2022/08/API-Fellowship-Journey-e1712312597509.png</image:loc>
@@ -2079,7 +2207,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/my-keploy-api-fellowship-journey-2</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2022/12/API-Fellowship-Journey.png</image:loc>
@@ -2087,7 +2215,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/no-code-api-testing-tools</loc>
-    <lastmod>2025-07-03</lastmod>
+    <lastmod>2026-07-01</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/01/No-Code-API-Testing-Frameworks.png</image:loc>
@@ -2096,7 +2224,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/open-source-load-testing-tools-for-devops</loc>
-    <lastmod>2025-11-26</lastmod>
+    <lastmod>2026-07-09</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/11/Open-Source-Load-Testing-Tools.webp</image:loc>
@@ -2132,7 +2260,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/performance-testing-guide-to-ensure-your-software-performs-at-its-best</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-07-20</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/01/performance-testing.webp</image:loc>
@@ -2159,7 +2287,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/playwright-vs-cypress-choosing-the-best-e2e-testing-framework</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/11/Playwright-vs-Cypress.webp</image:loc>
@@ -2168,7 +2296,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/playwright-vs-selenium</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/09/Playwright-vs-Selenium.webp</image:loc>
@@ -2177,7 +2305,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/podman-vs-docker</loc>
-    <lastmod>2025-07-22</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/03/Podman-vs-Docker-e1741159944866.webp</image:loc>
@@ -2186,7 +2314,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/postman-alternative</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/01/Postman-Alternative-The-Best-API-Testing-Tools-to-Use-in-2026.webp</image:loc>
@@ -2203,8 +2331,17 @@
     </image:image>
   </url>
   <url>
+    <loc>https://keploy.io/blog/community/production-testing</loc>
+    <lastmod>2026-06-05</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/05/Production-Testing-Methods-Best-Practices-Tools-2026.webp</image:loc>
+      <image:title>Production Testing Methods, Best Practices &amp; Tools (2026)</image:title>
+    </image:image>
+  </url>
+  <url>
     <loc>https://keploy.io/blog/community/prompt-engineering-for-python-code-generation-with-keploy</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/02/Prompt-Engineering-for-Python-Code-Generation-with-Keploy.webp</image:loc>
@@ -2222,7 +2359,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/python-automation-testing-guide</loc>
-    <lastmod>2025-09-16</lastmod>
+    <lastmod>2026-04-28</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/07/Python-Automation-Testing-Guide.webp</image:loc>
@@ -2249,7 +2386,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/python-testing-with-pytest-features-best-practices</loc>
-    <lastmod>2025-06-26</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/01/Python-Testing-with-Pytest.webp</image:loc>
@@ -2267,7 +2404,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/qa-automation-engineers-overcoming-testing-limitations</loc>
-    <lastmod>2025-06-20</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/09/QA-Automation-Engineers-1-e1706077706505.png</image:loc>
@@ -2284,7 +2421,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/quality-assurance-testing</loc>
-    <lastmod>2026-02-08</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/07/Quality-Assurance-Testing.webp</image:loc>
@@ -2302,7 +2439,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/react-devtools-complete</loc>
-    <lastmod>2025-08-04</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/08/React-DevTools.webp</image:loc>
@@ -2311,7 +2448,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/react-testing-on-vs-code</loc>
-    <lastmod>2025-03-11</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/03/React-Testing-on-VS-Code.webp</image:loc>
@@ -2328,8 +2465,17 @@
     </image:image>
   </url>
   <url>
+    <loc>https://keploy.io/blog/community/reduce-test-maintenance</loc>
+    <lastmod>2026-07-13</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/07/How-to-Reduce-Test-Maintenance-Without-Losing-Coverage.webp</image:loc>
+      <image:title>How to Reduce Test Maintenance Without Losing Coverage</image:title>
+    </image:image>
+  </url>
+  <url>
     <loc>https://keploy.io/blog/community/regression-testing-an-introductory-guide</loc>
-    <lastmod>2026-03-13</lastmod>
+    <lastmod>2026-06-15</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/03/Regression-Testing-Guide-Tools-Best-Practices.webp</image:loc>
@@ -2338,11 +2484,11 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/regression-testing-tools</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-07-22</lastmod>
     <priority>0.70</priority>
     <image:image>
-      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/02/Top-Regression-Testing-Tools-for-2026-Cover-Image.webp</image:loc>
-      <image:title>Regression Testing Tools for 2026</image:title>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/05/Top-Regression-Testing-Tools-for-2026-Compared.png</image:loc>
+      <image:title>Top Regression Testing Tools for 2026- Compared</image:title>
     </image:image>
   </url>
   <url>
@@ -2356,7 +2502,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/reliability-testing-a-complete-guide</loc>
-    <lastmod>2025-07-29</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/07/Reliability-Testing-A-Complete-Guide.webp</image:loc>
@@ -2383,7 +2529,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/rest-assured-alternatives-for-api-testing</loc>
-    <lastmod>2026-04-03</lastmod>
+    <lastmod>2026-06-10</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/03/Screenshot-2025-03-22-101148.png</image:loc>
@@ -2428,11 +2574,20 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/running-react-code-in-visual-studio-code-and-online</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/05/Running-React-Code-in-Visual-Studio-Code-and-Online.webp</image:loc>
       <image:title>Running React Code in Visual Studio Code and Online</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://keploy.io/blog/community/sandbox-testing</loc>
+    <lastmod>2026-07-14</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/05/What-Is-Sandbox-Testing.webp</image:loc>
+      <image:title>What Is Sandbox Testing</image:title>
     </image:image>
   </url>
   <url>
@@ -2455,7 +2610,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/securing-data-protocols-tls-application</loc>
-    <lastmod>2025-07-03</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/02/Exploring-the-World-of-Internet-Protocols-e1707141831979.webp</image:loc>
@@ -2464,11 +2619,19 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/security-testing-guide</loc>
-    <lastmod>2026-02-10</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/02/Security-Testing-Explained-Protecting-Modern-Applications-and-APIs.webp</image:loc>
       <image:title>Security Testing Explained Protecting Modern Applications and APIs</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://keploy.io/blog/community/self-healing-test-automation</loc>
+    <lastmod>2026-05-27</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/05/ChatGPT-Image-May-27-2026-05_14_26-PM.webp</image:loc>
     </image:image>
   </url>
   <url>
@@ -2482,7 +2645,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/simplifying-junit-test-stubs-and-mocking</loc>
-    <lastmod>2025-06-17</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/05/Simplifying-JUnit-Test-e1707855950424.webp</image:loc>
@@ -2490,7 +2653,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/smoke-testing-vs-regression-testing</loc>
-    <lastmod>2026-03-02</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/06/Smoke-Testing-vs-Regression-Testing.webp</image:loc>
@@ -2499,7 +2662,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/soap-api-testing</loc>
-    <lastmod>2025-09-14</lastmod>
+    <lastmod>2026-07-16</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/08/SOAP-API-Testing-Made-Simple.webp</image:loc>
@@ -2508,7 +2671,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/soap-vs-rest-choosing-the-right-api-protocol</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/06/SOAP-vs.-REST-e1711093088961.webp</image:loc>
@@ -2526,7 +2689,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/software-deployment</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-06-22</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/01/Software-Deployment-in-2026.webp</image:loc>
@@ -2544,7 +2707,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/software-development-phases</loc>
-    <lastmod>2024-10-08</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/10/Software-Development-Phases-e1709664592421.webp</image:loc>
@@ -2552,8 +2715,17 @@
     </image:image>
   </url>
   <url>
+    <loc>https://keploy.io/blog/community/software-development-tools</loc>
+    <lastmod>2026-07-16</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2025/05/Top-Software-Development-Tools-in-2025.webp</image:loc>
+      <image:title>Software Development Tools</image:title>
+    </image:image>
+  </url>
+  <url>
     <loc>https://keploy.io/blog/community/software-development-tools-in-2025</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-11</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/05/Top-Software-Development-Tools-in-2025.webp</image:loc>
@@ -2562,7 +2734,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/software-egg-explained</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/03/software-egg-e1742297354261.png</image:loc>
@@ -2571,7 +2743,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/software-quality-assurance-services</loc>
-    <lastmod>2025-10-03</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/10/Software-Quality-Assurance-Service.webp</image:loc>
@@ -2580,7 +2752,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/software-quality-assurance-tools</loc>
-    <lastmod>2026-02-08</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/01/Top-Advanced-Software-Quality-Assurance-Tools-for-Modern-Teams.webp</image:loc>
@@ -2589,7 +2761,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/software-quality-gates</loc>
-    <lastmod>2026-03-06</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/01/Software-Quality-Gates-How-Do-They-Work.webp</image:loc>
@@ -2598,11 +2770,20 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/software-regression-testing-services</loc>
-    <lastmod>2025-08-08</lastmod>
+    <lastmod>2026-06-12</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/08/Regression-Testing-Services-for-Teams.webp</image:loc>
       <image:title>Regression Testing Services</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://keploy.io/blog/community/software-release-life-cycle</loc>
+    <lastmod>2026-05-06</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/04/Software-Release-Life-Cycle.png</image:loc>
+      <image:title>Software Release Life Cycle: Process &amp; Best Practices</image:title>
     </image:image>
   </url>
   <url>
@@ -2616,7 +2797,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/software-testing-basics</loc>
-    <lastmod>2026-04-15</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/02/Software-Testing-Basics-Simplified-A-Guide-for-Beginners.webp</image:loc>
@@ -2625,7 +2806,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/software-testing-life-cycle</loc>
-    <lastmod>2026-03-18</lastmod>
+    <lastmod>2026-07-01</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/03/software-testing-life-cycle-1.webp</image:loc>
@@ -2634,7 +2815,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/software-testing-metrics-for-qa</loc>
-    <lastmod>2026-02-05</lastmod>
+    <lastmod>2026-07-01</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/11/How-to-Use-Software-Testing-Metrics-to-Drive-Better-QA-Decisions.webp</image:loc>
@@ -2643,7 +2824,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/software-testing-strategies</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/02/software-testing-Strategies.webp</image:loc>
@@ -2670,7 +2851,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/ssl-problem-unable-to-get-local-issuer-certificate</loc>
-    <lastmod>2025-10-02</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/06/Unable-to-get-Local-Issuer-Certificate.webp</image:loc>
@@ -2697,7 +2878,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/stateful-vs-stateless</loc>
-    <lastmod>2026-01-14</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/01/Stateful-vs-Stateless-A-Developers-Real-World-Guide-2026.webp</image:loc>
@@ -2706,7 +2887,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/strategies-handling-edge-cases-e2e-tests</loc>
-    <lastmod>2025-11-19</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/09/E2E-Testing-Strategies.webp</image:loc>
@@ -2758,7 +2939,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/system-testing-vs-integration-testing</loc>
-    <lastmod>2025-07-18</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/01/Keploy-banner-2.png</image:loc>
@@ -2767,7 +2948,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/teleport-into-tech-space-through-api-gateways</loc>
-    <lastmod>2025-06-20</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2022/08/Teleport-into-tech-space.webp</image:loc>
@@ -2775,7 +2956,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/terminologies-around-api</loc>
-    <lastmod>2024-10-08</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/03/Terminologies-Around-API-e1711959967703.webp</image:loc>
@@ -2784,7 +2965,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/test-automation-best-practices</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-06-09</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/03/Top-Test-Automation-Best-Practices-Every-Team-Should-Follow.webp</image:loc>
@@ -2793,7 +2974,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/test-automation-pricing-comparison</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/10/ChatGPT-Image-Oct-13-2025-12_53_18-PM.webp</image:loc>
@@ -2801,8 +2982,17 @@
     </image:image>
   </url>
   <url>
+    <loc>https://keploy.io/blog/community/test-automation-tools</loc>
+    <lastmod>2026-07-21</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/05/Best-Test-Automation-Tools-Comparison-Cover-Image.webp</image:loc>
+      <image:title>Best Test Automation Tools Comparison - Keploy</image:title>
+    </image:image>
+  </url>
+  <url>
     <loc>https://keploy.io/blog/community/test-case-generation-for-faster-api-testing</loc>
-    <lastmod>2025-10-24</lastmod>
+    <lastmod>2026-07-16</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/03/How-to-Automate-Test-Case-Generation-for-Faster-API-Testing-scaled-e1741956899445.webp</image:loc>
@@ -2820,16 +3010,16 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/test-data-management</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-05-27</lastmod>
     <priority>0.70</priority>
     <image:image>
-      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/04/Test-Data-Management-1.webp</image:loc>
-      <image:title>Test Data Management</image:title>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/04/ChatGPT-Image-May-27-2026-05_23_46-PM.webp</image:loc>
+      <image:title>Modern SaaS illustration of test data management in software testing showing a centralized data hub connected to API testing, databases, masked data, and automated provisioning workflows with Keploy logo.</image:title>
     </image:image>
   </url>
   <url>
     <loc>https://keploy.io/blog/community/test-data-management-best-practices</loc>
-    <lastmod>2025-12-22</lastmod>
+    <lastmod>2026-07-14</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/12/Efficient-Test-Data-Strategies-for-Testing.webp</image:loc>
@@ -2856,7 +3046,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/test-recorder-guide</loc>
-    <lastmod>2025-11-14</lastmod>
+    <lastmod>2026-07-02</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/11/Test-Recorder.webp</image:loc>
@@ -2882,7 +3072,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/testing-in-production-with-keploy</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/11/Exploring-Testing-in-Production-e1709277092461.webp</image:loc>
@@ -2891,7 +3081,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/testing-library-react-hooks</loc>
-    <lastmod>2025-08-06</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/08/Testing-Library-React-Hooks.webp</image:loc>
@@ -2900,7 +3090,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/testing-methodologies-in-software-testing</loc>
-    <lastmod>2026-04-14</lastmod>
+    <lastmod>2026-07-20</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/05/Testing-Methodologies-in-Software-Testing.webp</image:loc>
@@ -2936,7 +3126,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/testng-vs-junit-performance-ease-of-use-and-flexibility-compared</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/12/TestNG-vs-JUnit-e1707036217326.webp</image:loc>
@@ -2945,7 +3135,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/the-game-of-shadow-testing-the-core-of-test-generation</loc>
-    <lastmod>2025-06-18</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/06/The-Game-of-Shadow-Testing-e1711086649127.webp</image:loc>
@@ -2972,7 +3162,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/tools-for-software-unit-testing</loc>
-    <lastmod>2025-07-28</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/03/api-unit-test.webp</image:loc>
@@ -2981,7 +3171,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/top-10-ai-tools-transforming-software-quality-assurance</loc>
-    <lastmod>2025-10-29</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/02/Top-10-AI-Tools-Transforming-Software-Quality-Assurance-e1739359461637.webp</image:loc>
@@ -2990,7 +3180,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/top-10-futuristic-open-source-testing-tools</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/08/Top-10-Futuristic-Open-Source-Testing-Tools-for-Software-Testing.webp</image:loc>
@@ -2999,7 +3189,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/top-10-open-source-automation-tools</loc>
-    <lastmod>2026-02-18</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/12/Top-10-Open-Source-Automation-Tools-for-Modern-Software-Testing.webp</image:loc>
@@ -3043,7 +3233,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/top-5-cypress-alternatives-for-web-testing-and-automation</loc>
-    <lastmod>2026-04-03</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/01/top-5-Cypress-Alternatives-for-Web-Testing-and-Automation-1.webp</image:loc>
@@ -3070,7 +3260,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/top-5-tools-for-performance-testing-boost-your-applications-speed</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-07-13</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/10/performance-tools.webp</image:loc>
@@ -3079,11 +3269,11 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/top-7-test-automation-tools-boost-your-software-testing-efficiency</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <priority>0.70</priority>
     <image:image>
-      <image:loc>https://wp.keploy.io/wp-content/uploads/2024/09/Top-7-Test-Automation-Tools-e1725519797532.webp</image:loc>
-      <image:title>Explore top test automation tools and learn how to streamline your testing processes to elevate your software testing strategy by discovering the right tool</image:title>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/05/Best-Test-Automation-Tools-Comparison-Cover-Image.webp</image:loc>
+      <image:title>Best Test Automation Tools Comparison - Keploy</image:title>
     </image:image>
   </url>
   <url>
@@ -3133,7 +3323,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/top-integration-testing-tools</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-07-14</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/02/Top-10-Tools-for-Integration-Testing-in-2026.webp</image:loc>
@@ -3142,7 +3332,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/top-open-source-ai-agents</loc>
-    <lastmod>2025-10-18</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/02/Open-Source-AI-Agents-e1740037037444.webp</image:loc>
@@ -3160,7 +3350,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/top-test-automation-frameworks</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-07-20</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/02/Top-10-Test-Automation-Frameworks-in-2026-Compared.webp</image:loc>
@@ -3169,7 +3359,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/top-tools-for-static-analysis-in-python</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/03/Top-Tools-for-Static-Analysis-Help-in-Your-Python-Projects.webp</image:loc>
@@ -3178,11 +3368,20 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/tracing-tls-data-with-ethical-and-secure-practices</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/01/Tracing-TLS-Data-with-Ethical-and-Secure-Practices.webp</image:loc>
       <image:title>tracing tls</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://keploy.io/blog/community/types-of-api-testing</loc>
+    <lastmod>2026-04-17</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/04/api_testing_feature_image-e1776413750405.webp</image:loc>
+      <image:title>api_testing_feature_image</image:title>
     </image:image>
   </url>
   <url>
@@ -3205,7 +3404,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/types-of-software-testing</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/02/Types-of-Software-Testing-Explained-2026-Guide.webp</image:loc>
@@ -3232,7 +3431,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/uft-testing-guide</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-07-02</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/08/UFT-Testing.webp</image:loc>
@@ -3241,7 +3440,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/understand-the-role-of-continuous-testing-in-ci-cd</loc>
-    <lastmod>2025-06-20</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/02/The-Continuous-Testing-Way-e1707464129272.webp</image:loc>
@@ -3268,7 +3467,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/understanding-code-coverage-in-software-testing</loc>
-    <lastmod>2025-12-17</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/12/Code-Coverage-in-the-Software-Testing.webp</image:loc>
@@ -3295,7 +3494,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/understanding-http-and-https-as-a-beginner</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2022/06/Understanding-HTTP-and-HTTPS.webp</image:loc>
@@ -3321,7 +3520,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/understanding-statement-coverage-in-software-testing</loc>
-    <lastmod>2025-07-18</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/12/Understanding-Statement-Coverage-in-Software-Testing-1-e1709233614711.webp</image:loc>
@@ -3339,7 +3538,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/understanding-testing-in-production</loc>
-    <lastmod>2024-10-08</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/02/Understanding-Testing-in-production-e1707311923165.webp</image:loc>
@@ -3348,7 +3547,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/understanding-the-components-of-apis-2</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2022/06/Understanding-the-components-1-e1707137675544.webp</image:loc>
@@ -3357,7 +3556,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/understanding-the-difference-between-test-scenarios-and-test-cases</loc>
-    <lastmod>2025-10-31</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/09/Test-Scenarios-and-Test-Cases-e1709873337435.webp</image:loc>
@@ -3375,7 +3574,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/understanding-the-different-levels-of-the-software-testing-pyramid</loc>
-    <lastmod>2026-02-17</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/05/Understanding-the-different-levels-of-the-Software-Testing-Pyramid-1-e1721305001528.webp</image:loc>
@@ -3384,7 +3583,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/unit-testing-in-python</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/06/Unit-Testing-in-Python-is-way-more-convenient-than-youve-thought.webp</image:loc>
@@ -3393,7 +3592,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/unit-testing-vs-end-to-end-testing</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/02/Unit-Testing-vs.-End-to-End-Testing.webp</image:loc>
@@ -3411,7 +3610,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/unit-testing-vs-integration-testing-a-comprehensive-guide</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/12/Unit-Testing-vs-Integration-Testing.webp</image:loc>
@@ -3420,7 +3619,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/unit-testing-vs-regression-testing</loc>
-    <lastmod>2026-02-02</lastmod>
+    <lastmod>2026-04-20</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/06/Unit-Testing-vs-Regression-Testing.webp</image:loc>
@@ -3429,7 +3628,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/using-ebpf-for-tracing-go-function-arguments-in-production</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/06/Tracing-Go-Function-Argument-e1710138175467.webp</image:loc>
@@ -3438,7 +3637,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/using-grpc-error-codes</loc>
-    <lastmod>2025-08-30</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/08/Understanding-and-Using-gRPC-Error-Codes.webp</image:loc>
@@ -3456,7 +3655,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/verification-vs-validation</loc>
-    <lastmod>2026-02-18</lastmod>
+    <lastmod>2026-06-11</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/12/Verification-vs-Validation-for-API-first-Software-Development.webp</image:loc>
@@ -3491,6 +3690,15 @@
     </image:image>
   </url>
   <url>
+    <loc>https://keploy.io/blog/community/vibe-testing</loc>
+    <lastmod>2026-07-21</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/07/df4ce261-c29a-42ff-b5e5-bd517a7fc97e.webp</image:loc>
+      <image:title>What Is Vibe Testing? A Practical Guide for Developers</image:title>
+    </image:image>
+  </url>
+  <url>
     <loc>https://keploy.io/blog/community/visual-regression-testing</loc>
     <lastmod>2026-03-02</lastmod>
     <priority>0.70</priority>
@@ -3501,7 +3709,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/visual-scripting-guide</loc>
-    <lastmod>2025-08-27</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/08/Visual-Scripting.webp</image:loc>
@@ -3510,7 +3718,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/volume-testing-a-comprehensive-guide</loc>
-    <lastmod>2024-12-26</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/12/Volume-Testing.webp</image:loc>
@@ -3564,7 +3772,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-does-extensible-mean</loc>
-    <lastmod>2025-12-25</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/12/c2d15a64-4108-4214-a85f-e4a3b690.webp</image:loc>
@@ -3582,7 +3790,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-is-a-flaky-test</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-07-09</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/07/What-is-a-Flaky-Test.webp</image:loc>
@@ -3600,7 +3808,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-is-a-test-environment</loc>
-    <lastmod>2025-11-17</lastmod>
+    <lastmod>2026-07-02</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/11/20251117_1336_Testing-Setup_simple_compose_01ka8dhnnrfmdvh9sacv67yevf.webp</image:loc>
@@ -3609,7 +3817,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-is-a-test-script-in-software-testing</loc>
-    <lastmod>2025-11-24</lastmod>
+    <lastmod>2026-07-01</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/11/What-is-a-Test-Script-in-Software-Testing.webp</image:loc>
@@ -3627,7 +3835,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-is-acceptance-testing</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-04-23</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/09/Acceptance-Testing.webp</image:loc>
@@ -3663,7 +3871,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-is-an-api-endpoint</loc>
-    <lastmod>2025-11-03</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/11/What-Is-an-API-Endpoint.webp</image:loc>
@@ -3681,7 +3889,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-is-api-mocking</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/10/API-Mocking-Benefits-Tools-and-Guide.webp</image:loc>
@@ -3690,7 +3898,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-is-api-testing</loc>
-    <lastmod>2026-04-09</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/08/What-Is-API-Testing.webp</image:loc>
@@ -3753,7 +3961,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-is-delta-testing</loc>
-    <lastmod>2026-04-08</lastmod>
+    <lastmod>2026-04-22</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/01/What-Is-Delta-Testing-How-It-Works-Benefits-Best-Practices.webp</image:loc>
@@ -3771,7 +3979,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-is-grey-box-testing</loc>
-    <lastmod>2025-10-14</lastmod>
+    <lastmod>2026-04-23</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/10/what-is-grey-testing.webp</image:loc>
@@ -3798,7 +4006,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-is-low-code-and-no-code</loc>
-    <lastmod>2025-08-12</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/08/What-is-Low-code-and-No-code.webp</image:loc>
@@ -3812,6 +4020,15 @@
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/10/What-is-Monkey-Testing-in-Software-Testing.webp</image:loc>
       <image:title>What Is Monkey Testing In Software Testing? Types, Tools &amp; More</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://keploy.io/blog/community/what-is-mttr</loc>
+    <lastmod>2026-07-14</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/06/What-Is-MTTR-Definition-Formula-Benchmarks-2026.webp</image:loc>
+      <image:title>What Is MTTR</image:title>
     </image:image>
   </url>
   <url>
@@ -3869,7 +4086,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-is-sanity-testing</loc>
-    <lastmod>2025-09-08</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/09/Sanity-Testing.webp</image:loc>
@@ -3878,7 +4095,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-is-scenario-testing</loc>
-    <lastmod>2025-11-20</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/11/ChatGPT-Image-Nov-12-2025-03_02_58-PM.png</image:loc>
@@ -3896,7 +4113,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-is-service-mesh</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/01/eBPF-Service-Mesh-and-Sidecar-e1708633569650.webp</image:loc>
@@ -3914,7 +4131,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-is-spiral-model-in-software-engineering</loc>
-    <lastmod>2026-02-09</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/07/What-is-Spiral-Model-in-Software-Engineering.webp</image:loc>
@@ -3932,7 +4149,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-is-test-automation</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-06-09</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/09/Test-Automation-Cover-Image.webp</image:loc>
@@ -3940,7 +4157,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-is-test-planning</loc>
-    <lastmod>2026-04-15</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/02/What-is-Test-Planning-e1739267542953.webp</image:loc>
@@ -3958,7 +4175,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/what-is-unit-testing</loc>
-    <lastmod>2025-07-22</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/05/What-is-unit-testing-e1746507328551.png</image:loc>
@@ -4000,6 +4217,15 @@
     </image:image>
   </url>
   <url>
+    <loc>https://keploy.io/blog/community/white-box-testing</loc>
+    <lastmod>2026-06-16</lastmod>
+    <priority>0.70</priority>
+    <image:image>
+      <image:loc>https://wp.keploy.io/wp-content/uploads/2026/06/White-Box-Testing-Techniques-Examples-Best-Practices-2026.webp</image:loc>
+      <image:title>White Box Testing: Techniques, Examples &amp; Best Practices (2026)</image:title>
+    </image:image>
+  </url>
+  <url>
     <loc>https://keploy.io/blog/community/why-apps-crash-and-how-resilience-testing-can-help</loc>
     <lastmod>2025-09-03</lastmod>
     <priority>0.70</priority>
@@ -4010,7 +4236,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/why-developers-should-care-about-uat</loc>
-    <lastmod>2025-07-04</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2025/03/Why-Developers-Should-Care-About-UAT.webp</image:loc>
@@ -4019,7 +4245,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/why-do-i-need-a-unit-testing-tool</loc>
-    <lastmod>2025-06-20</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/01/Why-do-I-need-a-unit-testing-e1706090406688.webp</image:loc>
@@ -4028,7 +4254,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/why-i-love-end-to-end-e2e-testing</loc>
-    <lastmod>2025-11-19</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/11/Simple-Technology-Blog-Banner-1-e1709271109432.png</image:loc>
@@ -4037,7 +4263,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/why-i-switched-from-rest-assured-to-keploy-for-microservices-testing</loc>
-    <lastmod>2026-04-03</lastmod>
+    <lastmod>2026-04-28</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2026/01/Why-I-Switched-from-Rest-Assured-to-Keploy-for-Microservices-Testing.webp</image:loc>
@@ -4046,7 +4272,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/why-manual-testing-matters-a-ultimate-guide-to-software-testing</loc>
-    <lastmod>2026-03-20</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/09/Manual-Testing.webp</image:loc>
@@ -4063,7 +4289,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/write-clean-and-efficient-unit-tests-in-go</loc>
-    <lastmod>2025-06-18</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/04/Write-Clean-and-Efficient-Unit-Tests-in-Go-e1713346999614.webp</image:loc>
@@ -4080,7 +4306,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/community/writing-test-cases-for-cron-jobs-testing</loc>
-    <lastmod>2025-06-18</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/02/Writing-test-cases-for-Cron-Job-Testing-e1707744217899.webp</image:loc>
@@ -4107,7 +4333,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/technology/adding-colour-to-the-log-output-of-logging-libraries-in-go</loc>
-    <lastmod>2025-07-03</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/05/Adding-colour-to-the-log-output-of-logging-libraries-in-Go.webp</image:loc>
@@ -4115,7 +4341,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/technology/automated-e2e-tests-using-property-based-testing-part-ii</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-06-07</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/08/Automated-E2E-tests-using-e1709118384887.webp</image:loc>
@@ -4124,7 +4350,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/technology/automated-end-to-end-tests-using-property-based-testing-part-i</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-07-02</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/08/Automated-End-to-Part-I-e1709056278625.webp</image:loc>
@@ -4133,7 +4359,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/technology/bitbucket-self-hosting-running-ebpfprivileged-programs</loc>
-    <lastmod>2025-06-17</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/08/BitBucket-e1723016950468.webp</image:loc>
@@ -4151,7 +4377,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/technology/capture-grpc-traffic-going-out-from-a-server</loc>
-    <lastmod>2024-10-08</lastmod>
+    <lastmod>2026-06-07</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/11/Capture-gRPC-Traffic-going-out-from-a-Server-e1708513972680.webp</image:loc>
@@ -4221,7 +4447,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/technology/getting-code-coverage-data-for-each-request-coming-to-a-python-web-server</loc>
-    <lastmod>2025-06-20</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/04/Getting-code-coverage-e1713524276625.webp</image:loc>
@@ -4248,7 +4474,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/technology/how-to-test-traffic-with-a-custom-kubernetes-controller</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/12/How-to-Test-Traffic-with-a-Custom-Kubernetes-Controller.webp</image:loc>
@@ -4275,7 +4501,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/technology/integration-vs-e2e-testing-what-worked-for-me-as-a-charm</loc>
-    <lastmod>2025-11-19</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2023/09/Integration-vs-E2E-Testing-e1706171839573.webp</image:loc>
@@ -4292,7 +4518,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/technology/managing-go-processes</loc>
-    <lastmod>2024-10-08</lastmod>
+    <lastmod>2026-06-08</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/04/Managing-Go-Processes-e1714306695146.webp</image:loc>
@@ -4336,7 +4562,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/technology/playwright-alternative-for-api-testing</loc>
-    <lastmod>2025-06-19</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/12/Playwright-Alternative-for-API-Testing.webp</image:loc>
@@ -4363,7 +4589,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/technology/scram-authentication-overcoming-mock-testing-challenges</loc>
-    <lastmod>2025-06-18</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/05/SCRAM-Authentication-1.webp</image:loc>
@@ -4371,7 +4597,7 @@
   </url>
   <url>
     <loc>https://keploy.io/blog/technology/secure-your-database-communications-with-ssl-in-docker-containers-learn-to-set-up-ssl-for-mongodb-and-postgresql-efficiently</loc>
-    <lastmod>2025-06-17</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <priority>0.70</priority>
     <image:image>
       <image:loc>https://wp.keploy.io/wp-content/uploads/2024/11/Docker-Containers.webp</image:loc>

--- a/tests/lib/isr.test.ts
+++ b/tests/lib/isr.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for the ISR revalidation policy (lib/isr.ts).
+ *
+ * Run via: `npm run test:unit`
+ *
+ * These pin two things that fail *silently* in production if they drift:
+ *
+ *   1. BASE_PATH vs next.config.js. `res.revalidate(path)` does not look up a
+ *      route — on Vercel it performs a real `fetch('https://' + host + path)`.
+ *      If BASE_PATH stops matching the app's basePath, every webhook-driven
+ *      revalidation 404s, nothing regenerates, and the only symptom is content
+ *      going stale up to 24h later. Nothing else in the build catches this.
+ *
+ *   2. The TTL ordering. The whole point of the on-demand setup is that
+ *      content and not-found TTLs stay large; someone "fixing" perceived
+ *      staleness by dropping them back to 10/60s would quietly restore the
+ *      ~2,224 GB-Hrs/period regeneration bill.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import {
+  BASE_PATH,
+  postPath,
+  REVALIDATE_CONTENT,
+  REVALIDATE_ERROR,
+  REVALIDATE_NOT_FOUND,
+} from "../../lib/isr";
+
+// Read next.config.js as text rather than importing it: the config throws at
+// module load unless WORDPRESS_API_URL is set, which we don't want to require
+// just to assert a constant.
+function basePathFromNextConfig(): string {
+  const configPath = path.join(process.cwd(), "next.config.js");
+  const source = readFileSync(configPath, "utf8");
+  const match = source.match(/^\s*basePath:\s*['"]([^'"]+)['"]/m);
+  assert.ok(match, "could not find `basePath` in next.config.js");
+  return match![1];
+}
+
+test("BASE_PATH matches basePath in next.config.js", () => {
+  assert.equal(
+    BASE_PATH,
+    basePathFromNextConfig(),
+    "lib/isr.ts BASE_PATH has drifted from next.config.js — on-demand " +
+      "revalidation would silently 404 on every path"
+  );
+});
+
+test("postPath builds a public URL path including the basePath", () => {
+  assert.equal(postPath("community", "my-post"), `${BASE_PATH}/community/my-post`);
+  assert.equal(postPath("technology", "my-post"), `${BASE_PATH}/technology/my-post`);
+});
+
+test("postPath output is absolute — res.revalidate rejects relative paths", () => {
+  // Next throws "Invalid urlPath provided to revalidate()" for anything not
+  // starting with "/".
+  assert.ok(postPath("community", "x").startsWith("/"));
+});
+
+test("content and not-found TTLs stay long enough to keep regeneration off the hot path", () => {
+  const ONE_HOUR = 3600;
+
+  assert.ok(
+    REVALIDATE_CONTENT >= ONE_HOUR,
+    `REVALIDATE_CONTENT is ${REVALIDATE_CONTENT}s. Freshness comes from the ` +
+      `WordPress webhook, not from polling — see docs/on-demand-revalidation.md`
+  );
+
+  assert.ok(
+    REVALIDATE_NOT_FOUND >= ONE_HOUR,
+    `REVALIDATE_NOT_FOUND is ${REVALIDATE_NOT_FOUND}s. A short TTL lets ` +
+      `bot-sprayed URLs re-render on every expiry — unbounded function duration`
+  );
+});
+
+test("error TTL stays short so a WordPress blip self-heals", () => {
+  assert.ok(
+    REVALIDATE_ERROR <= 300,
+    `REVALIDATE_ERROR is ${REVALIDATE_ERROR}s — too long. A transient WP ` +
+      `failure would pin a real post as a 404 for that whole window.`
+  );
+  assert.ok(
+    REVALIDATE_ERROR < REVALIDATE_NOT_FOUND,
+    "degraded responses must retry sooner than genuine 404s"
+  );
+});

--- a/tests/lib/revalidate.test.ts
+++ b/tests/lib/revalidate.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Unit tests for the on-demand revalidation endpoint (pages/api/revalidate.ts).
+ *
+ * Run via: `npm run test:unit`
+ *
+ * This endpoint is the blog's entire freshness mechanism now that every page
+ * sits behind a 24h safety-net TTL, and it is reachable from the public
+ * internet. Two classes of regression matter:
+ *
+ *   1. Auth / input handling. It can force unbounded page regeneration, so a
+ *      bypass is both a correctness and a cost problem.
+ *   2. Target coverage. If a page type stops being revalidated here, nothing
+ *      fails loudly — the page just silently serves stale content for up to a
+ *      day. That is precisely the bug this file is meant to catch.
+ */
+
+import { test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import handler from "../../pages/api/revalidate";
+import { BASE_PATH } from "../../lib/isr";
+
+const SECRET = "unit-test-secret";
+
+function mockRes() {
+  const revalidated: string[] = [];
+  const failFor = new Set<string>();
+  const res: any = {
+    statusCode: 0,
+    headers: {} as Record<string, string>,
+    body: undefined as any,
+    revalidated,
+    failFor,
+    setHeader(key: string, value: string) {
+      res.headers[key.toLowerCase()] = value;
+    },
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    json(payload: any) {
+      res.body = payload;
+      return res;
+    },
+    async revalidate(path: string) {
+      if (failFor.has(path)) throw new Error(`Failed to revalidate ${path}`);
+      revalidated.push(path);
+    },
+  };
+  return res;
+}
+
+function mockReq(overrides: any = {}) {
+  return {
+    method: "POST",
+    headers: { "x-revalidate-secret": SECRET },
+    body: {},
+    ...overrides,
+  } as any;
+}
+
+let originalSecret: string | undefined;
+
+beforeEach(() => {
+  originalSecret = process.env.REVALIDATE_SECRET;
+  process.env.REVALIDATE_SECRET = SECRET;
+});
+
+afterEach(() => {
+  if (originalSecret === undefined) delete process.env.REVALIDATE_SECRET;
+  else process.env.REVALIDATE_SECRET = originalSecret;
+});
+
+test("rejects non-POST", async () => {
+  const res = mockRes();
+  await handler(mockReq({ method: "GET" }), res);
+  assert.equal(res.statusCode, 405);
+  assert.equal(res.revalidated.length, 0);
+});
+
+test("fails closed when REVALIDATE_SECRET is unset", async () => {
+  delete process.env.REVALIDATE_SECRET;
+  const res = mockRes();
+  await handler(mockReq({ body: { slug: "a", category: "community" } }), res);
+  assert.equal(res.statusCode, 500);
+  assert.equal(res.revalidated.length, 0);
+});
+
+test("rejects a missing or wrong secret", async () => {
+  for (const headers of [{}, { "x-revalidate-secret": "nope" }, { "x-revalidate-secret": "" }]) {
+    const res = mockRes();
+    await handler(mockReq({ headers, body: { slug: "a", category: "community" } }), res);
+    assert.equal(res.statusCode, 401, `expected 401 for ${JSON.stringify(headers)}`);
+    assert.equal(res.revalidated.length, 0);
+  }
+});
+
+test("secret comparison tolerates a length mismatch instead of throwing", async () => {
+  // timingSafeEqual throws on unequal buffer lengths; the handler hashes first.
+  const res = mockRes();
+  await handler(
+    mockReq({ headers: { "x-revalidate-secret": "x" }, body: { slug: "a" } }),
+    res
+  );
+  assert.equal(res.statusCode, 401);
+});
+
+test("requires slug or paths", async () => {
+  const res = mockRes();
+  await handler(mockReq({ body: {} }), res);
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.revalidated.length, 0);
+});
+
+test("revalidates the post plus every surface that lists it", async () => {
+  const res = mockRes();
+  await handler(
+    mockReq({
+      body: {
+        slug: "my-post",
+        category: "community",
+        tags: ["API Testing"],
+        author: "neha",
+      },
+    }),
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.revalidated, true);
+
+  // A publish that isn't reflected on these pages is invisible for up to 24h.
+  for (const expected of [
+    `${BASE_PATH}/community/my-post`,
+    BASE_PATH,
+    `${BASE_PATH}/community`,
+    `${BASE_PATH}/technology`,
+    `${BASE_PATH}/search`,
+    `${BASE_PATH}/community/search`,
+    `${BASE_PATH}/tag`,
+    `${BASE_PATH}/authors`,
+    `${BASE_PATH}/tag/API%20Testing`,
+    `${BASE_PATH}/authors/neha`,
+  ]) {
+    assert.ok(
+      res.revalidated.includes(expected),
+      `expected ${expected} to be revalidated, got ${JSON.stringify(res.revalidated)}`
+    );
+  }
+});
+
+test("revalidates both category URLs when the category is unknown", async () => {
+  const res = mockRes();
+  await handler(mockReq({ body: { slug: "moved-post" } }), res);
+  assert.ok(res.revalidated.includes(`${BASE_PATH}/community/moved-post`));
+  assert.ok(res.revalidated.includes(`${BASE_PATH}/technology/moved-post`));
+});
+
+test("ignores an unrecognised category rather than trusting it", async () => {
+  const res = mockRes();
+  await handler(mockReq({ body: { slug: "p", category: "../../etc" } }), res);
+  assert.ok(!res.revalidated.some((p: string) => p.includes("etc")));
+  assert.ok(res.revalidated.includes(`${BASE_PATH}/community/p`));
+});
+
+test("rejects slugs and segments that could escape their path segment", async () => {
+  for (const slug of ["..", ".", "a/b", "a\\b", "", "   "]) {
+    const res = mockRes();
+    await handler(mockReq({ body: { slug } }), res);
+    assert.equal(res.statusCode, 400, `slug ${JSON.stringify(slug)} should be rejected`);
+  }
+});
+
+test("explicit paths are confined to the basePath", async () => {
+  const res = mockRes();
+  await handler(
+    mockReq({
+      body: {
+        paths: [
+          `${BASE_PATH}/community/ok`, // allowed
+          "/community/no-basepath", // outside basePath
+          "https://evil.example.com/x", // absolute URL
+          "//evil.example.com/x", // protocol-relative
+          `${BASE_PATH}/../../etc/passwd`, // traversal
+          `${BASE_PATH}//evil`, // double slash
+          "/etc/passwd",
+        ],
+      },
+    }),
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.ok(res.revalidated.includes(`${BASE_PATH}/community/ok`));
+  for (const bad of ["evil.example.com", "etc/passwd", "no-basepath"]) {
+    assert.ok(
+      !res.revalidated.some((p: string) => p.includes(bad)),
+      `${bad} must never be revalidated`
+    );
+  }
+});
+
+test("caps the fan-out an authenticated caller can request", async () => {
+  const res = mockRes();
+  const paths = Array.from({ length: 500 }, (_, i) => `${BASE_PATH}/community/post-${i}`);
+  await handler(mockReq({ body: { paths } }), res);
+
+  // 50 explicit + the fixed listing/search/index targets — nowhere near 500.
+  assert.ok(
+    res.revalidated.length < 100,
+    `expected the fan-out to be capped, got ${res.revalidated.length}`
+  );
+});
+
+test("one failing path does not abort the rest", async () => {
+  const res = mockRes();
+  res.failFor.add(`${BASE_PATH}/technology`);
+  await handler(mockReq({ body: { slug: "p", category: "community" } }), res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.revalidated, true);
+  assert.ok(res.revalidated.includes(`${BASE_PATH}/community/p`));
+  assert.ok(
+    res.body.results.some((r: any) => r.path === `${BASE_PATH}/technology` && !r.revalidated)
+  );
+});
+
+test("reports 500 only when every path fails", async () => {
+  const res = mockRes();
+  const failAll = { ...res, async revalidate(p: string) { throw new Error(`boom ${p}`); } };
+  failAll.setHeader = res.setHeader;
+  failAll.status = (c: number) => { failAll.statusCode = c; return failAll; };
+  failAll.json = (b: any) => { failAll.body = b; return failAll; };
+
+  await handler(mockReq({ body: { slug: "p", category: "community" } }), failAll as any);
+  assert.equal(failAll.statusCode, 500);
+  assert.equal(failAll.body.revalidated, false);
+});
+
+test("never allows its own response to be cached", async () => {
+  const res = mockRes();
+  await handler(mockReq({ body: { slug: "p", category: "community" } }), res);
+  assert.equal(res.headers["cache-control"], "no-store");
+});

--- a/tests/mock-server.js
+++ b/tests/mock-server.js
@@ -202,6 +202,15 @@ function handleGraphQL(body) {
         return reviewAuthorResponse;
     }
 
+    // getAllSlugsForCategory (lib/api.ts) — powers getStaticPaths on the post
+    // pages, so without this branch the e2e build pre-renders zero posts and
+    // silently falls back to on-demand rendering instead of exercising the
+    // real path. Selects on the variable; the literal-category branches below
+    // don't match because this query passes categoryName as $categoryName.
+    if (query.includes('AllSlugsForCategory')) {
+        return variables.categoryName === 'community' ? communityPosts : technologyPosts;
+    }
+
     if (query.includes('AllPostsForCategory')) {
         if (variables.categoryName === 'community' || query.includes('categoryName: "community"')) {
             return communityPosts;

--- a/vercel.json
+++ b/vercel.json
@@ -28,7 +28,7 @@
   ],
   "headers": [
     {
-      "source": "/blog/api/(.*)",
+      "source": "/blog/api/(preview|exit-preview|revalidate)",
       "headers": [
         {
           "key": "Cache-Control",


### PR DESCRIPTION
## Summary

Adds **impression tracking** to the sidebar ad banners so we can measure real **CTR (clicks ÷ impressions)** per banner, not just raw clicks.

## What it does

- Fires a **viewable impression once** each time a banner scrolls **≥50% into view** (IntersectionObserver, one impression per page load — not on every scroll).
- Sends to both, carrying `banner_id` (same pattern as the existing `banner_click`):
  - **GA4:** `gtag("event", "banner_impression", { banner_id })`
  - **Clarity:** `clarity("set", "banner_shown", banner_id)`
- Works for the fallback card too, and no-ops safely if `IntersectionObserver`/analytics aren't available.

## Why

Raw clicks alone can mislead — a banner shown more often will get more clicks even if it converts worse. With impressions we get true per-banner CTR:

```
CTR = banner_click / banner_impression   (per banner_id)
```

## GA4 note (no new setup)

`banner_id` is already registered as a custom dimension, so `banner_impression` shows up with the same breakdown. In an Exploration you can put both `banner_click` and `banner_impression` counts side by side per `banner_id` and derive CTR.

## Testing

- Verified locally (headless): impression fires once on view — `dataLayer` gets `["event","banner_impression",{banner_id}]` and Clarity gets `["set","banner_shown",banner_id]`.
- `tsc` + `next lint` clean.
