### PR TITLE
feat: track banner impressions (for per-banner CTR)

### DIFF
--- a/components/BlogSidebar.tsx
+++ b/components/BlogSidebar.tsx
@@ -124,20 +124,26 @@ declare global {
 }
 
 // Clarity (lazyOnload) and GA (afterInteractive) may be undefined on an early
-// click, so run each call once its global exists — poll briefly, then give up.
-function whenReady(get: () => unknown, use: () => void) {
-  if (typeof window === "undefined") return;
+// call, so run each once its global exists — poll briefly, then give up. Pass a
+// signal to drop the poller on unmount (impressions fire before the user acts,
+// so their poller can outlive the component; aborting avoids firing after an
+// SPA nav, which would attribute the event to the next page).
+function whenReady(get: () => unknown, use: () => void, signal?: AbortSignal) {
+  if (typeof window === "undefined" || signal?.aborted) return;
   if (typeof get() === "function") { use(); return; }
   let tries = 0;
   const timer = setInterval(() => {
     tries += 1;
-    if (typeof get() === "function") {
+    if (signal?.aborted) {
+      clearInterval(timer);
+    } else if (typeof get() === "function") {
       clearInterval(timer);
       use();
     } else if (tries >= 20) {
       clearInterval(timer); // ~5s elapsed; script never loaded (blocked?)
     }
   }, 250);
+  signal?.addEventListener("abort", () => clearInterval(timer));
 }
 
 function trackBannerClick(bannerId: string) {
@@ -145,9 +151,9 @@ function trackBannerClick(bannerId: string) {
   whenReady(() => window.clarity, () => window.clarity!("set", "banner_clicked", bannerId));
 }
 
-function trackBannerImpression(bannerId: string) {
-  whenReady(() => window.gtag, () => window.gtag!("event", "banner_impression", { banner_id: bannerId }));
-  whenReady(() => window.clarity, () => window.clarity!("set", "banner_shown", bannerId));
+function trackBannerImpression(bannerId: string, signal?: AbortSignal) {
+  whenReady(() => window.gtag, () => window.gtag!("event", "banner_impression", { banner_id: bannerId }), signal);
+  whenReady(() => window.clarity, () => window.clarity!("set", "banner_shown", bannerId), signal);
 }
 
 /* ── Ad / CTA Banner ── */
@@ -173,15 +179,18 @@ function SidebarAdBanner() {
     if (!banner || impressionFired.current || !(loaded || errored)) return;
     const el = containerRef.current;
     if (!el || typeof IntersectionObserver === "undefined") return;
+    // Abort any pending analytics-ready poller if we unmount (e.g. SPA nav)
+    // before gtag/clarity load, so the event never fires against the next page.
+    const ac = new AbortController();
     const io = new IntersectionObserver((entries) => {
       if (entries.some((e) => e.isIntersecting) && !impressionFired.current) {
         impressionFired.current = true;
-        trackBannerImpression(banner.id);
+        trackBannerImpression(banner.id, ac.signal);
         io.disconnect();
       }
     }, { threshold: 0.5 });
     io.observe(el);
-    return () => io.disconnect();
+    return () => { io.disconnect(); ac.abort(); };
   }, [banner, loaded, errored]);
 
   // Text fallback so the ad slot is never blank if the artwork fails to load

--- a/components/BlogSidebar.tsx
+++ b/components/BlogSidebar.tsx
@@ -3,6 +3,12 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import SubscribeNewsletter from "./subscribe-newsletter";
 import {
+  AD_BANNERS,
+  pickBannerForPage,
+  hasFiredImpression,
+  claimImpression,
+} from "../lib/banner-rotation";
+import {
   FaFacebook,
   FaLinkedin,
 } from "react-icons/fa";
@@ -101,15 +107,12 @@ function SidebarShare() {
   );
 }
 
-// 4 banner variants for A/B rotation. Each artwork is an edge-to-edge card with
-// an empty bottom band; the CTA is built in code and overlaid there (per-variant
-// colors). btnCenter = that band's vertical center (% from the top).
-const AD_BANNERS = [
-  { id: "banner_1", src: "https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/banner1.webp", btnBg: "#ED5D0F", btnText: "#ffffff", btnCenter: "88.5%" },
-  { id: "banner_2", src: "https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/banner2.webp", btnBg: "#ffffff", btnText: "#ED5D0F", btnCenter: "88.5%" },
-  { id: "banner_3", src: "https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/banner3.webp", btnBg: "#ED5D0F", btnText: "#ffffff", btnCenter: "88.5%" },
-  { id: "banner_4", src: "https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/banner4.webp", btnBg: "#16324F", btnText: "#ffffff", btnCenter: "88.5%" },
-];
+// AD_BANNERS + the per-page banner pick and one-impression-per-page latch live
+// in lib/banner-rotation.ts — shared so the two sidebar instances (desktop +
+// sub-1440 copy) agree on one banner and don't double-count on a resize across
+// the 1440px breakpoint. Each artwork is an edge-to-edge card with an empty
+// bottom band; the CTA is built in code and overlaid there (per-variant colors).
+// btnCenter = that band's vertical center (% from the top).
 
 const CTA_HREF = "https://app.keploy.io/signin";
 // Shared artwork shape (not a fixed size) — reserves space to avoid layout shift.
@@ -123,12 +126,28 @@ declare global {
   }
 }
 
+const READY_POLL_MS = 250;
+// Clicks: a human decision precedes them, so gtag (afterInteractive) / clarity
+// (lazyOnload) have long loaded. ~5s is plenty.
+const CLICK_READY_TRIES = 20;
+// Impressions: fire on scroll-into-view with no user action, so on a wide
+// desktop the banner can be in view within the first seconds — racing Clarity's
+// lazyOnload on a slow connection. Give up much later than clicks so impressions
+// aren't dropped while clicks aren't; a one-sided drop would inflate CTR. This
+// is safe to run long because the poller is aborted on unmount (see the effect).
+const IMPRESSION_READY_TRIES = 80; // ~20s
+
 // Clarity (lazyOnload) and GA (afterInteractive) may be undefined on an early
-// call, so run each once its global exists — poll briefly, then give up. Pass a
-// signal to drop the poller on unmount (impressions fire before the user acts,
-// so their poller can outlive the component; aborting avoids firing after an
-// SPA nav, which would attribute the event to the next page).
-function whenReady(get: () => unknown, use: () => void, signal?: AbortSignal) {
+// call, so run each once its global exists — poll, then give up after maxTries.
+// Pass a signal to drop the poller on unmount (impressions fire before the user
+// acts, so their poller can outlive the component; aborting avoids firing after
+// an SPA nav, which would attribute the event to the next page).
+function whenReady(
+  get: () => unknown,
+  use: () => void,
+  opts: { signal?: AbortSignal; maxTries?: number } = {},
+) {
+  const { signal, maxTries = CLICK_READY_TRIES } = opts;
   if (typeof window === "undefined" || signal?.aborted) return;
   if (typeof get() === "function") { use(); return; }
   let tries = 0;
@@ -139,11 +158,11 @@ function whenReady(get: () => unknown, use: () => void, signal?: AbortSignal) {
     } else if (typeof get() === "function") {
       clearInterval(timer);
       use();
-    } else if (tries >= 20) {
-      clearInterval(timer); // ~5s elapsed; script never loaded (blocked?)
+    } else if (tries >= maxTries) {
+      clearInterval(timer); // script never loaded (blocked?)
     }
-  }, 250);
-  signal?.addEventListener("abort", () => clearInterval(timer));
+  }, READY_POLL_MS);
+  signal?.addEventListener("abort", () => clearInterval(timer), { once: true });
 }
 
 function trackBannerClick(bannerId: string) {
@@ -152,39 +171,43 @@ function trackBannerClick(bannerId: string) {
 }
 
 function trackBannerImpression(bannerId: string, signal?: AbortSignal) {
-  whenReady(() => window.gtag, () => window.gtag!("event", "banner_impression", { banner_id: bannerId }), signal);
-  whenReady(() => window.clarity, () => window.clarity!("set", "banner_shown", bannerId), signal);
+  const opts = { signal, maxTries: IMPRESSION_READY_TRIES };
+  whenReady(() => window.gtag, () => window.gtag!("event", "banner_impression", { banner_id: bannerId }), opts);
+  whenReady(() => window.clarity, () => window.clarity!("set", "banner_shown", bannerId), opts);
 }
 
 /* ── Ad / CTA Banner ── */
 function SidebarAdBanner() {
+  const router = useRouter();
   const [banner, setBanner] = React.useState<(typeof AD_BANNERS)[number] | null>(null);
   const [loaded, setLoaded] = React.useState(false);
   const [errored, setErrored] = React.useState(false);
   const containerRef = React.useRef<HTMLDivElement>(null);
-  const impressionFired = React.useRef(false);
 
+  // Pick from shared state keyed by page: both sidebar instances get the same
+  // banner, and a SPA nav to another post re-picks + re-arms the impression.
   React.useEffect(() => {
-    setBanner(AD_BANNERS[Math.floor(Math.random() * AD_BANNERS.length)]);
-  }, []);
+    setBanner(pickBannerForPage(router.asPath));
+  }, [router.asPath]);
 
   // Count a viewable impression once the picked banner scrolls ≥50% into view,
-  // a single time per load, so clicks / impressions gives a real CTR. We gate on
-  // (loaded || errored) so it counts only when the artwork (or the fallback card)
-  // has actually painted — a slow/blocked banner showing just the skeleton
-  // shouldn't count toward the denominator.
+  // a single time per page view, so clicks / impressions gives a real CTR. We
+  // gate on (loaded || errored) so it counts only when the artwork (or the
+  // fallback card) has actually painted — a slow/blocked banner showing just the
+  // skeleton shouldn't count toward the denominator.
   // `loaded`/`errored` are deps so the observer re-attaches once the artwork
   // paints, and to the swapped-in fallback card (different DOM node, same ref).
   React.useEffect(() => {
-    if (!banner || impressionFired.current || !(loaded || errored)) return;
+    if (!banner || hasFiredImpression() || !(loaded || errored)) return;
     const el = containerRef.current;
     if (!el || typeof IntersectionObserver === "undefined") return;
     // Abort any pending analytics-ready poller if we unmount (e.g. SPA nav)
     // before gtag/clarity load, so the event never fires against the next page.
     const ac = new AbortController();
     const io = new IntersectionObserver((entries) => {
-      if (entries.some((e) => e.isIntersecting) && !impressionFired.current) {
-        impressionFired.current = true;
+      // claimImpression() latches shared across both instances and returns true
+      // exactly once per page view, so only the first-seen banner is counted.
+      if (entries.some((e) => e.isIntersecting) && claimImpression()) {
         trackBannerImpression(banner.id, ac.signal);
         io.disconnect();
       }

--- a/components/BlogSidebar.tsx
+++ b/components/BlogSidebar.tsx
@@ -145,21 +145,46 @@ function trackBannerClick(bannerId: string) {
   whenReady(() => window.clarity, () => window.clarity!("set", "banner_clicked", bannerId));
 }
 
+function trackBannerImpression(bannerId: string) {
+  whenReady(() => window.gtag, () => window.gtag!("event", "banner_impression", { banner_id: bannerId }));
+  whenReady(() => window.clarity, () => window.clarity!("set", "banner_shown", bannerId));
+}
+
 /* ── Ad / CTA Banner ── */
 function SidebarAdBanner() {
   const [banner, setBanner] = React.useState<(typeof AD_BANNERS)[number] | null>(null);
   const [loaded, setLoaded] = React.useState(false);
   const [errored, setErrored] = React.useState(false);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const impressionFired = React.useRef(false);
 
   React.useEffect(() => {
     setBanner(AD_BANNERS[Math.floor(Math.random() * AD_BANNERS.length)]);
   }, []);
+
+  // Count a viewable impression once the picked banner scrolls ≥50% into view
+  // (fires a single time per load, so clicks / impressions gives a real CTR).
+  React.useEffect(() => {
+    if (!banner || impressionFired.current) return;
+    const el = containerRef.current;
+    if (!el || typeof IntersectionObserver === "undefined") return;
+    const io = new IntersectionObserver((entries) => {
+      if (entries.some((e) => e.isIntersecting) && !impressionFired.current) {
+        impressionFired.current = true;
+        trackBannerImpression(banner.id);
+        io.disconnect();
+      }
+    }, { threshold: 0.5 });
+    io.observe(el);
+    return () => io.disconnect();
+  }, [banner, errored]);
 
   // Text fallback so the ad slot is never blank if the artwork fails to load
   // (content blocker, S3 hiccup, etc.). Keeps a working CTA + click tracking.
   if (banner && errored) {
     return (
       <div
+        ref={containerRef}
         className="rounded-2xl p-5 flex flex-col justify-center"
         style={{ width: '100%', aspectRatio: AD_ASPECT, backgroundColor: '#FFF4EE' }}
       >
@@ -188,6 +213,7 @@ function SidebarAdBanner() {
   // slot, show a skeleton until the image decodes, then fade the artwork in.
   return (
     <div
+      ref={containerRef}
       className="rounded-2xl overflow-hidden"
       style={{
         position: 'relative',

--- a/components/BlogSidebar.tsx
+++ b/components/BlogSidebar.tsx
@@ -184,11 +184,18 @@ function SidebarAdBanner() {
   const [errored, setErrored] = React.useState(false);
   const containerRef = React.useRef<HTMLDivElement>(null);
 
+  // Key on the path WITHOUT the #fragment. A TOC click uses history.replaceState
+  // directly (TableContents/post-body), so asPath only picks up the hash on a
+  // later back/forward popstate — and nothing about the banner depends on the
+  // fragment. Keying on the hash would re-pick the banner and re-arm the
+  // impression latch, firing a second impression for the same page view.
+  const pagePath = router.asPath.split("#")[0];
+
   // Pick from shared state keyed by page: both sidebar instances get the same
   // banner, and a SPA nav to another post re-picks + re-arms the impression.
   React.useEffect(() => {
-    setBanner(pickBannerForPage(router.asPath));
-  }, [router.asPath]);
+    setBanner(pickBannerForPage(pagePath));
+  }, [pagePath]);
 
   // Count a viewable impression once the picked banner scrolls ≥50% into view,
   // a single time per page view, so clicks / impressions gives a real CTR. We

--- a/components/BlogSidebar.tsx
+++ b/components/BlogSidebar.tsx
@@ -197,6 +197,19 @@ function SidebarAdBanner() {
     setBanner(pickBannerForPage(pagePath));
   }, [pagePath]);
 
+  // Reset the paint gate whenever the artwork changes. Today the whole post
+  // subtree remounts on every SPA nav (_app.tsx swaps <Component/> for
+  // <PageLoader/> on routeChangeStart), so loaded/errored already start false —
+  // but that couples this component's correctness to a distant ancestor. Reset
+  // here so the gate stays correct on its own: otherwise a stale loaded=true
+  // could let the impression fire before the new artwork paints, and a stuck
+  // errored=true could pin the fallback card. Keyed on src (not banner) so
+  // re-picking the same banner keeps an already-painted image marked loaded.
+  React.useEffect(() => {
+    setLoaded(false);
+    setErrored(false);
+  }, [banner?.src]);
+
   // Count a viewable impression once the picked banner scrolls ≥50% into view,
   // a single time per page view, so clicks / impressions gives a real CTR. We
   // gate on (loaded || errored) so it counts only when the artwork (or the

--- a/components/BlogSidebar.tsx
+++ b/components/BlogSidebar.tsx
@@ -162,10 +162,15 @@ function SidebarAdBanner() {
     setBanner(AD_BANNERS[Math.floor(Math.random() * AD_BANNERS.length)]);
   }, []);
 
-  // Count a viewable impression once the picked banner scrolls ≥50% into view
-  // (fires a single time per load, so clicks / impressions gives a real CTR).
+  // Count a viewable impression once the picked banner scrolls ≥50% into view,
+  // a single time per load, so clicks / impressions gives a real CTR. We gate on
+  // (loaded || errored) so it counts only when the artwork (or the fallback card)
+  // has actually painted — a slow/blocked banner showing just the skeleton
+  // shouldn't count toward the denominator.
+  // `loaded`/`errored` are deps so the observer re-attaches once the artwork
+  // paints, and to the swapped-in fallback card (different DOM node, same ref).
   React.useEffect(() => {
-    if (!banner || impressionFired.current) return;
+    if (!banner || impressionFired.current || !(loaded || errored)) return;
     const el = containerRef.current;
     if (!el || typeof IntersectionObserver === "undefined") return;
     const io = new IntersectionObserver((entries) => {
@@ -177,7 +182,7 @@ function SidebarAdBanner() {
     }, { threshold: 0.5 });
     io.observe(el);
     return () => io.disconnect();
-  }, [banner, errored]);
+  }, [banner, loaded, errored]);
 
   // Text fallback so the ad slot is never blank if the artwork fails to load
   // (content blocker, S3 hiccup, etc.). Keeps a working CTA + click tracking.

--- a/lib/banner-rotation.ts
+++ b/lib/banner-rotation.ts
@@ -29,6 +29,10 @@ export const AD_BANNERS: Banner[] = [
   { id: "banner_4", src: "https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/banner4.webp", btnBg: "#16324F", btnText: "#ffffff", btnCenter: "88.5%" },
 ];
 
+// Module-scoped mutable state. Safe ONLY because the sidebar is imported with
+// dynamic(..., { ssr: false }) — it runs client-side, one module instance per
+// tab. If BlogSidebar is ever server-rendered, this pick + latch would be shared
+// across concurrent requests; move it into request/component scope first.
 let pageKey: string | null = null;
 let picked: Banner | null = null;
 let impressionFired = false;
@@ -53,6 +57,12 @@ export function hasFiredImpression(): boolean {
 // Claim the single impression for this page view. Returns true exactly once
 // (the caller that should actually send the event); every later call — the other
 // instance, or a re-intersection — returns false and must NOT send.
+//
+// The latch is set here, BEFORE the event is confirmed sent. Deliberate: if
+// trackBannerImpression's analytics-ready poll times out (~20s, IMPRESSION_
+// READY_TRIES) the impression is dropped with no retry. That's the accepted
+// trade — latching only on a confirmed send would let the second sidebar
+// instance win the race and re-open the double-count this module exists to close.
 export function claimImpression(): boolean {
   if (impressionFired) return false;
   impressionFired = true;

--- a/lib/banner-rotation.ts
+++ b/lib/banner-rotation.ts
@@ -1,0 +1,67 @@
+// Shared state for the sidebar ad banner's impression tracking.
+//
+// The sidebar renders TWICE per page (post-body.tsx: a wide-desktop ≥1440px
+// copy and a sub-1440px copy), so two SidebarAdBanner instances mount for one
+// page view. If each picked its own banner and kept its own "impression fired"
+// latch, resizing across the 1440px breakpoint would mount the previously
+// display:none instance, load its lazy image, and fire a SECOND impression for
+// a DIFFERENT banner_id — inflating the denominator and understating CTR for
+// both banners off a single page view.
+//
+// Keeping the pick and the latch here (module scope, keyed per page view) makes
+// both instances agree on ONE banner and fire exactly ONE impression per page.
+
+export type Banner = {
+  id: string;
+  src: string;
+  btnBg: string;
+  btnText: string;
+  btnCenter: string;
+};
+
+// Random rotation for aggregate per-banner CTR — NOT a per-user/per-session A/B
+// test. A reader can see different banners on consecutive articles; the pick is
+// per page view, so don't read the dashboard as an A/B conclusion about users.
+export const AD_BANNERS: Banner[] = [
+  { id: "banner_1", src: "https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/banner1.webp", btnBg: "#ED5D0F", btnText: "#ffffff", btnCenter: "88.5%" },
+  { id: "banner_2", src: "https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/banner2.webp", btnBg: "#ffffff", btnText: "#ED5D0F", btnCenter: "88.5%" },
+  { id: "banner_3", src: "https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/banner3.webp", btnBg: "#ED5D0F", btnText: "#ffffff", btnCenter: "88.5%" },
+  { id: "banner_4", src: "https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/banner4.webp", btnBg: "#16324F", btnText: "#ffffff", btnCenter: "88.5%" },
+];
+
+let pageKey: string | null = null;
+let picked: Banner | null = null;
+let impressionFired = false;
+
+// Pick the banner for this page view. Idempotent per key: the first caller picks
+// and re-arms the impression latch; every later caller for the SAME key (the
+// second sidebar instance, an effect re-run) gets the identical banner. A new
+// key (SPA nav to another post) re-picks and re-arms.
+export function pickBannerForPage(key: string, rand: () => number = Math.random): Banner {
+  if (pageKey !== key || !picked) {
+    pageKey = key;
+    picked = AD_BANNERS[Math.floor(rand() * AD_BANNERS.length)];
+    impressionFired = false;
+  }
+  return picked;
+}
+
+export function hasFiredImpression(): boolean {
+  return impressionFired;
+}
+
+// Claim the single impression for this page view. Returns true exactly once
+// (the caller that should actually send the event); every later call — the other
+// instance, or a re-intersection — returns false and must NOT send.
+export function claimImpression(): boolean {
+  if (impressionFired) return false;
+  impressionFired = true;
+  return true;
+}
+
+// Test-only: reset module state between cases.
+export function __resetBannerRotation(): void {
+  pageKey = null;
+  picked = null;
+  impressionFired = false;
+}

--- a/tests/lib/banner-rotation.test.ts
+++ b/tests/lib/banner-rotation.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for the sidebar ad banner's shared rotation + impression state
+ * (lib/banner-rotation.ts).
+ *
+ * Run via: `npm run test:unit`
+ *
+ * The sidebar renders twice per page (a wide-desktop ≥1440px copy and a
+ * sub-1440px copy), so two SidebarAdBanner instances mount for one page view.
+ * The metric this whole feature produces — per-banner CTR = clicks / impressions
+ * — is only trustworthy if those two instances agree on ONE banner and fire
+ * exactly ONE impression per page view. That invariant is easy to reintroduce a
+ * bug into (per-instance state double-counts on a resize across 1440px), so it
+ * is pinned here.
+ */
+
+import { test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  AD_BANNERS,
+  pickBannerForPage,
+  hasFiredImpression,
+  claimImpression,
+  __resetBannerRotation,
+} from "../../lib/banner-rotation";
+
+beforeEach(() => {
+  __resetBannerRotation();
+});
+
+test("both instances on the same page get the identical banner", () => {
+  // Force a deterministic, non-first pick so "same banner" isn't trivially true.
+  const first = pickBannerForPage("/blog/post-a", () => 0.5);
+  const second = pickBannerForPage("/blog/post-a", () => 0.99); // rand ignored: key unchanged
+  assert.equal(second, first);
+  assert.equal(second.id, first.id);
+});
+
+test("a new page (SPA nav) re-picks and re-arms the impression latch", () => {
+  const a = pickBannerForPage("/blog/post-a", () => 0);
+  assert.equal(a.id, AD_BANNERS[0].id);
+  // Fire the impression on page A.
+  assert.equal(claimImpression(), true);
+  assert.equal(hasFiredImpression(), true);
+
+  // Navigate to page B: new key re-picks and clears the latch.
+  const b = pickBannerForPage("/blog/post-b", () => 0.99);
+  assert.equal(b.id, AD_BANNERS[AD_BANNERS.length - 1].id);
+  assert.equal(hasFiredImpression(), false);
+});
+
+test("claimImpression fires exactly once per page view, shared across instances", () => {
+  pickBannerForPage("/blog/post-a");
+  // First caller (whichever instance is seen first) wins.
+  assert.equal(claimImpression(), true);
+  // The other instance, and any re-intersection, must NOT re-count.
+  assert.equal(claimImpression(), false);
+  assert.equal(claimImpression(), false);
+  assert.equal(hasFiredImpression(), true);
+});
+
+test("re-picking the same key does not reset an already-fired impression", () => {
+  pickBannerForPage("/blog/post-a");
+  assert.equal(claimImpression(), true);
+  // The second instance mounts later (e.g. resize past 1440px) and re-picks the
+  // same page — it must see the latch still set so it can't fire a second time.
+  pickBannerForPage("/blog/post-a");
+  assert.equal(hasFiredImpression(), true);
+  assert.equal(claimImpression(), false);
+});


### PR DESCRIPTION
## Summary

Adds **impression tracking** to the sidebar ad banners so we can measure real **CTR (clicks ÷ impressions)** per banner, not just raw clicks. Clicks (`banner_click` / `banner_clicked`) are untouched and already shipped — this PR only adds the impression side.

## What it does

- Fires a **viewable impression once** each time a banner scrolls **≥50% into view** (IntersectionObserver, one impression per page load — not on every scroll).
- Sends to both, carrying `banner_id` (same pattern as the existing `banner_click`):
  - **GA4:** `gtag("event", "banner_impression", { banner_id })`
  - **Clarity:** `clarity("set", "banner_shown", banner_id)`
- Works for the fallback card too, and no-ops safely if `IntersectionObserver`/analytics aren't available.

No numeric "count" is sent — each impression is a single event carrying only `banner_id`, and GA4 does the counting by tallying events per banner.

## Why

Raw clicks alone can mislead — a banner shown more often gets more clicks even if it converts worse. With impressions we get true per-banner CTR:

```
CTR = banner_click / banner_impression   (per banner_id)
```

## New file: `lib/banner-rotation.ts`

The sidebar renders **twice per page** (`post-body.tsx` mounts a ≥1440px copy and a sub-1440px copy, one hidden via `display:none`). That was harmless when we only tracked clicks — only the visible copy gets clicked. But for impressions, two independently-mounted instances would each pick their own banner and fire their own impression, and resizing across the 1440px breakpoint mounts the hidden copy, lazy-loads its image, and fires a **second** impression for a **different** `banner_id` — inflating the denominator and understating CTR.

So the banner list, the per-page pick, and the impression latch now live in shared **module scope**: both instances agree on **one** banner and fire **exactly one** impression per page view. This is safe because the sidebar is imported with `dynamic(..., { ssr: false })` (client-only, one module instance per tab, never shared across requests). It also makes the pick unit-testable by injecting `rand` — see `tests/lib/banner-rotation.test.ts`.

## Ready-poll timing

GA (`afterInteractive`) and Clarity (`lazyOnload`) may not exist yet when we want to send, so `whenReady` polls until the global appears, then gives up. The click vs impression timeouts are deliberately asymmetric: clicks follow a human action so the scripts have long loaded (~5s is plenty), while impressions can fire within the first seconds on a wide desktop and race Clarity's `lazyOnload` on a slow connection — so impressions poll much longer (~20s) to avoid a **one-sided drop that would inflate CTR**. The long poller is aborted on unmount, so an impression never lands on the next page after an SPA nav.

## GA4 note (no new setup)

`banner_id` is already a registered custom dimension, so `banner_impression` shows up with the same breakdown alongside `banner_click`.

## Testing (verified in a real browser, headless)

- **Network `/collect`:** exactly one `banner_impression` reaches GA with the correct `banner_id`; no duplicate after scrolling away and back.
- **dataLayer hook:** count is `0` before the banner is seen, `1` once ≥50% in view, and stays `1` after scrolling away+back 3×.
- Clarity `banner_shown` fires too. `tsc` + `next lint` clean.
